### PR TITLE
on String() methods, properly format strings

### DIFF
--- a/batchControl.go
+++ b/batchControl.go
@@ -112,7 +112,7 @@ func (bc *BatchControl) String() string {
 	var buf strings.Builder
 	buf.Grow(94)
 	buf.WriteString(bc.recordType)
-	buf.WriteString(string(bc.ServiceClassCode))
+	buf.WriteString(fmt.Sprintf("%v", bc.ServiceClassCode))
 	buf.WriteString(bc.EntryAddendaCountField())
 	buf.WriteString(bc.EntryHashField())
 	buf.WriteString(bc.TotalDebitEntryDollarAmountField())

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -159,7 +159,7 @@ func (bh *BatchHeader) String() string {
 	var buf strings.Builder
 	buf.Grow(94)
 	buf.WriteString(bh.recordType)
-	buf.WriteString(string(bh.ServiceClassCode))
+	buf.WriteString(fmt.Sprintf("%v", bh.ServiceClassCode))
 	buf.WriteString(bh.CompanyNameField())
 	buf.WriteString(bh.CompanyDiscretionaryDataField())
 	buf.WriteString(bh.CompanyIdentificationField())
@@ -168,7 +168,7 @@ func (bh *BatchHeader) String() string {
 	buf.WriteString(bh.CompanyDescriptiveDateField())
 	buf.WriteString(bh.EffectiveEntryDateField())
 	buf.WriteString(bh.settlementDateField())
-	buf.WriteString(string(bh.OriginatorStatusCode))
+	buf.WriteString(fmt.Sprintf("%v", bh.OriginatorStatusCode))
 	buf.WriteString(bh.ODFIIdentificationField())
 	buf.WriteString(bh.BatchNumberField())
 	return buf.String()

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -129,7 +129,7 @@ func (ed *EntryDetail) String() string {
 	var buf strings.Builder
 	buf.Grow(94)
 	buf.WriteString(ed.recordType)
-	buf.WriteString(string(ed.TransactionCode))
+	buf.WriteString(fmt.Sprintf("%v", ed.TransactionCode))
 	buf.WriteString(ed.RDFIIdentificationField())
 	buf.WriteString(ed.CheckDigit)
 	buf.WriteString(ed.DFIAccountNumberField())
@@ -137,7 +137,7 @@ func (ed *EntryDetail) String() string {
 	buf.WriteString(ed.IdentificationNumberField())
 	buf.WriteString(ed.IndividualNameField())
 	buf.WriteString(ed.DiscretionaryDataField())
-	buf.WriteString(string(ed.AddendaRecordIndicator))
+	buf.WriteString(fmt.Sprintf("%v", ed.AddendaRecordIndicator))
 	buf.WriteString(ed.TraceNumberField())
 	return buf.String()
 }

--- a/iatBatchHeader.go
+++ b/iatBatchHeader.go
@@ -225,7 +225,7 @@ func (iatBh *IATBatchHeader) String() string {
 	var buf strings.Builder
 	buf.Grow(94)
 	buf.WriteString(iatBh.recordType)
-	buf.WriteString(string(iatBh.ServiceClassCode))
+	buf.WriteString(fmt.Sprintf("%v", iatBh.ServiceClassCode))
 	buf.WriteString(iatBh.IATIndicatorField())
 	buf.WriteString(iatBh.ForeignExchangeIndicatorField())
 	buf.WriteString(iatBh.ForeignExchangeReferenceIndicatorField())
@@ -238,7 +238,7 @@ func (iatBh *IATBatchHeader) String() string {
 	buf.WriteString(iatBh.ISODestinationCurrencyCodeField())
 	buf.WriteString(iatBh.EffectiveEntryDateField())
 	buf.WriteString(iatBh.settlementDateField())
-	buf.WriteString(string(iatBh.OriginatorStatusCode))
+	buf.WriteString(fmt.Sprintf("%v", iatBh.OriginatorStatusCode))
 	buf.WriteString(iatBh.ODFIIdentificationField())
 	buf.WriteString(iatBh.BatchNumberField())
 	return buf.String()

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -155,7 +155,7 @@ func (ed *IATEntryDetail) String() string {
 	var buf strings.Builder
 	buf.Grow(94)
 	buf.WriteString(ed.recordType)
-	buf.WriteString(string(ed.TransactionCode))
+	buf.WriteString(fmt.Sprintf("%v", ed.TransactionCode))
 	buf.WriteString(ed.RDFIIdentificationField())
 	buf.WriteString(ed.CheckDigit)
 	buf.WriteString(ed.AddendaRecordsField())
@@ -165,7 +165,7 @@ func (ed *IATEntryDetail) String() string {
 	buf.WriteString(ed.reservedTwoField())
 	buf.WriteString(ed.OFACSreeningIndicatorField())
 	buf.WriteString(ed.SecondaryOFACSreeningIndicatorField())
-	buf.WriteString(string(ed.AddendaRecordIndicator))
+	buf.WriteString(fmt.Sprintf("%v", ed.AddendaRecordIndicator))
 	buf.WriteString(ed.TraceNumberField())
 	return buf.String()
 }


### PR DESCRIPTION
string() in Go will print based on the integer as a character code
rather than printing the integer.