### PR TITLE
server: don't trample content-type in encodeResponse

### DIFF
--- a/server/routing.go
+++ b/server/routing.go
@@ -271,13 +271,23 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 		encodeError(ctx, e.error(), w)
 		return nil
 	}
+
+	// Used for pagination
 	if e, ok := response.(counter); ok {
 		w.Header().Set("X-Total-Count", strconv.Itoa(e.count()))
 	}
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	// Don't overwrite a header (i.e. called from encodeTextResponse)
+	if v := w.Header().Get("Content-Type"); v == "" {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	}
+
 	return json.NewEncoder(w).Encode(response)
 }
 
+// encodeTextResponse will marshal response into the HTTP Response
+// This method is designed text/plain content-types and expects response
+// to be an io.Reader.
 func encodeTextResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
 	if r, ok := response.(io.Reader); ok {
 		w.Header().Set("Content-Type", "text/plain")

--- a/server/routing_test.go
+++ b/server/routing_test.go
@@ -2,12 +2,51 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/moov-io/ach"
 )
+
+func TestEncodeResponse(t *testing.T) {
+	ctx := context.TODO()
+	w := httptest.NewRecorder()
+	if err := encodeResponse(ctx, w, "hi mom"); err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+
+	var resp string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Error(err)
+	}
+	if resp != "hi mom" {
+		t.Errorf("got %q", resp)
+	}
+
+	v := w.Header().Get("content-type")
+	if v != "application/json; charset=utf-8" {
+		t.Errorf("got %q", v)
+	}
+}
+
+func TestEncodeTextResponse(t *testing.T) {
+	ctx := context.TODO()
+	w := httptest.NewRecorder()
+	if err := encodeTextResponse(ctx, w, strings.NewReader("hi mom")); err != nil {
+		t.Fatal(err)
+	}
+	if v := w.Body.String(); v != "hi mom" {
+		t.Errorf("got %q", v)
+	}
+
+	if v := w.Header().Get("content-type"); v != "text/plain" {
+		t.Errorf("got %q", v)
+	}
+}
 
 func TestAcceptableContentLength(t *testing.T) {
 	h := make(http.Header)


### PR DESCRIPTION
Found while working on #284. There's only one endpoint that uses `encodeTextResponse`. 