### PR TITLE
IAT: add ISO 3166 validation 

### DIFF
--- a/iatBatchHeader.go
+++ b/iatBatchHeader.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/moov-io/ach/internal/iso3166"
 )
 
 // msgServiceClass
@@ -265,6 +267,10 @@ func (iatBh *IATBatchHeader) Validate() error {
 	if err := iatBh.isForeignExchangeReferenceIndicator(iatBh.ForeignExchangeReferenceIndicator); err != nil {
 		return &FieldError{FieldName: "ForeignExchangeReferenceIndicator",
 			Value: strconv.Itoa(iatBh.ForeignExchangeReferenceIndicator), Msg: err.Error()}
+	}
+	if !iso3166.Valid(iatBh.ISODestinationCountryCode) {
+		return &FieldError{FieldName: "ISODestinationCountryCode",
+			Value: iatBh.ISODestinationCountryCode, Msg: "invalid ISO 3166-1-alpha-2 code"}
 	}
 	if err := iatBh.isAlphanumeric(iatBh.ISODestinationCountryCode); err != nil {
 		return &FieldError{FieldName: "ISODestinationCountryCode",

--- a/internal/iso3166/iso3166.go
+++ b/internal/iso3166/iso3166.go
@@ -1,0 +1,258 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+// Generated on 2018-10-10T04:53:09Z by adam, any modifications will be overwritten
+package iso3166
+
+var countryCodes = map[string]bool{
+	"AF": true, // Afghanistan
+	"AX": true, // Åland Islands
+	"AL": true, // Albania
+	"DZ": true, // Algeria
+	"AS": true, // American Samoa
+	"AD": true, // Andorra
+	"AO": true, // Angola
+	"AI": true, // Anguilla
+	"AQ": true, // Antarctica
+	"AG": true, // Antigua and Barbuda
+	"AR": true, // Argentina
+	"AM": true, // Armenia
+	"AW": true, // Aruba
+	"AU": true, // Australia
+	"AT": true, // Austria
+	"AZ": true, // Azerbaijan
+	"BS": true, // Bahamas
+	"BH": true, // Bahrain
+	"BD": true, // Bangladesh
+	"BB": true, // Barbados
+	"BY": true, // Belarus
+	"BE": true, // Belgium
+	"BZ": true, // Belize
+	"BJ": true, // Benin
+	"BM": true, // Bermuda
+	"BT": true, // Bhutan
+	"BO": true, // Bolivia, Plurinational State of
+	"BQ": true, // Bonaire, Sint Eustatius and Saba
+	"BA": true, // Bosnia and Herzegovina
+	"BW": true, // Botswana
+	"BV": true, // Bouvet Island
+	"BR": true, // Brazil
+	"IO": true, // British Indian Ocean Territory
+	"BN": true, // Brunei Darussalam
+	"BG": true, // Bulgaria
+	"BF": true, // Burkina Faso
+	"BI": true, // Burundi
+	"KH": true, // Cambodia
+	"CM": true, // Cameroon
+	"CA": true, // Canada
+	"CV": true, // Cape Verde
+	"KY": true, // Cayman Islands
+	"CF": true, // Central African Republic
+	"TD": true, // Chad
+	"CL": true, // Chile
+	"CN": true, // China
+	"CX": true, // Christmas Island
+	"CC": true, // Cocos (Keeling) Islands
+	"CO": true, // Colombia
+	"KM": true, // Comoros
+	"CG": true, // Congo
+	"CD": true, // Congo, the Democratic Republic of the
+	"CK": true, // Cook Islands
+	"CR": true, // Costa Rica
+	"CI": true, // Côte d'Ivoire
+	"HR": true, // Croatia
+	"CU": true, // Cuba
+	"CW": true, // Curaçao
+	"CY": true, // Cyprus
+	"CZ": true, // Czech Republic
+	"DK": true, // Denmark
+	"DJ": true, // Djibouti
+	"DM": true, // Dominica
+	"DO": true, // Dominican Republic
+	"EC": true, // Ecuador
+	"EG": true, // Egypt
+	"SV": true, // El Salvador
+	"GQ": true, // Equatorial Guinea
+	"ER": true, // Eritrea
+	"EE": true, // Estonia
+	"ET": true, // Ethiopia
+	"FK": true, // Falkland Islands (Malvinas)
+	"FO": true, // Faroe Islands
+	"FJ": true, // Fiji
+	"FI": true, // Finland
+	"FR": true, // France
+	"GF": true, // French Guiana
+	"PF": true, // French Polynesia
+	"TF": true, // French Southern Territories
+	"GA": true, // Gabon
+	"GM": true, // Gambia
+	"GE": true, // Georgia
+	"DE": true, // Germany
+	"GH": true, // Ghana
+	"GI": true, // Gibraltar
+	"GR": true, // Greece
+	"GL": true, // Greenland
+	"GD": true, // Grenada
+	"GP": true, // Guadeloupe
+	"GU": true, // Guam
+	"GT": true, // Guatemala
+	"GG": true, // Guernsey
+	"GN": true, // Guinea
+	"GW": true, // Guinea-Bissau
+	"GY": true, // Guyana
+	"HT": true, // Haiti
+	"HM": true, // Heard Island and McDonald Islands
+	"VA": true, // Holy See (Vatican City State)
+	"HN": true, // Honduras
+	"HK": true, // Hong Kong
+	"HU": true, // Hungary
+	"IS": true, // Iceland
+	"IN": true, // India
+	"ID": true, // Indonesia
+	"IR": true, // Iran, Islamic Republic of
+	"IQ": true, // Iraq
+	"IE": true, // Ireland
+	"IM": true, // Isle of Man
+	"IL": true, // Israel
+	"IT": true, // Italy
+	"JM": true, // Jamaica
+	"JP": true, // Japan
+	"JE": true, // Jersey
+	"JO": true, // Jordan
+	"KZ": true, // Kazakhstan
+	"KE": true, // Kenya
+	"KI": true, // Kiribati
+	"KP": true, // Korea, Democratic People's Republic of
+	"KR": true, // Korea, Republic of
+	"KW": true, // Kuwait
+	"KG": true, // Kyrgyzstan
+	"LA": true, // Lao People's Democratic Republic
+	"LV": true, // Latvia
+	"LB": true, // Lebanon
+	"LS": true, // Lesotho
+	"LR": true, // Liberia
+	"LY": true, // Libya
+	"LI": true, // Liechtenstein
+	"LT": true, // Lithuania
+	"LU": true, // Luxembourg
+	"MO": true, // Macao
+	"MK": true, // Macedonia, the Former Yugoslav Republic of
+	"MG": true, // Madagascar
+	"MW": true, // Malawi
+	"MY": true, // Malaysia
+	"MV": true, // Maldives
+	"ML": true, // Mali
+	"MT": true, // Malta
+	"MH": true, // Marshall Islands
+	"MQ": true, // Martinique
+	"MR": true, // Mauritania
+	"MU": true, // Mauritius
+	"YT": true, // Mayotte
+	"MX": true, // Mexico
+	"FM": true, // Micronesia, Federated States of
+	"MD": true, // Moldova, Republic of
+	"MC": true, // Monaco
+	"MN": true, // Mongolia
+	"ME": true, // Montenegro
+	"MS": true, // Montserrat
+	"MA": true, // Morocco
+	"MZ": true, // Mozambique
+	"MM": true, // Myanmar
+	"NA": true, // Namibia
+	"NR": true, // Nauru
+	"NP": true, // Nepal
+	"NL": true, // Netherlands
+	"NC": true, // New Caledonia
+	"NZ": true, // New Zealand
+	"NI": true, // Nicaragua
+	"NE": true, // Niger
+	"NG": true, // Nigeria
+	"NU": true, // Niue
+	"NF": true, // Norfolk Island
+	"MP": true, // Northern Mariana Islands
+	"NO": true, // Norway
+	"OM": true, // Oman
+	"PK": true, // Pakistan
+	"PW": true, // Palau
+	"PS": true, // Palestine, State of
+	"PA": true, // Panama
+	"PG": true, // Papua New Guinea
+	"PY": true, // Paraguay
+	"PE": true, // Peru
+	"PH": true, // Philippines
+	"PN": true, // Pitcairn
+	"PL": true, // Poland
+	"PT": true, // Portugal
+	"PR": true, // Puerto Rico
+	"QA": true, // Qatar
+	"RE": true, // Réunion
+	"RO": true, // Romania
+	"RU": true, // Russian Federation
+	"RW": true, // Rwanda
+	"BL": true, // Saint Barthélemy
+	"SH": true, // Saint Helena, Ascension and Tristan da Cunha
+	"KN": true, // Saint Kitts and Nevis
+	"LC": true, // Saint Lucia
+	"MF": true, // Saint Martin (French part)
+	"PM": true, // Saint Pierre and Miquelon
+	"VC": true, // Saint Vincent and the Grenadines
+	"WS": true, // Samoa
+	"SM": true, // San Marino
+	"ST": true, // Sao Tome and Principe
+	"SA": true, // Saudi Arabia
+	"SN": true, // Senegal
+	"RS": true, // Serbia
+	"SC": true, // Seychelles
+	"SL": true, // Sierra Leone
+	"SG": true, // Singapore
+	"SX": true, // Sint Maarten (Dutch part)
+	"SK": true, // Slovakia
+	"SI": true, // Slovenia
+	"SB": true, // Solomon Islands
+	"SO": true, // Somalia
+	"ZA": true, // South Africa
+	"GS": true, // South Georgia and the South Sandwich Islands
+	"SS": true, // South Sudan
+	"ES": true, // Spain
+	"LK": true, // Sri Lanka
+	"SD": true, // Sudan
+	"SR": true, // Suriname
+	"SJ": true, // Svalbard and Jan Mayen
+	"SZ": true, // Swaziland
+	"SE": true, // Sweden
+	"CH": true, // Switzerland
+	"SY": true, // Syrian Arab Republic
+	"TW": true, // Taiwan, Province of China
+	"TJ": true, // Tajikistan
+	"TZ": true, // Tanzania, United Republic of
+	"TH": true, // Thailand
+	"TL": true, // Timor-Leste
+	"TG": true, // Togo
+	"TK": true, // Tokelau
+	"TO": true, // Tonga
+	"TT": true, // Trinidad and Tobago
+	"TN": true, // Tunisia
+	"TR": true, // Turkey
+	"TM": true, // Turkmenistan
+	"TC": true, // Turks and Caicos Islands
+	"TV": true, // Tuvalu
+	"UG": true, // Uganda
+	"UA": true, // Ukraine
+	"AE": true, // United Arab Emirates
+	"GB": true, // United Kingdom
+	"US": true, // United States
+	"UM": true, // United States Minor Outlying Islands
+	"UY": true, // Uruguay
+	"UZ": true, // Uzbekistan
+	"VU": true, // Vanuatu
+	"VE": true, // Venezuela, Bolivarian Republic of
+	"VN": true, // Viet Nam
+	"VG": true, // Virgin Islands, British
+	"VI": true, // Virgin Islands, U.S.
+	"WF": true, // Wallis and Futuna
+	"EH": true, // Western Sahara
+	"YE": true, // Yemen
+	"ZM": true, // Zambia
+	"ZW": true, // Zimbabwe
+}

--- a/internal/iso3166/iso3166_gen.go
+++ b/internal/iso3166/iso3166_gen.go
@@ -1,0 +1,92 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+// Generates iso3166.go.
+//
+// This file grabs the ISO 3166-1-alpha2 codes and writes them
+// into source code so we don't rely on any external files (zip,
+// json, etc).
+//
+// The data is pulled from datahub.io as the ISO.org site only offers
+// XML.
+//
+// https://datahub.io/core/country-list#data
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/format"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os/user"
+	"runtime"
+	"time"
+)
+
+const (
+	// From https://datahub.io/core/country-list#data
+	downloadUrl = "https://datahub.io/core/country-list/r/data.json"
+
+	outputFilename = "internal/iso3166/iso3166.go"
+)
+
+// [{"Code": "AF", "Name": "Afghanistan"}, ...]
+type country struct {
+	Code string `json:"Code"`
+	Name string `json:"Name"`
+}
+
+func main() {
+	when := time.Now().Format("2006-01-02T03:04:05Z")
+	who, err := user.Current()
+	if err != nil {
+		log.Fatalf("Unable to get user on %s", runtime.GOOS)
+	}
+
+	// Write copyright header
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, `// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+// Generated on %s by %s, any modifications will be overwritten
+package iso3166
+`, when, who.Username)
+
+	// Download certs
+	resp, err := http.Get(downloadUrl)
+	if err != nil {
+		log.Fatalf("error while downloading %s: %v", downloadUrl, err)
+	}
+	defer resp.Body.Close()
+
+	var countries []country
+	if err := json.NewDecoder(resp.Body).Decode(&countries); err != nil {
+		log.Fatalf("error while parsing country response: %v", err)
+	}
+
+	// Write countries to source code
+	fmt.Fprintln(&buf, "var countryCodes = map[string]bool{")
+	for i := range countries {
+		fmt.Fprintf(&buf, fmt.Sprintf(`"%s": true, // %s`+"\n", countries[i].Code, countries[i].Name))
+	}
+	fmt.Fprintln(&buf, "}")
+
+	// format source code and write file
+	out, err := format.Source(buf.Bytes())
+	if err != nil {
+		fmt.Println(buf.String())
+		log.Fatalf("error formatting output code, err=%v", err)
+	}
+
+	err = ioutil.WriteFile(outputFilename, out, 0644)
+	if err != nil {
+		log.Fatalf("error writing file, err=%v", err)
+	}
+}

--- a/internal/iso3166/validate.go
+++ b/internal/iso3166/validate.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package iso3166
+
+import (
+	"strings"
+)
+
+// Valid returns successful if code is a valid ISO 3166-1-alpha-2
+// country code. Example: US
+func Valid(code string) bool {
+	_, ok := countryCodes[strings.ToUpper(code)]
+	return ok
+}

--- a/internal/iso3166/validate_test.go
+++ b/internal/iso3166/validate_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package iso3166
+
+import (
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	if !Valid("US") {
+		t.Error("expected valid")
+	}
+
+	if !Valid("SS") {
+		t.Error("expected valid")
+	}
+
+	if Valid("") {
+		t.Errorf("invalid")
+	}
+
+	if Valid("QZ") {
+		t.Errorf("invalid")
+	}
+}

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ docker: clean
 	docker build -t moov/ach:$(VERSION) -f Dockerfile .
 	docker tag moov/ach:$(VERSION) moov/ach:latest
 
-release: docker AUTHORS
+release: docker generate AUTHORS
 	go test ./...
 	git tag -f $(VERSION)
 

--- a/makefile
+++ b/makefile
@@ -1,10 +1,13 @@
 VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+([-a-zA-Z0-9]*)?)' version.go)
 
-.PHONY: build docker release
+.PHONY: build generate docker release
 
 build:
 	go fmt ./...
 	CGO_ENABLED=0 go build -o bin/ach ./cmd/server
+
+generate: clean
+	go run internal/iso3166/iso3166_gen.go
 
 clean:
 	@rm -rf tmp/

--- a/validators.go
+++ b/validators.go
@@ -48,8 +48,6 @@ type FieldError struct {
 	Msg       string // context of the error.
 }
 
-// ToDo:  Add state and country look-up or use a 3rd party look up -verify with Wade
-
 // Error message is constructed
 // FieldName Msg Value
 // Example1: BatchCount $% has none alphanumeric characters


### PR DESCRIPTION
This adds a quick, dependency free ISO 3166 validator. I put it in `internal/` so external projects don't import this. We can expose it if wanted.

The [iso.org website](https://www.iso.org/iso-3166-country-codes.html) makes finding this information really difficult. We'll re-generate this file on each release.

Source: https://datahub.io/core/country-list

FYI: We can do this for [ISO 4217 codes](https://datahub.io/core/currency-codes) from the same datahub.io.