### PR TITLE
file: ensure we can't struct tag unmarshal File

### DIFF
--- a/file.go
+++ b/file.go
@@ -97,6 +97,10 @@ func FileFromJson(bs []byte) (*File, error) {
 	return &file, nil
 }
 
+func (f *File) UnmarshalJSON(p []byte) error {
+	return errors.New("json struct tag unmarshal is deprecated, use ach.FileFromJSON instead.")
+}
+
 type batchesJSON struct {
 	Batches []*batch `json:"batches"`
 }

--- a/file_test.go
+++ b/file_test.go
@@ -5,8 +5,10 @@
 package ach
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -380,5 +382,12 @@ func TestFile__readFromJson(t *testing.T) {
 
 	if len(file.Batches) != 1 {
 		t.Errorf("got %d batches: %v", len(file.Batches), file.Batches)
+	}
+
+	// ensure we error on struct tag unmarshal
+	var f File
+	err = json.Unmarshal(bs, &f)
+	if !strings.Contains(err.Error(), "use ach.FileFromJSON instead") {
+		t.Error("expected error, see FileFromJson definition")
 	}
 }


### PR DESCRIPTION
We've previously prevented this (by adding FileFromJson) and so
in order to prevent bugs associated to json.Unmarshal calls let's
tell the user how to fix.