### PR TITLE
build: add go.mod, bump to Go 1.11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   GOARCH: amd64
   DEBUG: true
 
-stack: go 1.10
+stack: go 1.11
 
 before_test:
   - go vet ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 - linux
 - osx
 go:
-- 1.10.x
+- 1.11
 osx_image: xcode9.1
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Note: 32-bit platforms have known issues and is not supported.
 
 Yes please! Please review our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) to get started!
 
-Note: This project requires Go 1.10 or higher to compile.
+Note: This project requires Go 1.11 or higher to compile.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Note: 32-bit platforms have known issues and is not supported.
 
 Yes please! Please review our [Contributing guide](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) to get started!
 
-Note: This project requires Go 1.11 or higher to compile.
+Note: This project uses Go Modules, which requires Go 1.11 or higher, but we ship the vendor directory in our repository.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/moov-io/ach


### PR DESCRIPTION
See: https://ukiahsmith.com/blog/a-gentle-introduction-to-golang-modules/

I just ran `go mod init` -- There are no external deps right now. 

Issue: https://github.com/moov-io/ach/issues/253
Issue: https://github.com/moov-io/ach/issues/257