### PR TITLE
Re-use compiled regular expressions when using the validator

### DIFF
--- a/fileHeader_internal_test.go
+++ b/fileHeader_internal_test.go
@@ -42,6 +42,17 @@ func TestMockFileHeader(t *testing.T) {
 
 // TestParseFileHeader parses a known File Header Record string.
 func TestParseFileHeader(t *testing.T) {
+	parseFileHeader(t)
+}
+
+func BenchmarkParseFileHeader(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseFileHeader(b)
+	}
+}
+
+func parseFileHeader(t testing.TB) {
 	var line = "101 076401251 0764012510807291511A094101achdestname            companyname                    "
 	r := NewReader(strings.NewReader(line))
 	r.line = line

--- a/validators.go
+++ b/validators.go
@@ -12,6 +12,11 @@ import (
 	"strconv"
 )
 
+var (
+	upperAlphanumericRegex = regexp.MustCompile(`[^ A-Z0-9!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`)
+	alphanumericRegex      = regexp.MustCompile(`[^ \w!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`)
+)
+
 // validator is common validation and formating of golang types to ach type strings
 type validator struct{}
 
@@ -241,7 +246,7 @@ func (v *validator) isOriginatorStatusCode(code int) error {
 
 // isUpperAlphanumeric checks if string only contains ASCII alphanumeric upper case characters
 func (v *validator) isUpperAlphanumeric(s string) error {
-	if regexp.MustCompile(`[^ A-Z0-9!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`).MatchString(s) {
+	if upperAlphanumericRegex.MatchString(s) {
 		return errors.New(msgUpperAlpha)
 	}
 	return nil
@@ -249,7 +254,7 @@ func (v *validator) isUpperAlphanumeric(s string) error {
 
 // isAlphanumeric checks if a string only contains ASCII alphanumeric characters
 func (v *validator) isAlphanumeric(s string) error {
-	if regexp.MustCompile(`[^ \w!"#$%&'()*+,-.\\/:;<>=?@\[\]^_{}|~]+`).MatchString(s) {
+	if alphanumericRegex.MatchString(s) {
 		// ^[ A-Za-z0-9_@./#&+-]*$/
 		return errors.New(msgAlphanumeric)
 	}


### PR DESCRIPTION
I've wrapped the original `TestParseFileHeader` in order to use the same functionality on the benchmark.
To run the benchmarks I've used the following commands, on `master`:
```
go test -bench=BenchmarkParseFileHeader -count=5 > old
```
On my branch:
```
go test -bench=BenchmarkParseFileHeader -count=5 > new
```
The `benchcmp` output looks like this:
```
% benchcmp old new 
benchmark                      old ns/op     new ns/op     delta
BenchmarkParseFileHeader-8     33891         3308          -90.24%
BenchmarkParseFileHeader-8     33785         3415          -89.89%
BenchmarkParseFileHeader-8     33801         3472          -89.73%
BenchmarkParseFileHeader-8     33830         3494          -89.67%
BenchmarkParseFileHeader-8     33794         3481          -89.70%

benchmark                      old allocs     new allocs     delta
BenchmarkParseFileHeader-8     118            22             -81.36%
BenchmarkParseFileHeader-8     118            22             -81.36%
BenchmarkParseFileHeader-8     118            22             -81.36%
BenchmarkParseFileHeader-8     118            22             -81.36%
BenchmarkParseFileHeader-8     118            22             -81.36%

benchmark                      old bytes     new bytes     delta
BenchmarkParseFileHeader-8     162640        400           -99.75%
BenchmarkParseFileHeader-8     162640        400           -99.75%
BenchmarkParseFileHeader-8     162640        400           -99.75%
BenchmarkParseFileHeader-8     162640        400           -99.75%
BenchmarkParseFileHeader-8     162640        400           -99.75%
```
Cheers