### PR TITLE
file: validate Header and Control also

### DIFF
--- a/file.go
+++ b/file.go
@@ -224,6 +224,13 @@ func (f *File) Validate() error {
 		return &FileError{FieldName: "BatchCount", Value: strconv.Itoa(len(f.Batches)), Msg: msg}
 	}
 
+	if err := f.Header.Validate(); err != nil {
+		return err
+	}
+	if err := f.Control.Validate(); err != nil {
+		return err
+	}
+
 	if err := f.isEntryAddendaCount(); err != nil {
 		return err
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -7,6 +7,7 @@ package ach
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -40,6 +41,19 @@ func BenchmarkFileError(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		testFileError(b)
+	}
+}
+
+func TestFileEmptyError(t *testing.T) {
+	file := &File{}
+	if err := file.Create(); err == nil {
+		t.Error("expected error")
+	}
+
+	err := file.Validate()
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "recordType") || !strings.Contains(msg, "is a mandatory field") {
+		t.Errorf("got %q", err)
 	}
 }
 


### PR DESCRIPTION
An empty `File` object can't really build the underlying file and isn't valid, so we shouldn't ever validate it. 