### PR TITLE
WIP: build: add Dockerfile and makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang-alpine:1.11 as builder
+
+WORKDIR /go/src/github.com/moov-io/ach
+COPY . .
+RUN make build
+
+FROM scratch
+COPY --from=builder /go/src/github.com/moov-io/ach/bin/server /bin/server
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+EXPOSE 8080
+ENTRYPOINT ["/bin/server"]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/moov-io/ach"
 	"github.com/moov-io/ach/server"
 
 	"github.com/go-kit/kit/log"
@@ -56,6 +57,7 @@ func main() {
 	logger = log.NewLogfmtLogger(os.Stderr)
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 	logger = log.With(logger, "caller", log.DefaultCaller)
+	logger.Log("startup", fmt.Sprintf("Starting ach server version %s", ach.Version))
 
 	// Setup underlying ach service
 	r := server.NewRepositoryInMemory()

--- a/makefile
+++ b/makefile
@@ -1,0 +1,19 @@
+VERSION := $(shell grep -Eo '(\d\.\d\.\d)(-dev)?' version.go)
+
+.PHONY: build docker release
+
+build:
+	go fmt ./...
+	go build .
+	CGO_ENABLED=0 go build -o bin/server ./cmd/server
+	go vet ./...
+
+docker:
+	docker build -t moov.io/ach:$(VERSION) Dockerfile
+
+release: docker
+	$(shell go test ./...)
+	$(shell git tag $(VERSION))
+
+release-push:
+	git push origin $(VERSION)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,7 @@
+// Copyright 2018 The ACH Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package ach
+
+const Version = "v0.3.0-dev"


### PR DESCRIPTION
This sets up a basic docker image build inside the project. Also, we can easily start down a proper release path, which requires [semver tagging](https://github.com/moov-io/ach/issues/257) and [prebuild binaries and a docker image](https://github.com/moov-io/ach/issues/254). 
