### PR TITLE
Fixed for loop to correctly pad end of files

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -68,7 +68,7 @@ func (w *Writer) Write(file *File) error {
 	w.lineNum++
 
 	// pad the final block
-	for i := 0; i < w.lineNum%10; i++ {
+	for i := 0; i < (10-(w.lineNum%10)) && w.lineNum%10 != 0; i++ {
 		if _, err := w.w.WriteString(strings.Repeat("9", 94) + "\n"); err != nil {
 			return err
 		}


### PR DESCRIPTION
I noticed the padding did not always complete the block of 10 records. It looked like the for loop was not looping the correct amount of time. I fixed the loop condition. 

Other then that this works amazing! 
@wadearnold  