### PR TITLE
Adds X-Total-Count headers for the GetFiles request

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -83,6 +83,8 @@ type getFilesResponse struct {
 	Err   error       `json:"error"`
 }
 
+func (r getFilesResponse) count() int { return len(r.Files) }
+
 func (r getFilesResponse) error() error { return r.Err }
 
 // MakeGetFileEndpoint returns an endpoint via the passed service.

--- a/server/routing.go
+++ b/server/routing.go
@@ -254,6 +254,12 @@ type errorer interface {
 	error() error
 }
 
+// counter is implemented by any concrete response types that may contain
+// some arbitrary count information.
+type counter interface {
+	count() int
+}
+
 // encodeResponse is the common method to encode all response types to the
 // client. I chose to do it this way because, since we're using JSON, there's no
 // reason to provide anything more specific. It's certainly possible to
@@ -264,6 +270,9 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 		// Provide those as HTTP errors.
 		encodeError(ctx, e.error(), w)
 		return nil
+	}
+	if e, ok := response.(counter); ok {
+		w.Header().Set("X-Total-Count", strconv.Itoa(e.count()))
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	return json.NewEncoder(w).Encode(response)

--- a/server/routing_test.go
+++ b/server/routing_test.go
@@ -1,8 +1,12 @@
 package server
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/moov-io/ach"
 )
 
 func TestAcceptableContentLength(t *testing.T) {
@@ -20,5 +24,23 @@ func TestAcceptableContentLength(t *testing.T) {
 	h.Set("Content-Length", "10000000000000")
 	if acceptableContentLength(h) {
 		t.Error("should have rejected")
+	}
+}
+
+func TestXTotalCountHeader(t *testing.T) {
+	counter := getFilesResponse{
+		Files: []*ach.File{ach.NewFile()},
+		Err:   nil,
+	}
+
+	w := httptest.NewRecorder()
+	encodeResponse(context.Background(), w, counter)
+
+	actual, ok := w.Result().Header["X-Total-Count"]
+	if !ok {
+		t.Fatal("should have count")
+	}
+	if actual[0] != "1" {
+		t.Errorf("should be 1, got %v", actual[0])
 	}
 }


### PR DESCRIPTION
This PR fixes the missing X-Total-Count header in the GET request for /files endpoint (#280).

Inside server/endpoints.go, the `getFilesResponse` struct defines a method `count()` that returns the length of its Files slice.

Inside server/routing.go, the encodeResponse func now looks to see if the response type implements the `counter` interface.  If it does, it sets the X-Total-Count header on the response with the value of counter.count().

@adamdecaf for comments.