### PR TITLE
switch String() to use strings.Builder internally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-- 1.9.x
 - 1.10.x
+- 1.11rc1
 env:
   global:
     secure: QPkcX77j8QEqTwOYyLGItqvxYwE6Na5WaSZWjmhp48OlxYatWRHxJBwcFYSn1OWD5FMn+3oW39fHknReIxtrnhXMaNvI7x3/0gy4zujD/xZ2xAg7NsQ+l5buvEFO8/LEwwo0fp4knItFcBv8xH/ziJBJyXvgfMtj7Is4Q/pB1p6pWDdVy1vtAj3zH02bcqh1yXXS3HvcD8UhTszfU017gVNXDN1ow0rp1L3ainr3btrVK9izUxZfKvb7PlWJO1ogah7xNr/dIOJLsx2SfKgzKp+3H28L2WegtbzON74Op4jXvRywCwqjmUt/nwJ/Y9anunMNHT136h+ye4ziG1i/VdbWq0Q4PopQ8yYqinujG7SjfQio+wNCV2cwc2r/WjNBjbH0N9/Pflogq3RHvgy/9VtPif1tY+RrZCSntohoEZbYpVcFQFE1xDyf6xq/uLxVeEcCU33gqq7cKEfpcUgyCITa+yCPfBdtgkLBJ8h7Sew1j08D1kTKUW6g3D1epmwlCh/Z16oHG5VwSnCLGDjJy8wm/hQk1i/g7qeP7g24CfNzffzlFBCy88HhjzmrhUpcaTyfVVDf4h8wK6Zu/J3dHjHXQYwfiQRqpMa+2DYyjGgZhniccuh4GWolGZauDQdmO9SD4Ugyt9PEMk02i32ax3A4XE/Q6VNOam+qszviX3Q=

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Package 'moov-io/ach' implements a file reader and writer for parsing [ACH](http
 
 ACH is under active development but already in production for multiple companies. Please star the project if you are interested in its progress.
 
-* Library currently supports the reading and writing 
+* Library currently supports the reading and writing
 	* ARC (Accounts Receivable Entry)
 	* BOC (Back Office Conversion)
 	* CCD (Corporate credit or debit)
@@ -38,7 +38,7 @@ ACH is under active development but already in production for multiple companies
 	* Addenda Type Code 98 (NOC)
 	* Addenda Type Code 99 (Return)
 	* IAT
-	
+
 ## Project Roadmap
 * Additional SEC codes will be added based on library users needs. Please open an issue with a valid test file.
 * Review the project issues for more detailed information
@@ -63,25 +63,25 @@ if err != nil {
 if achFile.Validate(); err != nil {
 	fmt.Printf("Could not validate entire read file: %v", err)
 }
-// Check if any Notifications Of Change exist in the file 
+// Check if any Notifications Of Change exist in the file
 if len(achFile.NotificationOfChange) > 0 {
 	for _, batch := range achFile.NotificationOfChange {
 		a98 := batch.GetEntries()[0].Addendum[0].(*Addenda98)
 		println(a98.CorrectedData)
-	} 
-} 
-// Check if any Return Entries exist in the file 
+	}
+}
+// Check if any Return Entries exist in the file
 if len(achFile.ReturnEntries) > 0 {
 	for _, batch := range achFile.ReturnEntries {
 		aReturn := batch.GetEntries()[0].Addendum[0].(*Addenda99)
 		println(aReturn.ReturnCode)
-	} 
+	}
 }
-```	
+```
 
 ### Create a file
 The following is based on [simple file creation](https://github.com/moov-io/ach/tree/master/test/simple-file-creation)
- 
+
  ```go
 	fh := ach.NewFileHeader()
 	fh.ImmediateDestination = "9876543210" // A blank space followed by your ODFI's transit/routing number
@@ -94,7 +94,7 @@ The following is based on [simple file creation](https://github.com/moov-io/ach/
 	file.SetHeader(fh)
 ```
 
-Explicitly create a PPD batch file. 
+Explicitly create a PPD batch file.
 
 Errors only if payment type is not supported
 
@@ -153,7 +153,7 @@ To add one or more optional addenda records for an entry
 addenda := NewAddenda05()
 addenda.PaymentRelatedInformation = "Bonus pay for amazing work on #OSS"
 ```
-Add the addenda record to the detail entry 
+Add the addenda record to the detail entry
 
  ```go
 entry.AddAddenda(addenda)
@@ -249,7 +249,7 @@ w.Flush()
 }
 ```
 
-Which will generate a well formed ACH flat file. 
+Which will generate a well formed ACH flat file.
 
 ```text
 101 210000890 1234567891708290000A094101Your Bank              Your Company           #00000A1
@@ -261,10 +261,10 @@ Which will generate a well formed ACH flat file.
 6221020010175343121          0000000799#123456        Wade Arnold           R 1234567890000001
 705Monthly Membership Subscription                                                 00010000001
 82200000020010200101000000000000000000000799123456789                          234567890000002
-9000002000001000000040020400202000000017500000000000799 
+9000002000001000000040020400202000000017500000000000799
 ```
 
-### Create an IAT file 
+### Create an IAT file
 
 ```go
     file := NewFile().SetHeader(mockFileHeader())
@@ -337,14 +337,14 @@ Which will generate a well formed ACH flat file.
 	w := NewWriter(os.Stdout)
 	if err := w.Write(file); err != nil {
 		log.Fatalf("Unexpected error: %s\n", err)
-	}	
+	}
 	w.Flush()
 ```
 
 This will generate a well formed flat IAT ACH file
 
 ```text
-101 987654321 1234567891807200000A094101Federal Reserve Bank   My Bank Name                   
+101 987654321 1234567891807200000A094101Federal Reserve Bank   My Bank Name
 5220                FF3               US123456789 IATTRADEPAYMTCADUSD010101   0231380100000001
 6221210428820007             0000100000123456789                              1231380100000001
 710ANN000000000000100000928383-23938          BEK Enterprises                          0000001
@@ -379,25 +379,27 @@ This will generate a well formed flat IAT ACH file
 718Bank of Turkey                     0112312345678910                    TR       00040000001
 718Bank of United Kingdom             011234567890123456789012345678901234GB       00050000001
 82200000150012104288000000002000000000000000                                   231380100000002
-9000002000004000000300024208576000000002000000000100000                                       
+9000002000004000000300024208576000000002000000000100000
 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
 9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
 ```
 
-# Getting Help 
+# Getting Help
 
- channel | info 
+ channel | info
  ------- | -------
  Google Group [moov-users](https://groups.google.com/forum/#!forum/moov-users)| The Moov users Google group is for contributors other people contributing to the Moov project. You can join them without a google account by sending an email to [moov-users+subscribe@googlegroups.com](mailto:moov-users+subscribe@googlegroups.com). After receiving the join-request message, you can simply reply to that to confirm the subscription.
 Twitter [@moov_io](https://twitter.com/moov_io)	| You can follow Moov.IO's Twitter feed to get updates on our project(s). You can also tweet us questions or just share blogs or stories.
-[GitHub Issue](https://github.com/moov-io) | If you are able to reproduce an problem please open a GitHub Issue under the specific project that caused the error. 
-[moov-io slack](http://moov-io.slack.com/) | Join our slack channel to have an interactive discussion about the development of the project. 
+[GitHub Issue](https://github.com/moov-io) | If you are able to reproduce an problem please open a GitHub Issue under the specific project that caused the error.
+[moov-io slack](http://moov-io.slack.com/) | Join our slack channel to have an interactive discussion about the development of the project.
 
-## Contributing 
+## Contributing
 
-Yes please! Please review our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) to get started! 
+Yes please! Please review our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) to get started!
+
+Note: This project requires Go 1.10 or higher to compile.
 
 ## License
 

--- a/addenda02.go
+++ b/addenda02.go
@@ -89,20 +89,21 @@ func (addenda02 *Addenda02) Parse(record string) {
 
 // String writes the Addenda02 struct to a 94 character string.
 func (addenda02 *Addenda02) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v%v",
-		addenda02.recordType,
-		addenda02.typeCode,
-		addenda02.ReferenceInformationOneField(),
-		addenda02.ReferenceInformationTwoField(),
-		addenda02.TerminalIdentificationCodeField(),
-		addenda02.TransactionSerialNumberField(),
-		addenda02.TransactionDateField(),
-		addenda02.AuthorizationCodeOrExpireDateField(),
-		addenda02.TerminalLocationField(),
-		addenda02.TerminalCityField(),
-		addenda02.TerminalStateField(),
-		addenda02.TraceNumberField(),
-	)
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda02.recordType)
+	buf.WriteString(addenda02.typeCode)
+	buf.WriteString(addenda02.ReferenceInformationOneField())
+	buf.WriteString(addenda02.ReferenceInformationTwoField())
+	buf.WriteString(addenda02.TerminalIdentificationCodeField())
+	buf.WriteString(addenda02.TransactionSerialNumberField())
+	buf.WriteString(addenda02.TransactionDateField())
+	buf.WriteString(addenda02.AuthorizationCodeOrExpireDateField())
+	buf.WriteString(addenda02.TerminalLocationField())
+	buf.WriteString(addenda02.TerminalCityField())
+	buf.WriteString(addenda02.TerminalStateField())
+	buf.WriteString(addenda02.TraceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda05.go
+++ b/addenda05.go
@@ -60,12 +60,14 @@ func (addenda05 *Addenda05) Parse(record string) {
 
 // String writes the Addenda05 struct to a 94 character string.
 func (addenda05 *Addenda05) String() string {
-	return fmt.Sprintf("%v%v%v%v%v",
-		addenda05.recordType,
-		addenda05.typeCode,
-		addenda05.PaymentRelatedInformationField(),
-		addenda05.SequenceNumberField(),
-		addenda05.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda05.recordType)
+	buf.WriteString(addenda05.typeCode)
+	buf.WriteString(addenda05.PaymentRelatedInformationField())
+	buf.WriteString(addenda05.SequenceNumberField())
+	buf.WriteString(addenda05.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda10.go
+++ b/addenda10.go
@@ -79,16 +79,18 @@ func (addenda10 *Addenda10) Parse(record string) {
 
 // String writes the Addenda10 struct to a 94 character string.
 func (addenda10 *Addenda10) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v",
-		addenda10.recordType,
-		addenda10.typeCode,
-		// TransactionTypeCode Validator
-		addenda10.TransactionTypeCode,
-		addenda10.ForeignPaymentAmountField(),
-		addenda10.ForeignTraceNumberField(),
-		addenda10.NameField(),
-		addenda10.reservedField(),
-		addenda10.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda10.recordType)
+	buf.WriteString(addenda10.typeCode)
+	// TransactionTypeCode Validator
+	buf.WriteString(addenda10.TransactionTypeCode)
+	buf.WriteString(addenda10.ForeignPaymentAmountField())
+	buf.WriteString(addenda10.ForeignTraceNumberField())
+	buf.WriteString(addenda10.NameField())
+	buf.WriteString(addenda10.reservedField())
+	buf.WriteString(addenda10.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda11.go
+++ b/addenda11.go
@@ -66,13 +66,15 @@ func (addenda11 *Addenda11) Parse(record string) {
 
 // String writes the Addenda11 struct to a 94 character string.
 func (addenda11 *Addenda11) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v",
-		addenda11.recordType,
-		addenda11.typeCode,
-		addenda11.OriginatorNameField(),
-		addenda11.OriginatorStreetAddressField(),
-		addenda11.reservedField(),
-		addenda11.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda11.recordType)
+	buf.WriteString(addenda11.typeCode)
+	buf.WriteString(addenda11.OriginatorNameField())
+	buf.WriteString(addenda11.OriginatorStreetAddressField())
+	buf.WriteString(addenda11.reservedField())
+	buf.WriteString(addenda11.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda12.go
+++ b/addenda12.go
@@ -71,14 +71,16 @@ func (addenda12 *Addenda12) Parse(record string) {
 
 // String writes the Addenda12 struct to a 94 character string.
 func (addenda12 *Addenda12) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v",
-		addenda12.recordType,
-		addenda12.typeCode,
-		addenda12.OriginatorCityStateProvinceField(),
-		// ToDo Validator for backslash
-		addenda12.OriginatorCountryPostalCodeField(),
-		addenda12.reservedField(),
-		addenda12.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda12.recordType)
+	buf.WriteString(addenda12.typeCode)
+	buf.WriteString(addenda12.OriginatorCityStateProvinceField())
+	// ToDo Validator for backslash
+	buf.WriteString(addenda12.OriginatorCountryPostalCodeField())
+	buf.WriteString(addenda12.reservedField())
+	buf.WriteString(addenda12.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda13.go
+++ b/addenda13.go
@@ -91,15 +91,17 @@ func (addenda13 *Addenda13) Parse(record string) {
 
 // String writes the Addenda13 struct to a 94 character string.
 func (addenda13 *Addenda13) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v",
-		addenda13.recordType,
-		addenda13.typeCode,
-		addenda13.ODFINameField(),
-		addenda13.ODFIIDNumberQualifierField(),
-		addenda13.ODFIIdentificationField(),
-		addenda13.ODFIBranchCountryCodeField(),
-		addenda13.reservedField(),
-		addenda13.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda13.recordType)
+	buf.WriteString(addenda13.typeCode)
+	buf.WriteString(addenda13.ODFINameField())
+	buf.WriteString(addenda13.ODFIIDNumberQualifierField())
+	buf.WriteString(addenda13.ODFIIdentificationField())
+	buf.WriteString(addenda13.ODFIBranchCountryCodeField())
+	buf.WriteString(addenda13.reservedField())
+	buf.WriteString(addenda13.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda14.go
+++ b/addenda14.go
@@ -87,15 +87,17 @@ func (addenda14 *Addenda14) Parse(record string) {
 
 // String writes the Addenda14 struct to a 94 character string.
 func (addenda14 *Addenda14) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v",
-		addenda14.recordType,
-		addenda14.typeCode,
-		addenda14.RDFINameField(),
-		addenda14.RDFIIDNumberQualifierField(),
-		addenda14.RDFIIdentificationField(),
-		addenda14.RDFIBranchCountryCodeField(),
-		addenda14.reservedField(),
-		addenda14.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda14.recordType)
+	buf.WriteString(addenda14.typeCode)
+	buf.WriteString(addenda14.RDFINameField())
+	buf.WriteString(addenda14.RDFIIDNumberQualifierField())
+	buf.WriteString(addenda14.RDFIIdentificationField())
+	buf.WriteString(addenda14.RDFIBranchCountryCodeField())
+	buf.WriteString(addenda14.reservedField())
+	buf.WriteString(addenda14.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda15.go
+++ b/addenda15.go
@@ -67,13 +67,15 @@ func (addenda15 *Addenda15) Parse(record string) {
 
 // String writes the Addenda15 struct to a 94 character string.
 func (addenda15 *Addenda15) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v",
-		addenda15.recordType,
-		addenda15.typeCode,
-		addenda15.ReceiverIDNumberField(),
-		addenda15.ReceiverStreetAddressField(),
-		addenda15.reservedField(),
-		addenda15.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda15.recordType)
+	buf.WriteString(addenda15.typeCode)
+	buf.WriteString(addenda15.ReceiverIDNumberField())
+	buf.WriteString(addenda15.ReceiverStreetAddressField())
+	buf.WriteString(addenda15.reservedField())
+	buf.WriteString(addenda15.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda16.go
+++ b/addenda16.go
@@ -70,13 +70,15 @@ func (addenda16 *Addenda16) Parse(record string) {
 
 // String writes the Addenda16 struct to a 94 character string.
 func (addenda16 *Addenda16) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v",
-		addenda16.recordType,
-		addenda16.typeCode,
-		addenda16.ReceiverCityStateProvinceField(),
-		addenda16.ReceiverCountryPostalCodeField(),
-		addenda16.reservedField(),
-		addenda16.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda16.recordType)
+	buf.WriteString(addenda16.typeCode)
+	buf.WriteString(addenda16.ReceiverCityStateProvinceField())
+	buf.WriteString(addenda16.ReceiverCountryPostalCodeField())
+	buf.WriteString(addenda16.reservedField())
+	buf.WriteString(addenda16.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda17.go
+++ b/addenda17.go
@@ -65,12 +65,14 @@ func (addenda17 *Addenda17) Parse(record string) {
 
 // String writes the Addenda17 struct to a 94 character string.
 func (addenda17 *Addenda17) String() string {
-	return fmt.Sprintf("%v%v%v%v%v",
-		addenda17.recordType,
-		addenda17.typeCode,
-		addenda17.PaymentRelatedInformationField(),
-		addenda17.SequenceNumberField(),
-		addenda17.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda17.recordType)
+	buf.WriteString(addenda17.typeCode)
+	buf.WriteString(addenda17.PaymentRelatedInformationField())
+	buf.WriteString(addenda17.SequenceNumberField())
+	buf.WriteString(addenda17.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda18.go
+++ b/addenda18.go
@@ -94,16 +94,18 @@ func (addenda18 *Addenda18) Parse(record string) {
 
 // String writes the Addenda18 struct to a 94 character string.
 func (addenda18 *Addenda18) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v",
-		addenda18.recordType,
-		addenda18.typeCode,
-		addenda18.ForeignCorrespondentBankNameField(),
-		addenda18.ForeignCorrespondentBankIDNumberQualifierField(),
-		addenda18.ForeignCorrespondentBankIDNumberField(),
-		addenda18.ForeignCorrespondentBankBranchCountryCodeField(),
-		addenda18.reservedField(),
-		addenda18.SequenceNumberField(),
-		addenda18.EntryDetailSequenceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda18.recordType)
+	buf.WriteString(addenda18.typeCode)
+	buf.WriteString(addenda18.ForeignCorrespondentBankNameField())
+	buf.WriteString(addenda18.ForeignCorrespondentBankIDNumberQualifierField())
+	buf.WriteString(addenda18.ForeignCorrespondentBankIDNumberField())
+	buf.WriteString(addenda18.ForeignCorrespondentBankBranchCountryCodeField())
+	buf.WriteString(addenda18.reservedField())
+	buf.WriteString(addenda18.SequenceNumberField())
+	buf.WriteString(addenda18.EntryDetailSequenceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/addenda98.go
+++ b/addenda98.go
@@ -86,17 +86,18 @@ func (addenda98 *Addenda98) Parse(record string) {
 
 // String writes the Addenda98 struct to a 94 character string
 func (addenda98 *Addenda98) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v",
-		addenda98.recordType,
-		addenda98.TypeCode(),
-		addenda98.ChangeCode,
-		addenda98.OriginalTraceField(),
-		"      ", //6 char reserved field
-		addenda98.OriginalDFIField(),
-		addenda98.CorrectedDataField(),
-		"               ", // 15 char reserved field
-		addenda98.TraceNumberField(),
-	)
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(addenda98.recordType)
+	buf.WriteString(addenda98.TypeCode())
+	buf.WriteString(addenda98.ChangeCode)
+	buf.WriteString(addenda98.OriginalTraceField())
+	buf.WriteString("      ") // 6 char reserved field
+	buf.WriteString(addenda98.OriginalDFIField())
+	buf.WriteString(addenda98.CorrectedDataField())
+	buf.WriteString("               ") // 15 char reserved field
+	buf.WriteString(addenda98.TraceNumberField())
+	return buf.String()
 }
 
 // Validate verifies NACHA rules for Addenda98

--- a/addenda99.go
+++ b/addenda99.go
@@ -98,16 +98,17 @@ func (Addenda99 *Addenda99) Parse(record string) {
 
 // String writes the Addenda99 struct to a 94 character string
 func (Addenda99 *Addenda99) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v",
-		Addenda99.recordType,
-		Addenda99.TypeCode(),
-		Addenda99.ReturnCode,
-		Addenda99.OriginalTraceField(),
-		Addenda99.DateOfDeathField(),
-		Addenda99.OriginalDFIField(),
-		Addenda99.AddendaInformationField(),
-		Addenda99.TraceNumberField(),
-	)
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(Addenda99.recordType)
+	buf.WriteString(Addenda99.TypeCode())
+	buf.WriteString(Addenda99.ReturnCode)
+	buf.WriteString(Addenda99.OriginalTraceField())
+	buf.WriteString(Addenda99.DateOfDeathField())
+	buf.WriteString(Addenda99.OriginalDFIField())
+	buf.WriteString(Addenda99.AddendaInformationField())
+	buf.WriteString(Addenda99.TraceNumberField())
+	return buf.String()
 }
 
 // Validate verifies NACHA rules for Addenda99

--- a/batchControl.go
+++ b/batchControl.go
@@ -109,19 +109,20 @@ func NewBatchControl() *BatchControl {
 
 // String writes the BatchControl struct to a 94 character string.
 func (bc *BatchControl) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v",
-		bc.recordType,
-		bc.ServiceClassCode,
-		bc.EntryAddendaCountField(),
-		bc.EntryHashField(),
-		bc.TotalDebitEntryDollarAmountField(),
-		bc.TotalCreditEntryDollarAmountField(),
-		bc.CompanyIdentificationField(),
-		bc.MessageAuthenticationCodeField(),
-		"      ",
-		bc.ODFIIdentificationField(),
-		bc.BatchNumberField(),
-	)
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(bc.recordType)
+	buf.WriteString(string(bc.ServiceClassCode))
+	buf.WriteString(bc.EntryAddendaCountField())
+	buf.WriteString(bc.EntryHashField())
+	buf.WriteString(bc.TotalDebitEntryDollarAmountField())
+	buf.WriteString(bc.TotalCreditEntryDollarAmountField())
+	buf.WriteString(bc.CompanyIdentificationField())
+	buf.WriteString(bc.MessageAuthenticationCodeField())
+	buf.WriteString("      ")
+	buf.WriteString(bc.ODFIIdentificationField())
+	buf.WriteString(bc.BatchNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -156,21 +156,22 @@ func (bh *BatchHeader) Parse(record string) {
 
 // String writes the BatchHeader struct to a 94 character string.
 func (bh *BatchHeader) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v%v%v",
-		bh.recordType,
-		bh.ServiceClassCode,
-		bh.CompanyNameField(),
-		bh.CompanyDiscretionaryDataField(),
-		bh.CompanyIdentificationField(),
-		bh.StandardEntryClassCode,
-		bh.CompanyEntryDescriptionField(),
-		bh.CompanyDescriptiveDateField(),
-		bh.EffectiveEntryDateField(),
-		bh.settlementDateField(),
-		bh.OriginatorStatusCode,
-		bh.ODFIIdentificationField(),
-		bh.BatchNumberField(),
-	)
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(bh.recordType)
+	buf.WriteString(string(bh.ServiceClassCode))
+	buf.WriteString(bh.CompanyNameField())
+	buf.WriteString(bh.CompanyDiscretionaryDataField())
+	buf.WriteString(bh.CompanyIdentificationField())
+	buf.WriteString(bh.StandardEntryClassCode)
+	buf.WriteString(bh.CompanyEntryDescriptionField())
+	buf.WriteString(bh.CompanyDescriptiveDateField())
+	buf.WriteString(bh.EffectiveEntryDateField())
+	buf.WriteString(bh.settlementDateField())
+	buf.WriteString(string(bh.OriginatorStatusCode))
+	buf.WriteString(bh.ODFIIdentificationField())
+	buf.WriteString(bh.BatchNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -126,18 +126,20 @@ func (ed *EntryDetail) Parse(record string) {
 
 // String writes the EntryDetail struct to a 94 character string.
 func (ed *EntryDetail) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v",
-		ed.recordType,
-		ed.TransactionCode,
-		ed.RDFIIdentificationField(),
-		ed.CheckDigit,
-		ed.DFIAccountNumberField(),
-		ed.AmountField(),
-		ed.IdentificationNumberField(),
-		ed.IndividualNameField(),
-		ed.DiscretionaryDataField(),
-		ed.AddendaRecordIndicator,
-		ed.TraceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(ed.recordType)
+	buf.WriteString(string(ed.TransactionCode))
+	buf.WriteString(ed.RDFIIdentificationField())
+	buf.WriteString(ed.CheckDigit)
+	buf.WriteString(ed.DFIAccountNumberField())
+	buf.WriteString(ed.AmountField())
+	buf.WriteString(ed.IdentificationNumberField())
+	buf.WriteString(ed.IndividualNameField())
+	buf.WriteString(ed.DiscretionaryDataField())
+	buf.WriteString(string(ed.AddendaRecordIndicator))
+	buf.WriteString(ed.TraceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated
@@ -224,7 +226,7 @@ func (ed *EntryDetail) AddAddenda(addenda Addendumer) []Addendumer {
 		ed.Addendum = nil
 		ed.Addendum = append(ed.Addendum, addenda)
 		return ed.Addendum
-	// default is current *Addenda05
+		// default is current *Addenda05
 	default:
 		ed.Category = CategoryForward
 		ed.Addendum = append(ed.Addendum, addenda)

--- a/fileControl.go
+++ b/fileControl.go
@@ -4,7 +4,10 @@
 
 package ach
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // FileControl record contains entry counts, dollar totals and hash
 // totals accumulated from each batch control record in the file.
@@ -71,16 +74,17 @@ func NewFileControl() FileControl {
 
 // String writes the FileControl struct to a 94 character string.
 func (fc *FileControl) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v",
-		fc.recordType,
-		fc.BatchCountField(),
-		fc.BlockCountField(),
-		fc.EntryAddendaCountField(),
-		fc.EntryHashField(),
-		fc.TotalDebitEntryDollarAmountInFileField(),
-		fc.TotalCreditEntryDollarAmountInFileField(),
-		fc.reserved,
-	)
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(fc.recordType)
+	buf.WriteString(fc.BatchCountField())
+	buf.WriteString(fc.BlockCountField())
+	buf.WriteString(fc.EntryAddendaCountField())
+	buf.WriteString(fc.EntryHashField())
+	buf.WriteString(fc.TotalDebitEntryDollarAmountInFileField())
+	buf.WriteString(fc.TotalCreditEntryDollarAmountInFileField())
+	buf.WriteString(fc.reserved)
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/fileHeader.go
+++ b/fileHeader.go
@@ -138,28 +138,27 @@ func (fh *FileHeader) Parse(record string) {
 
 // String writes the FileHeader struct to a 94 character string.
 func (fh *FileHeader) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v%v%v",
-		fh.recordType,
-		fh.priorityCode,
-		fh.ImmediateDestinationField(),
-		fh.ImmediateOriginField(),
-		fh.FileCreationDateField(),
-		fh.FileCreationTimeField(),
-		fh.FileIDModifier,
-		fh.recordSize,
-		fh.blockingFactor,
-		fh.formatCode,
-		fh.ImmediateDestinationNameField(),
-		fh.ImmediateOriginNameField(),
-		fh.ReferenceCodeField(),
-	)
-
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(fh.recordType)
+	buf.WriteString(fh.priorityCode)
+	buf.WriteString(fh.ImmediateDestinationField())
+	buf.WriteString(fh.ImmediateOriginField())
+	buf.WriteString(fh.FileCreationDateField())
+	buf.WriteString(fh.FileCreationTimeField())
+	buf.WriteString(fh.FileIDModifier)
+	buf.WriteString(fh.recordSize)
+	buf.WriteString(fh.blockingFactor)
+	buf.WriteString(fh.formatCode)
+	buf.WriteString(fh.ImmediateDestinationNameField())
+	buf.WriteString(fh.ImmediateOriginNameField())
+	buf.WriteString(fh.ReferenceCodeField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated
 // The first error encountered is returned and stops the parsing.
 func (fh *FileHeader) Validate() error {
-
 	if err := fh.fieldInclusion(); err != nil {
 		return err
 	}

--- a/iatBatchHeader.go
+++ b/iatBatchHeader.go
@@ -222,25 +222,26 @@ func (iatBh *IATBatchHeader) Parse(record string) {
 
 // String writes the BatchHeader struct to a 94 character string.
 func (iatBh *IATBatchHeader) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v%v",
-		iatBh.recordType,
-		iatBh.ServiceClassCode,
-		iatBh.IATIndicatorField(),
-		iatBh.ForeignExchangeIndicatorField(),
-		iatBh.ForeignExchangeReferenceIndicatorField(),
-		iatBh.ForeignExchangeReferenceField(),
-		iatBh.ISODestinationCountryCodeField(),
-		iatBh.OriginatorIdentificationField(),
-		iatBh.StandardEntryClassCode,
-		iatBh.CompanyEntryDescriptionField(),
-		iatBh.ISOOriginatingCurrencyCodeField(),
-		iatBh.ISODestinationCurrencyCodeField(),
-		iatBh.EffectiveEntryDateField(),
-		iatBh.settlementDateField(),
-		iatBh.OriginatorStatusCode,
-		iatBh.ODFIIdentificationField(),
-		iatBh.BatchNumberField(),
-	)
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(iatBh.recordType)
+	buf.WriteString(string(iatBh.ServiceClassCode))
+	buf.WriteString(iatBh.IATIndicatorField())
+	buf.WriteString(iatBh.ForeignExchangeIndicatorField())
+	buf.WriteString(iatBh.ForeignExchangeReferenceIndicatorField())
+	buf.WriteString(iatBh.ForeignExchangeReferenceField())
+	buf.WriteString(iatBh.ISODestinationCountryCodeField())
+	buf.WriteString(iatBh.OriginatorIdentificationField())
+	buf.WriteString(iatBh.StandardEntryClassCode)
+	buf.WriteString(iatBh.CompanyEntryDescriptionField())
+	buf.WriteString(iatBh.ISOOriginatingCurrencyCodeField())
+	buf.WriteString(iatBh.ISODestinationCurrencyCodeField())
+	buf.WriteString(iatBh.EffectiveEntryDateField())
+	buf.WriteString(iatBh.settlementDateField())
+	buf.WriteString(string(iatBh.OriginatorStatusCode))
+	buf.WriteString(iatBh.ODFIIdentificationField())
+	buf.WriteString(iatBh.BatchNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -7,6 +7,7 @@ package ach
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // IATEntryDetail contains the actual transaction data for an individual entry.
@@ -151,20 +152,22 @@ func (ed *IATEntryDetail) Parse(record string) {
 
 // String writes the EntryDetail struct to a 94 character string.
 func (ed *IATEntryDetail) String() string {
-	return fmt.Sprintf("%v%v%v%v%v%v%v%v%v%v%v%v%v",
-		ed.recordType,
-		ed.TransactionCode,
-		ed.RDFIIdentificationField(),
-		ed.CheckDigit,
-		ed.AddendaRecordsField(),
-		ed.reservedField(),
-		ed.AmountField(),
-		ed.DFIAccountNumberField(),
-		ed.reservedTwoField(),
-		ed.OFACSreeningIndicatorField(),
-		ed.SecondaryOFACSreeningIndicatorField(),
-		ed.AddendaRecordIndicator,
-		ed.TraceNumberField())
+	var buf strings.Builder
+	buf.Grow(94)
+	buf.WriteString(ed.recordType)
+	buf.WriteString(string(ed.TransactionCode))
+	buf.WriteString(ed.RDFIIdentificationField())
+	buf.WriteString(ed.CheckDigit)
+	buf.WriteString(ed.AddendaRecordsField())
+	buf.WriteString(ed.reservedField())
+	buf.WriteString(ed.AmountField())
+	buf.WriteString(ed.DFIAccountNumberField())
+	buf.WriteString(ed.reservedTwoField())
+	buf.WriteString(ed.OFACSreeningIndicatorField())
+	buf.WriteString(ed.SecondaryOFACSreeningIndicatorField())
+	buf.WriteString(string(ed.AddendaRecordIndicator))
+	buf.WriteString(ed.TraceNumberField())
+	return buf.String()
 }
 
 // Validate performs NACHA format rule checks on the record and returns an error if not Validated


### PR DESCRIPTION
I'm not actually sure this helps a lot. We're still creating a lot of internal strings (i.e. from alphaField` and `numericField`). I ran a couple benchmarks locally and didn't see allocs decrease, and the ns/op time didn't change much. 

Fixes: https://github.com/moov-io/ach/issues/169