### PR TITLE
Addenda and batch benchmarks

### DIFF
--- a/addenda05_test.go
+++ b/addenda05_test.go
@@ -27,7 +27,7 @@ func TestMockAddenda05(t *testing.T) {
 	}
 }
 
-func TestParseAddenda05(t *testing.T) {
+func testParseAddenda05(t testing.TB) {
 	addendaPPD := NewAddenda05()
 	var line = "705PPD                                        DIEGO MAY                            00010000001"
 	addendaPPD.Parse(line)
@@ -65,14 +65,36 @@ func TestParseAddenda05(t *testing.T) {
 	}
 }
 
+func TestParseAddenda05(t *testing.T) {
+	testParseAddenda05(t)
+}
+
+func BenchmarkParseAddenda05(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testParseAddenda05(b)
+	}
+}
+
 // TestAddenda05 String validates that a known parsed file can be return to a string of the same value
-func TestAddenda05String(t *testing.T) {
+func testAddenda05String(t testing.TB) {
 	addenda05 := NewAddenda05()
 	var line = "705WEB                                        DIEGO MAY                            00010000001"
 	addenda05.Parse(line)
 
 	if addenda05.String() != line {
 		t.Errorf("Strings do not match")
+	}
+}
+
+func TestAddenda05String(t *testing.T) {
+	testAddenda05String(t)
+}
+
+func BenchmarkAddenda05String(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda05String(b)
 	}
 }
 

--- a/addenda98_test.go
+++ b/addenda98_test.go
@@ -15,7 +15,7 @@ func mockAddenda98() *Addenda98 {
 	return addenda98
 }
 
-func TestAddenda98Parse(t *testing.T) {
+func testAddenda98Parse(t testing.TB) {
 	addenda98 := NewAddenda98()
 	line := "798C01099912340000015      091012981918171614                                  091012980000088"
 	addenda98.Parse(line)
@@ -43,7 +43,18 @@ func TestAddenda98Parse(t *testing.T) {
 	}
 }
 
-func TestAddenda98String(t *testing.T) {
+func TestAddenda98Parse(t *testing.T) {
+	testAddenda98Parse(t)
+}
+
+func BenchmarkAddenda98Parse(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98Parse(b)
+	}
+}
+
+func testAddenda98String(t testing.TB) {
 	addenda98 := NewAddenda98()
 	line := "798C01099912340000015      091012981918171614                                  091012980000088"
 	addenda98.Parse(line)
@@ -53,7 +64,18 @@ func TestAddenda98String(t *testing.T) {
 	}
 }
 
-func TestAddenda98ValidRecordType(t *testing.T) {
+func TestAddenda98String(t *testing.T) {
+	testAddenda98String(t)
+}
+
+func BenchmarkAddenda98String(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98String(b)
+	}
+}
+
+func testAddenda98ValidRecordType(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.recordType = "63"
 	if err := addenda98.Validate(); err != nil {
@@ -66,8 +88,18 @@ func TestAddenda98ValidRecordType(t *testing.T) {
 		}
 	}
 }
+func TestAddenda98ValidRecordType(t *testing.T) {
+	testAddenda98ValidRecordType(t)
+}
 
-func TestAddenda98ValidTypeCode(t *testing.T) {
+func BenchmarkAddenda98ValidRecordType(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98ValidRecordType(b)
+	}
+}
+
+func testAddenda98ValidTypeCode(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.typeCode = "05"
 	if err := addenda98.Validate(); err != nil {
@@ -81,7 +113,18 @@ func TestAddenda98ValidTypeCode(t *testing.T) {
 	}
 }
 
-func TestAddenda98ValidCorrectedData(t *testing.T) {
+func TestAddenda98ValidTypeCode(t *testing.T) {
+	testAddenda98ValidTypeCode(t)
+}
+
+func BenchmarkAddenda98ValidTypeCode(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98ValidTypeCode(b)
+	}
+}
+
+func testAddenda98ValidCorrectedData(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.CorrectedData = ""
 	if err := addenda98.Validate(); err != nil {
@@ -95,7 +138,18 @@ func TestAddenda98ValidCorrectedData(t *testing.T) {
 	}
 }
 
-func TestAddenda98ValidateTrue(t *testing.T) {
+func TestAddenda98ValidCorrectedData(t *testing.T) {
+	testAddenda98ValidCorrectedData(t)
+}
+
+func BenchmarkAddenda98ValidCorrectedData(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98ValidCorrectedData(b)
+	}
+}
+
+func testAddenda98ValidateTrue(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.ChangeCode = "C11"
 	if err := addenda98.Validate(); err != nil {
@@ -108,7 +162,19 @@ func TestAddenda98ValidateTrue(t *testing.T) {
 		}
 	}
 }
-func TestAddenda98ValidateChangeCodeFalse(t *testing.T) {
+
+func TestAddenda98ValidateTrue(t *testing.T) {
+	testAddenda98ValidateTrue(t)
+}
+
+func BenchmarkAddenda98ValidateTrue(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98ValidateTrue(b)
+	}
+}
+
+func testAddenda98ValidateChangeCodeFalse(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.ChangeCode = "C63"
 	if err := addenda98.Validate(); err != nil {
@@ -122,7 +188,18 @@ func TestAddenda98ValidateChangeCodeFalse(t *testing.T) {
 	}
 }
 
-func TestAddenda98OriginalTraceField(t *testing.T) {
+func TestAddenda98ValidateChangeCodeFalse(t *testing.T) {
+	testAddenda98ValidateChangeCodeFalse(t)
+}
+
+func BenchmarkAddenda98ValidateChangeCodeFalse(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98ValidateChangeCodeFalse(b)
+	}
+}
+
+func testAddenda98OriginalTraceField(t testing.TB) {
 	addenda98 := mockAddenda98()
 	exp := "000000000012345"
 	if addenda98.OriginalTraceField() != exp {
@@ -130,7 +207,18 @@ func TestAddenda98OriginalTraceField(t *testing.T) {
 	}
 }
 
-func TestAddenda98OriginalDFIField(t *testing.T) {
+func TestAddenda98OriginalTraceField(t *testing.T) {
+	testAddenda98OriginalTraceField(t)
+}
+
+func BenchmarkAddenda98OriginalTraceField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98OriginalTraceField(b)
+	}
+}
+
+func testAddenda98OriginalDFIField(t testing.TB) {
 	addenda98 := mockAddenda98()
 	exp := "09101298"
 	if addenda98.OriginalDFIField() != exp {
@@ -138,7 +226,18 @@ func TestAddenda98OriginalDFIField(t *testing.T) {
 	}
 }
 
-func TestAddenda98CorrectedDataField(t *testing.T) {
+func TestAddenda98OriginalDFIField(t *testing.T) {
+	testAddenda98OriginalDFIField(t)
+}
+
+func BenchmarkAddenda98OriginalDFIField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98OriginalDFIField(b)
+	}
+}
+
+func testAddenda98CorrectedDataField(t testing.TB) {
 	addenda98 := mockAddenda98()
 	exp := "1918171614                   " // 29 char
 	if addenda98.CorrectedDataField() != exp {
@@ -146,10 +245,32 @@ func TestAddenda98CorrectedDataField(t *testing.T) {
 	}
 }
 
-func TestAddenda98TraceNumberField(t *testing.T) {
+func TestAddenda98CorrectedDataField(t *testing.T) {
+	testAddenda98CorrectedDataField(t)
+}
+
+func BenchmarkAddenda98CorrectedDataField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98CorrectedDataField(b)
+	}
+}
+
+func testAddenda98TraceNumberField(t testing.TB) {
 	addenda98 := mockAddenda98()
 	exp := "091012980000088"
 	if addenda98.TraceNumberField() != exp {
 		t.Errorf("expected %v received %v", exp, addenda98.TraceNumberField())
+	}
+}
+
+func TestAddenda98TraceNumberField(t *testing.T) {
+	testAddenda98TraceNumberField(t)
+}
+
+func BenchmarkAddenda98TraceNumberField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda98TraceNumberField(b)
 	}
 }

--- a/addenda99_test.go
+++ b/addenda99_test.go
@@ -19,7 +19,7 @@ func mockAddenda99() *Addenda99 {
 	return addenda99
 }
 
-func TestAddenda99Parse(t *testing.T) {
+func testAddenda99Parse(t testing.TB) {
 	addenda99 := NewAddenda99()
 	line := "799R07099912340000015      09101298Authorization revoked                       091012980000066"
 	addenda99.Parse(line)
@@ -50,7 +50,18 @@ func TestAddenda99Parse(t *testing.T) {
 	}
 }
 
-func TestAddenda99String(t *testing.T) {
+func TestAddenda99Parse(t *testing.T) {
+	testAddenda99Parse(t)
+}
+
+func BenchmarkAddenda99Parse(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99Parse(b)
+	}
+}
+
+func testAddenda99String(t testing.TB) {
 	addenda99 := NewAddenda99()
 	line := "799R07099912340000015      09101298Authorization revoked                       091012980000066"
 	addenda99.Parse(line)
@@ -60,8 +71,19 @@ func TestAddenda99String(t *testing.T) {
 	}
 }
 
+func TestAddenda99String(t *testing.T) {
+	testAddenda99String(t)
+}
+
+func BenchmarkAddenda99String(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99String(b)
+	}
+}
+
 // This is not an exported function but utilized for validation
-func TestAddenda99MakeReturnCodeDict(t *testing.T) {
+func testAddenda99MakeReturnCodeDict(t testing.TB) {
 	codes := makeReturnCodeDict()
 	// check if known code is present
 	_, prs := codes["R01"]
@@ -75,7 +97,18 @@ func TestAddenda99MakeReturnCodeDict(t *testing.T) {
 	}
 }
 
-func TestAddenda99ValidateTrue(t *testing.T) {
+func TestAddenda99MakeReturnCodeDict(t *testing.T) {
+	testAddenda99MakeReturnCodeDict(t)
+}
+
+func BenchmarkAddenda99MakeReturnCodeDict(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99MakeReturnCodeDict(b)
+	}
+}
+
+func testAddenda99ValidateTrue(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.ReturnCode = "R13"
 	if err := addenda99.Validate(); err != nil {
@@ -89,7 +122,18 @@ func TestAddenda99ValidateTrue(t *testing.T) {
 	}
 }
 
-func TestAddenda99ValidateReturnCodeFalse(t *testing.T) {
+func TestAddenda99ValidateTrue(t *testing.T) {
+	testAddenda99ValidateTrue(t)
+}
+
+func BenchmarkAddenda99ValidateTrue(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99ValidateTrue(b)
+	}
+}
+
+func testAddenda99ValidateReturnCodeFalse(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.ReturnCode = ""
 	if err := addenda99.Validate(); err != nil {
@@ -103,7 +147,18 @@ func TestAddenda99ValidateReturnCodeFalse(t *testing.T) {
 	}
 }
 
-func TestAddenda99OriginalTraceField(t *testing.T) {
+func TestAddenda99ValidateReturnCodeFalse(t *testing.T) {
+	testAddenda99ValidateReturnCodeFalse(t)
+}
+
+func BenchmarkAddenda99ValidateReturnCodeFalse(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99ValidateReturnCodeFalse(b)
+	}
+}
+
+func testAddenda99OriginalTraceField(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.OriginalTrace = 12345
 	if addenda99.OriginalTraceField() != "000000000012345" {
@@ -111,7 +166,18 @@ func TestAddenda99OriginalTraceField(t *testing.T) {
 	}
 }
 
-func TestAddenda99DateOfDeathField(t *testing.T) {
+func TestAddenda99OriginalTraceField(t *testing.T) {
+	testAddenda99OriginalTraceField(t)
+}
+
+func BenchmarkAddenda99OriginalTraceField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99OriginalTraceField(b)
+	}
+}
+
+func testAddenda99DateOfDeathField(t testing.TB) {
 	addenda99 := mockAddenda99()
 	// Check for all zeros
 	if addenda99.DateOfDeathField() != "      " {
@@ -124,7 +190,17 @@ func TestAddenda99DateOfDeathField(t *testing.T) {
 	}
 }
 
-func TestAddenda99OriginalDFIField(t *testing.T) {
+func TestAddenda99DateOfDeathField(t *testing.T) {
+	testAddenda99DateOfDeathField(t)
+}
+func BenchmarkAddenda99DateOfDeathField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99DateOfDeathField(b)
+	}
+}
+
+func testAddenda99OriginalDFIField(t testing.TB) {
 	addenda99 := mockAddenda99()
 	exp := "09101298"
 	if addenda99.OriginalDFIField() != exp {
@@ -132,7 +208,18 @@ func TestAddenda99OriginalDFIField(t *testing.T) {
 	}
 }
 
-func TestAddenda99AddendaInformationField(t *testing.T) {
+func TestAddenda99OriginalDFIField(t *testing.T) {
+	testAddenda99OriginalDFIField(t)
+}
+
+func BenchmarkAddenda99OriginalDFIField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99OriginalDFIField(b)
+	}
+}
+
+func testAddenda99AddendaInformationField(t testing.TB) {
 	addenda99 := mockAddenda99()
 	exp := "Authorization Revoked                       "
 	if addenda99.AddendaInformationField() != exp {
@@ -140,11 +227,33 @@ func TestAddenda99AddendaInformationField(t *testing.T) {
 	}
 }
 
-func TestAddenda99TraceNumberField(t *testing.T) {
+func TestAddenda99AddendaInformationField(t *testing.T) {
+	testAddenda99AddendaInformationField(t)
+}
+
+func BenchmarkAddenda99AddendaInformationField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99AddendaInformationField(b)
+	}
+}
+
+func testAddenda99TraceNumberField(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.TraceNumber = 91012980000066
 	exp := "091012980000066"
 	if addenda99.TraceNumberField() != exp {
 		t.Errorf("expected %v received %v", exp, addenda99.TraceNumberField())
+	}
+}
+
+func TestAddenda99TraceNumberField(t *testing.T) {
+	testAddenda99TraceNumberField(t)
+}
+
+func BenchmarkAddenda99TraceNumberField(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testAddenda99TraceNumberField(b)
 	}
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -59,8 +59,7 @@ func mockBatchInvalidSECHeader() *BatchHeader {
 }
 
 // Test cases that apply to all batch types
-
-func TestBatchNumberMismatch(t *testing.T) {
+func testBatchNumberMismatch(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.GetControl().BatchNumber = 2
 	if err := mockBatch.verify(); err != nil {
@@ -74,7 +73,17 @@ func TestBatchNumberMismatch(t *testing.T) {
 	}
 }
 
-func TestCreditBatchisBatchAmount(t *testing.T) {
+func TestBatchNumberMismatch(t *testing.T) {
+	testBatchNumberMismatch(t)
+}
+func BenchmarkBatchNumberMismatch(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchNumberMismatch(b)
+	}
+}
+
+func testCreditBatchisBatchAmount(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.SetHeader(mockBatchHeader())
 	e1 := mockBatch.GetEntries()[0]
@@ -101,7 +110,18 @@ func TestCreditBatchisBatchAmount(t *testing.T) {
 	}
 }
 
-func TestSavingsBatchisBatchAmount(t *testing.T) {
+func TestCreditBatchisBatchAmount(t *testing.T) {
+	testCreditBatchisBatchAmount(t)
+}
+
+func BenchmarkCreditBatchisBatchAmount(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testCreditBatchisBatchAmount(b)
+	}
+
+}
+func testSavingsBatchisBatchAmount(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.SetHeader(mockBatchHeader())
 	e1 := mockBatch.GetEntries()[0]
@@ -129,7 +149,18 @@ func TestSavingsBatchisBatchAmount(t *testing.T) {
 	}
 }
 
-func TestBatchisEntryHash(t *testing.T) {
+func TestSavingsBatchisBatchAmount(t *testing.T) {
+	testSavingsBatchisBatchAmount(t)
+}
+
+func BenchmarkSavingsBatchisBatchAmount(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testSavingsBatchisBatchAmount(b)
+	}
+}
+
+func testBatchisEntryHash(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.GetControl().EntryHash = 1
 	if err := mockBatch.verify(); err != nil {
@@ -143,7 +174,18 @@ func TestBatchisEntryHash(t *testing.T) {
 	}
 }
 
-func TestBatchDNEMismatch(t *testing.T) {
+func TestBatchisEntryHash(t *testing.T) {
+	testBatchisEntryHash(t)
+}
+
+func BenchmarkBatchisEntryHash(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchisEntryHash(b)
+	}
+}
+
+func testBatchDNEMismatch(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.SetHeader(mockBatchHeader())
 	ed := mockBatch.GetEntries()[0]
@@ -164,7 +206,18 @@ func TestBatchDNEMismatch(t *testing.T) {
 	}
 }
 
-func TestBatchTraceNumberNotODFI(t *testing.T) {
+func TestBatchDNEMismatch(t *testing.T) {
+	testBatchDNEMismatch(t)
+}
+
+func BenchmarkBatchDNEMismatch(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchDNEMismatch(b)
+	}
+}
+
+func testBatchTraceNumberNotODFI(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.GetEntries()[0].SetTraceNumber("12345678", 1)
 	if err := mockBatch.verify(); err != nil {
@@ -178,7 +231,18 @@ func TestBatchTraceNumberNotODFI(t *testing.T) {
 	}
 }
 
-func TestBatchEntryCountEquality(t *testing.T) {
+func TestBatchTraceNumberNotODFI(t *testing.T) {
+	testBatchTraceNumberNotODFI(t)
+}
+
+func BenchmarkBatchTraceNumberNotODFI(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchTraceNumberNotODFI(b)
+	}
+}
+
+func testBatchEntryCountEquality(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.SetHeader(mockBatchHeader())
 	e := mockEntryDetail()
@@ -201,7 +265,18 @@ func TestBatchEntryCountEquality(t *testing.T) {
 	}
 }
 
-func TestBatchAddendaIndicator(t *testing.T) {
+func TestBatchEntryCountEquality(t *testing.T) {
+	testBatchEntryCountEquality(t)
+}
+
+func BenchmarkBatchEntryCountEquality(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchEntryCountEquality(b)
+	}
+}
+
+func testBatchAddendaIndicator(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.GetEntries()[0].AddAddenda(mockAddenda05())
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 0
@@ -217,7 +292,18 @@ func TestBatchAddendaIndicator(t *testing.T) {
 	}
 }
 
-func TestBatchIsAddendaSeqAscending(t *testing.T) {
+func TestBatchAddendaIndicator(t *testing.T) {
+	testBatchAddendaIndicator(t)
+}
+
+func BenchmarkBatchAddendaIndicator(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchAddendaIndicator(b)
+	}
+}
+
+func testBatchIsAddendaSeqAscending(t testing.TB) {
 	mockBatch := mockBatch()
 	ed := mockBatch.GetEntries()[0]
 	ed.AddAddenda(mockAddenda05())
@@ -235,10 +321,19 @@ func TestBatchIsAddendaSeqAscending(t *testing.T) {
 			t.Errorf("%T: %s", err, err)
 		}
 	}
-
 }
 
-func TestBatchIsSequenceAscending(t *testing.T) {
+func TestBatchIsAddendaSeqAscending(t *testing.T) {
+	testBatchIsAddendaSeqAscending(t)
+}
+func BenchmarkBatchIsAddendaSeqAscending(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchIsAddendaSeqAscending(b)
+	}
+}
+
+func testBatchIsSequenceAscending(t testing.TB) {
 	mockBatch := mockBatch()
 	e3 := mockEntryDetail()
 	e3.TraceNumber = 1
@@ -255,7 +350,18 @@ func TestBatchIsSequenceAscending(t *testing.T) {
 	}
 }
 
-func TestBatchAddendaTraceNumber(t *testing.T) {
+func TestBatchIsSequenceAscending(t *testing.T) {
+	testBatchIsSequenceAscending(t)
+}
+
+func BenchmarkBatchIsSequenceAscending(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchIsSequenceAscending(b)
+	}
+}
+
+func testBatchAddendaTraceNumber(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.GetEntries()[0].AddAddenda(mockAddenda05())
 	if err := mockBatch.build(); err != nil {
@@ -274,7 +380,17 @@ func TestBatchAddendaTraceNumber(t *testing.T) {
 	}
 }
 
-func TestNewBatchDefault(t *testing.T) {
+func TestBatchAddendaTraceNumber(t *testing.T) {
+	testBatchAddendaTraceNumber(t)
+}
+
+func BenchmarkBatchAddendaTraceNumber(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchAddendaTraceNumber(b)
+	}
+}
+func testNewBatchDefault(t testing.TB) {
 	_, err := NewBatch(mockBatchInvalidSECHeader())
 
 	if e, ok := err.(*FileError); ok {
@@ -286,7 +402,18 @@ func TestNewBatchDefault(t *testing.T) {
 	}
 }
 
-func TestBatchCategory(t *testing.T) {
+func TestNewBatchDefault(t *testing.T) {
+	testNewBatchDefault(t)
+}
+
+func BenchmarkNewBatchDefault(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testNewBatchDefault(b)
+	}
+}
+
+func testBatchCategory(t testing.TB) {
 	mockBatch := mockBatch()
 	// Add a Addenda Return to the mock batch
 	entry := mockEntryDetail()
@@ -302,7 +429,18 @@ func TestBatchCategory(t *testing.T) {
 	}
 }
 
-func TestBatchCategoryForwardReturn(t *testing.T) {
+func TestBatchCategory(t *testing.T) {
+	testBatchCategory(t)
+}
+
+func BenchmarkBatchCategory(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchCategory(b)
+	}
+}
+
+func testBatchCategoryForwardReturn(t testing.TB) {
 	mockBatch := mockBatch()
 	// Add a Addenda Return to the mock batch
 	entry := mockEntryDetail()
@@ -323,8 +461,18 @@ func TestBatchCategoryForwardReturn(t *testing.T) {
 	}
 }
 
+func TestBatchCategoryForwardReturn(t *testing.T) {
+	testBatchCategoryForwardReturn(t)
+}
+func BenchmarkBatchCategoryForwardReturn(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchCategoryForwardReturn(b)
+	}
+}
+
 // Don't over write a batch trace number when building if it already exists
-func TestBatchTraceNumberExists(t *testing.T) {
+func testBatchTraceNumberExists(t testing.TB) {
 	mockBatch := mockBatch()
 	entry := mockEntryDetail()
 	traceBefore := entry.TraceNumberField()
@@ -336,7 +484,18 @@ func TestBatchTraceNumberExists(t *testing.T) {
 	}
 }
 
-func TestBatchFieldInclusion(t *testing.T) {
+func TestBatchTraceNumberExists(t *testing.T) {
+	testBatchTraceNumberExists(t)
+}
+
+func BenchmarkBatchTraceNumberExists(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchTraceNumberExists(b)
+	}
+}
+
+func testBatchFieldInclusion(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.header.ODFIIdentification = ""
 	if err := mockBatch.verify(); err != nil {
@@ -350,14 +509,36 @@ func TestBatchFieldInclusion(t *testing.T) {
 	}
 }
 
-func TestBatchInvalidTraceNumberODFI(t *testing.T) {
+func TestBatchFieldInclusion(t *testing.T) {
+	testBatchFieldInclusion(t)
+}
+
+func BenchmarkBatchFieldInclusion(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchFieldInclusion(b)
+	}
+}
+
+func testBatchInvalidTraceNumberODFI(t testing.TB) {
 	mockBatch := mockBatchInvalidTraceNumberODFI()
 	if err := mockBatch.build(); err != nil {
 		t.Errorf("%T: %s", err, err)
 	}
 }
 
-func TestBatchNoEntry(t *testing.T) {
+func TestBatchInvalidTraceNumberODFI(t *testing.T) {
+	testBatchInvalidTraceNumberODFI(t)
+}
+
+func BenchmarkBatchInvalidTraceNumberODFI(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchInvalidTraceNumberODFI(b)
+	}
+}
+
+func testBatchNoEntry(t testing.TB) {
 	mockBatch := mockBatchNoEntry()
 	if err := mockBatch.build(); err != nil {
 		if e, ok := err.(*BatchError); ok {
@@ -370,7 +551,18 @@ func TestBatchNoEntry(t *testing.T) {
 	}
 }
 
-func TestBatchControl(t *testing.T) {
+func TestBatchNoEntry(t *testing.T) {
+	testBatchNoEntry(t)
+}
+
+func BenchmarkBatchNoEntry(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchNoEntry(b)
+	}
+}
+
+func testBatchControl(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.control.ODFIIdentification = ""
 	if err := mockBatch.verify(); err != nil {
@@ -381,5 +573,16 @@ func TestBatchControl(t *testing.T) {
 		} else {
 			t.Errorf("%T: %s", err, err)
 		}
+	}
+}
+
+func TestBatchControl(t *testing.T) {
+	testBatchControl(t)
+}
+
+func BenchmarkBatchControl(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testBatchControl(b)
 	}
 }


### PR DESCRIPTION
@wadearnold I've wrapped some of the existing tests so that it's possible to use them for benchmarks, this can be enhanced/modified later but might be a good starting point for #166. The output looks like this:
```
goos: darwin
goarch: amd64
pkg: github.com/moov-io/ach
BenchmarkParseAddenda05-8                     	 1000000	      1943 ns/op	    1296 B/op	      23 allocs/op
BenchmarkAddenda05String-8                    	 1000000	      1264 ns/op	     352 B/op	      15 allocs/op
BenchmarkAddenda98Parse-8                     	 5000000	       337 ns/op	       0 B/op	       0 allocs/op
BenchmarkAddenda98String-8                    	 1000000	      1539 ns/op	     368 B/op	      19 allocs/op
BenchmarkAddenda98ValidRecordType-8           	10000000	       180 ns/op	      80 B/op	       2 allocs/op
BenchmarkAddenda98ValidTypeCode-8             	30000000	        51.9 ns/op	      48 B/op	       1 allocs/op
BenchmarkAddenda98ValidCorrectedData-8        	20000000	        67.2 ns/op	      48 B/op	       1 allocs/op
BenchmarkAddenda98ValidateTrue-8              	50000000	        34.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkAddenda98ValidateChangeCodeFalse-8   	20000000	        75.4 ns/op	      48 B/op	       1 allocs/op
BenchmarkAddenda98OriginalTraceField-8        	10000000	       179 ns/op	      48 B/op	       4 allocs/op
BenchmarkAddenda98OriginalDFIField-8          	20000000	       103 ns/op	      16 B/op	       3 allocs/op
BenchmarkAddenda98CorrectedDataField-8        	10000000	       154 ns/op	      96 B/op	       3 allocs/op
BenchmarkAddenda98TraceNumberField-8          	10000000	       160 ns/op	      32 B/op	       4 allocs/op
BenchmarkAddenda99Parse-8                     	 3000000	       457 ns/op	      80 B/op	       1 allocs/op
BenchmarkAddenda99String-8                    	 1000000	      1701 ns/op	     496 B/op	      23 allocs/op
BenchmarkAddenda99MakeReturnCodeDict-8        	  300000	      5285 ns/op	    3655 B/op	       7 allocs/op
BenchmarkAddenda99ValidateTrue-8              	50000000	        30.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkAddenda99ValidateReturnCodeFalse-8   	20000000	        69.4 ns/op	      48 B/op	       1 allocs/op
BenchmarkAddenda99OriginalTraceField-8        	10000000	       171 ns/op	      48 B/op	       4 allocs/op
BenchmarkAddenda99DateOfDeathField-8          	 5000000	       266 ns/op	      24 B/op	       3 allocs/op
BenchmarkAddenda99OriginalDFIField-8          	20000000	       104 ns/op	      16 B/op	       3 allocs/op
BenchmarkAddenda99AddendaInformationField-8   	10000000	       163 ns/op	     112 B/op	       3 allocs/op
BenchmarkAddenda99TraceNumberField-8          	10000000	       212 ns/op	      32 B/op	       4 allocs/op
BenchmarkBatchNumberMismatch-8                	  200000	      8207 ns/op	     856 B/op	      26 allocs/op
BenchmarkCreditBatchisBatchAmount-8           	  100000	     14626 ns/op	    1528 B/op	      48 allocs/op
BenchmarkSavingsBatchisBatchAmount-8          	  100000	     15572 ns/op	    1528 B/op	      48 allocs/op
BenchmarkBatchisEntryHash-8                   	  200000	      8473 ns/op	    1000 B/op	      36 allocs/op
BenchmarkBatchDNEMismatch-8                   	  200000	     11613 ns/op	    1560 B/op	      46 allocs/op
BenchmarkBatchTraceNumberNotODFI-8            	  200000	      8980 ns/op	    1000 B/op	      40 allocs/op
BenchmarkBatchEntryCountEquality-8            	  100000	     12951 ns/op	    1640 B/op	      51 allocs/op
BenchmarkBatchAddendaIndicator-8              	  200000	      7851 ns/op	     952 B/op	      34 allocs/op
BenchmarkBatchIsAddendaSeqAscending-8         	  200000	     11484 ns/op	    1400 B/op	      51 allocs/op
BenchmarkBatchIsSequenceAscending-8           	  200000	     10503 ns/op	    1136 B/op	      40 allocs/op
BenchmarkBatchAddendaTraceNumber-8            	  200000	     11330 ns/op	    1352 B/op	      52 allocs/op
BenchmarkNewBatchDefault-8                    	 5000000	       357 ns/op	     320 B/op	       4 allocs/op
BenchmarkBatchCategory-8                      	  200000	      6040 ns/op	    1288 B/op	      29 allocs/op
BenchmarkBatchCategoryForwardReturn-8         	  100000	     13884 ns/op	    1496 B/op	      56 allocs/op
BenchmarkBatchTraceNumberExists-8             	  200000	      5922 ns/op	    1176 B/op	      29 allocs/op
BenchmarkBatchFieldInclusion-8                	  500000	      3111 ns/op	     808 B/op	      18 allocs/op
BenchmarkBatchInvalidTraceNumberODFI-8        	  500000	      3293 ns/op	     760 B/op	      24 allocs/op
BenchmarkBatchNoEntry-8                       	 1000000	      1575 ns/op	     256 B/op	       2 allocs/op
BenchmarkBatchControl-8                       	  200000	      6997 ns/op	     840 B/op	      25 allocs/op
BenchmarkParseFileHeader-8                    	  500000	      3098 ns/op	     336 B/op	      14 allocs/op
PASS
ok  	github.com/moov-io/ach	76.330s
```