### PR TITLE
verify ABA routing number length in CalculateCheckDigit

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -429,6 +429,9 @@ func (v *validator) CalculateCheckDigit(routingNumber string) int {
 
 	var routeIndex [8]string
 	for i := 0; i < 8; i++ {
+		if routingNumber[i] < '0' || routingNumber[i] > '9' {
+			return -1 // only digits are allowed
+		}
 		routeIndex[i] = string(routingNumber[i])
 	}
 	n, _ := strconv.Atoi(routeIndex[0])

--- a/validators.go
+++ b/validators.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+	"unicode/utf8"
 )
 
 var (
@@ -422,6 +423,10 @@ func (v *validator) isAlphanumeric(s string) error {
 // Subtract the sum from the next highest multiple of 10.
 // The result is the Check Digit
 func (v *validator) CalculateCheckDigit(routingNumber string) int {
+	if n := utf8.RuneCountInString(routingNumber); n != 8 && n != 9 {
+		return -1
+	}
+
 	var routeIndex [8]string
 	for i := 0; i < 8; i++ {
 		routeIndex[i] = string(routingNumber[i])

--- a/validators_test.go
+++ b/validators_test.go
@@ -1,0 +1,28 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package ach
+
+import (
+	"testing"
+)
+
+func TestValidators__checkDigit(t *testing.T) {
+	cases := map[string]int{
+		// invalid
+		"":       -1,
+		"123456": -1,
+		// valid
+		"07300022": 8, // Wells Fargo - Iowa
+		"10200007": 6, // Wells Fargo - Colorado
+	}
+
+	v := validator{}
+	for rtn, check := range cases {
+		answer := v.CalculateCheckDigit(rtn)
+		if check != answer {
+			t.Errorf("input=%s answer=%d expected=%d", rtn, answer, check)
+		}
+	}
+}

--- a/validators_test.go
+++ b/validators_test.go
@@ -11,8 +11,11 @@ import (
 func TestValidators__checkDigit(t *testing.T) {
 	cases := map[string]int{
 		// invalid
-		"":       -1,
-		"123456": -1,
+		"":         -1,
+		"123456":   -1,
+		"1a8ab":    -1,
+		"0730002a": -1,
+		"0730A002": -1,
 		// valid
 		"07300022": 8, // Wells Fargo - Iowa
 		"10200007": 6, // Wells Fargo - Colorado


### PR DESCRIPTION
Previously there was a panic:

```
$ go test github.com/moov-io/ach -count 1 -run TestValidators
--- FAIL: TestValidators__checkDigit (0.00s)
panic: runtime error: index out of range [recovered]
	panic: runtime error: index out of range

goroutine 5 [running]:
testing.tRunner.func1(0xc0000a4300)
	/usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:792 +0x387
panic(0x125e400, 0x14936d0)
	/usr/local/Cellar/go/1.11.1/libexec/src/runtime/panic.go:513 +0x1b9
github.com/moov-io/ach.(*validator).CalculateCheckDigit(0xc00002fdd8, 0x0, 0x0, 0x8)
	/Users/adam/code/src/github.com/moov-io/ach/validators.go:427 +0x2aa
github.com/moov-io/ach.TestValidators__checkDigit(0xc0000a4300)
	/Users/adam/code/src/github.com/moov-io/ach/validators_test.go:22 +0x1e1
testing.tRunner(0xc0000a4300, 0x12ab828)
	/usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/usr/local/Cellar/go/1.11.1/libexec/src/testing/testing.go:878 +0x353
FAIL	github.com/moov-io/ach	0.007s

```