### PR TITLE
writer: return the underlying flush error

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -64,9 +64,8 @@ func (w *Writer) Write(file *File) error {
 }
 
 // Flush writes any buffered data to the underlying io.Writer.
-// To check if an error occurred during the Flush, call Error.
-func (w *Writer) Flush() {
-	w.w.Flush()
+func (w *Writer) Flush() error {
+	return w.w.Flush()
 }
 
 func (w *Writer) writeBatch(file *File) error {


### PR DESCRIPTION
This doesn't break compatibility because Go doesn't allow you to assign void returns to a value. People can still ignore the error, but at least it's returned now. 