### PR TITLE
 server: proxy back out any CORS headers we get

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+(-dev)?)' version.go)
+VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+([-a-zA-Z0-9]*)?)' version.go)
 
 .PHONY: build docker release
 

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@
 
 package ach
 
-const Version = "v0.4.0-dev"
+const Version = "v0.3.1-M2"


### PR DESCRIPTION
The request flow for `api.moov.io/v1/ach/files` goes like this:

```
Browser  -> Traefik  ->  (forward's request to auth service) -> Traefik copies those headers 
                           GET /users/login  (with cookie)      and makes request to ach service.
                           Response has Access-Control-Allow-* 

                                                             -> ACH service copies headers 
                                                                and responds to Browser.
```

There are some open issues on traefik such that it could copy these headers for us, but there's nothing merged/release yet. I'm tracking those issues. 

Issue: https://github.com/moov-io/moov-io/issues/4