### PR TITLE
323 proposal reduce ranging through batch entries

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -406,3 +406,35 @@ func (batch *batch) isCategory() error {
 	}
 	return nil
 }
+
+/*// categoryForwardAddenda02 verifies CategoryForward Addenda02 TypeCode is 02
+func (batch *batch) categoryForwardAddenda02(entry *EntryDetail, addenda Addendumer) error {
+	return nil
+}*/
+
+// categoryForwardAddenda05 verifies CategoryForward Addenda05 TypeCode is 05
+func (batch *batch) categoryForwardAddenda05(entry *EntryDetail, addenda Addendumer) error {
+	if addenda.typeCode() != "05" {
+		msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", entry.Category, batch.Header.StandardEntryClassCode)
+		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+	}
+	return nil
+}
+
+// categoryNOCAddenda98 verifies CategoryNOC Addenda98 TypeCode is 98
+func (batch *batch) categoryNOCAddenda98(entry *EntryDetail, addenda Addendumer) error {
+	if addenda.typeCode() != "98" {
+		msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
+		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+	}
+	return nil
+}
+
+// categoryReturnAddenda99 verifies CategoryReturn Addenda99 TypeCode is 99
+func (batch *batch) categoryReturnAddenda99(entry *EntryDetail, addenda Addendumer) error {
+	if addenda.typeCode() != "99" {
+		msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
+		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+	}
+	return nil
+}

--- a/batch.go
+++ b/batch.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 // Batch holds the Batch Header and Batch Control and all Entry Records
@@ -417,20 +416,6 @@ func (batch *batch) isCategory() error {
 			if batch.Entries[i].Category != category {
 				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "Category", Msg: msgBatchForwardReturn}
 			}
-		}
-	}
-	return nil
-}
-
-// isPaymentTypeCode checks that the Entry detail records have either:
-// "R" For a recurring WEB Entry
-// "S" For a Single-Entry WEB Entry
-func (batch *batch) isPaymentTypeCode() error {
-	for _, entry := range batch.Entries {
-		if !strings.Contains(strings.ToUpper(entry.PaymentTypeField()), "S") && !strings.Contains(strings.ToUpper(entry.PaymentTypeField()), "R") {
-			// TODO dead code because PaymentTypeField always returns S regardless of Discretionary Data value
-			msg := fmt.Sprintf(msgBatchWebPaymentType, entry.PaymentTypeField())
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "PaymentType", Msg: msg}
 		}
 	}
 	return nil

--- a/batch.go
+++ b/batch.go
@@ -409,6 +409,10 @@ func (batch *batch) isCategory() error {
 
 // categoryForwardAddenda02 verifies CategoryForward Addenda02 TypeCode is 02
 func (batch *batch) categoryForwardAddenda02(entry *EntryDetail, addenda Addendumer) error {
+	if addenda.typeCode() != "02" {
+		msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "02", entry.Category, batch.Header.StandardEntryClassCode)
+		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+	}
 	return nil
 }
 

--- a/batch.go
+++ b/batch.go
@@ -391,20 +391,6 @@ func (batch *batch) isAddendaSequence() error {
 	return nil
 }
 
-// isAddendaCount iterates through each entry detail and checks the number of addendum is greater than the count parameter otherwise it returns an error.
-// Following SEC codes allow for none or one Addendum
-// "PPD", "WEB", "CCD", "CIE", "DNE", "MTE", "POS", "SHR"
-func (batch *batch) isAddendaCount(count int) error {
-	for _, entry := range batch.Entries {
-		if len(entry.Addendum) > count {
-			msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), count, batch.Header.StandardEntryClassCode)
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
-		}
-
-	}
-	return nil
-}
-
 // isCategory verifies that a Forward and Return Category are not in the same batch
 func (batch *batch) isCategory() error {
 	category := batch.GetEntries()[0].Category

--- a/batch.go
+++ b/batch.go
@@ -407,10 +407,10 @@ func (batch *batch) isCategory() error {
 	return nil
 }
 
-/*// categoryForwardAddenda02 verifies CategoryForward Addenda02 TypeCode is 02
+// categoryForwardAddenda02 verifies CategoryForward Addenda02 TypeCode is 02
 func (batch *batch) categoryForwardAddenda02(entry *EntryDetail, addenda Addendumer) error {
 	return nil
-}*/
+}
 
 // categoryForwardAddenda05 verifies CategoryForward Addenda05 TypeCode is 05
 func (batch *batch) categoryForwardAddenda05(entry *EntryDetail, addenda Addendumer) error {

--- a/batchARC.go
+++ b/batchARC.go
@@ -78,17 +78,13 @@ func (batch *BatchARC) Validate() error {
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchARC.go
+++ b/batchARC.go
@@ -74,7 +74,7 @@ func (batch *BatchARC) Validate() error {
 			switch entry.Category {
 			case CategoryForward:
 				if len(entry.Addendum) > 0 {
-					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:

--- a/batchARC.go
+++ b/batchARC.go
@@ -37,14 +37,8 @@ func (batch *BatchARC) Validate() error {
 	if err := batch.verify(); err != nil {
 		return err
 	}
-	// Add configuration based validation for this type.
+	// Add configuration and type specific validation for this type.
 
-	// Batch ARC cannot have an addenda record
-	if err := batch.isAddendaCount(0); err != nil {
-		return err
-	}
-
-	// Add type specific validation.
 	if batch.Header.StandardEntryClassCode != "ARC" {
 		msg := fmt.Sprintf(msgBatchSECType, batch.Header.StandardEntryClassCode, "ARC")
 		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "StandardEntryClassCode", Msg: msg}
@@ -74,6 +68,28 @@ func (batch *BatchARC) Validate() error {
 		if entry.IdentificationNumber == "" {
 			msg := fmt.Sprintf(msgBatchCheckSerialNumber, "ARC")
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "CheckSerialNumber", Msg: msg}
+		}
+		// ARC cannot have Addenda02 or Addenda05.  There can be a NOC (98) or Return (99)
+		for _, addenda := range entry.Addendum {
+			switch entry.Category {
+			case CategoryForward:
+				if len(entry.Addendum) > 0 {
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+				}
+			case CategoryNOC:
+				if addenda.typeCode() != "98" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
+			case CategoryReturn:
+				if addenda.typeCode() != "99" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
+			}
 		}
 	}
 	return nil

--- a/batchARC_test.go
+++ b/batchARC_test.go
@@ -406,3 +406,39 @@ func BenchmarkBatchARCInvalidBuild(b *testing.B) {
 		testBatchARCInvalidBuild(b)
 	}
 }
+
+// TestBatchARCAddendum98 validates Addenda98 returns an error
+func TestBatchARCAddendum98(t *testing.T) {
+	mockBatch := NewBatchARC(mockBatchARCHeader())
+	mockBatch.AddEntry(mockARCEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchARCAddendum99 validates Addenda99 returns an error
+func TestBatchARCAddendum99(t *testing.T) {
+	mockBatch := NewBatchARC(mockBatchARCHeader())
+	mockBatch.AddEntry(mockARCEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -42,14 +42,8 @@ func (batch *BatchBOC) Validate() error {
 	if err := batch.verify(); err != nil {
 		return err
 	}
-	// Add configuration based validation for this type.
+	// Add configuration and type specific validation for this type.
 
-	// Batch BOC cannot have an addenda record
-	if err := batch.isAddendaCount(0); err != nil {
-		return err
-	}
-
-	// Add type specific validation.
 	if batch.Header.StandardEntryClassCode != "BOC" {
 		msg := fmt.Sprintf(msgBatchSECType, batch.Header.StandardEntryClassCode, "BOC")
 		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "StandardEntryClassCode", Msg: msg}
@@ -79,6 +73,28 @@ func (batch *BatchBOC) Validate() error {
 		if entry.IdentificationNumber == "" {
 			msg := fmt.Sprintf(msgBatchCheckSerialNumber, "BOC")
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "CheckSerialNumber", Msg: msg}
+		}
+		// BOC cannot have Addenda02 or Addenda05.  There can be a NOC (98) or Return (99)
+		for _, addenda := range entry.Addendum {
+			switch entry.Category {
+			case CategoryForward:
+				if len(entry.Addendum) > 0 {
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+				}
+			case CategoryNOC:
+				if addenda.typeCode() != "98" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
+			case CategoryReturn:
+				if addenda.typeCode() != "99" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
+			}
 		}
 	}
 	return nil

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -79,7 +79,7 @@ func (batch *BatchBOC) Validate() error {
 			switch entry.Category {
 			case CategoryForward:
 				if len(entry.Addendum) > 0 {
-					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -83,17 +83,13 @@ func (batch *BatchBOC) Validate() error {
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchBOC_test.go
+++ b/batchBOC_test.go
@@ -405,3 +405,39 @@ func BenchmarkBatchBOCInvalidBuild(b *testing.B) {
 		testBatchBOCInvalidBuild(b)
 	}
 }
+
+// TestBatchBOCAddendum98 validates Addenda98 returns an error
+func TestBatchBOCAddendum98(t *testing.T) {
+	mockBatch := NewBatchBOC(mockBatchBOCHeader())
+	mockBatch.AddEntry(mockBOCEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchBOCAddendum99 validates Addenda99 returns an error
+func TestBatchBOCAddendum99(t *testing.T) {
+	mockBatch := NewBatchBOC(mockBatchBOCHeader())
+	mockBatch.AddEntry(mockBOCEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}

--- a/batchCCD.go
+++ b/batchCCD.go
@@ -38,22 +38,32 @@ func (batch *BatchCCD) Validate() error {
 
 	for _, entry := range batch.Entries {
 		// CCD can have up to one Record TypeCode = 05, or there can be a NOC (98) or Return (99)
-		if len(entry.Addendum) > 1 {
-			msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
-		}
 		for _, addenda := range entry.Addendum {
-			switch addenda.typeCode() {
-			// Addenda TypeCode valid
-			case "05", "98", "99":
-				//Return error
-			default:
-				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", batch.Header.StandardEntryClassCode)
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+			switch entry.Category {
+			case CategoryForward:
+				if addenda.typeCode() != "05" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				if len(entry.Addendum) > 1 {
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+				}
+			case CategoryNOC:
+				if addenda.typeCode() != "98" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
+			case CategoryReturn:
+				if addenda.typeCode() != "99" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/batchCCD.go
+++ b/batchCCD.go
@@ -41,26 +41,21 @@ func (batch *BatchCCD) Validate() error {
 		for _, addenda := range entry.Addendum {
 			switch entry.Category {
 			case CategoryForward:
-				if addenda.typeCode() != "05" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryForwardAddenda05(entry, addenda); err != nil {
+					return err
 				}
 				if len(entry.Addendum) > 1 {
 					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchCCD.go
+++ b/batchCCD.go
@@ -45,7 +45,7 @@ func (batch *BatchCCD) Validate() error {
 					return err
 				}
 				if len(entry.Addendum) > 1 {
-					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:

--- a/batchCCD_test.go
+++ b/batchCCD_test.go
@@ -96,6 +96,42 @@ func BenchmarkBatchCCDAddendumCount(b *testing.B) {
 	}
 }
 
+// TestBatchCCDAddendum98 validates Addenda98 returns an error
+func TestBatchCCDAddendum98(t *testing.T) {
+	mockBatch := NewBatchCCD(mockBatchCCDHeader())
+	mockBatch.AddEntry(mockCCDEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchCCDAddendum99 validates Addenda99 returns an error
+func TestBatchCCDAddendum99(t *testing.T) {
+	mockBatch := NewBatchCCD(mockBatchCCDHeader())
+	mockBatch.AddEntry(mockCCDEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
 // testBatchCCDReceivingCompanyName validates Receiving company / Individual name is a mandatory field
 func testBatchCCDReceivingCompanyName(t testing.TB) {
 	mockBatch := mockBatchCCD()

--- a/batchCIE.go
+++ b/batchCIE.go
@@ -21,9 +21,6 @@ type BatchCIE struct {
 	batch
 }
 
-var msgBatchCIEAddenda = "found and 1 Addenda05 is the maximum for SEC code CIE"
-var msgBatchCIEAddendaType = "%T found where Addenda05 is required for SEC code CIE"
-
 // NewBatchCIE returns a *BatchCIE
 func NewBatchCIE(bh *BatchHeader) *BatchCIE {
 	batch := new(BatchCIE)
@@ -59,6 +56,12 @@ func (batch *BatchCIE) Validate() error {
 		if entry.CreditOrDebit() != "C" {
 			msg := fmt.Sprintf(msgBatchTransactionCodeCredit, entry.TransactionCode)
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TransactionCode", Msg: msg}
+		}
+
+		// CIE must have one Addenda05 record
+		if len(entry.Addendum) != 1 {
+			msg := fmt.Sprintf(msgBatchRequiredAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 		}
 
 		// CIE can have up to one Record TypeCode = 05, or there can be a NOC (98) or Return (99)

--- a/batchCIE.go
+++ b/batchCIE.go
@@ -68,26 +68,21 @@ func (batch *BatchCIE) Validate() error {
 		for _, addenda := range entry.Addendum {
 			switch entry.Category {
 			case CategoryForward:
-				if addenda.typeCode() != "05" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryForwardAddenda05(entry, addenda); err != nil {
+					return err
 				}
 				if len(entry.Addendum) > 1 {
 					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchCIE.go
+++ b/batchCIE.go
@@ -71,10 +71,6 @@ func (batch *BatchCIE) Validate() error {
 				if err := batch.categoryForwardAddenda05(entry, addenda); err != nil {
 					return err
 				}
-				if len(entry.Addendum) > 1 {
-					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
-				}
 			case CategoryNOC:
 				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
 					return err

--- a/batchCIE_test.go
+++ b/batchCIE_test.go
@@ -468,3 +468,19 @@ func TestBatchCIEAddendum99(t *testing.T) {
 		}
 	}
 }
+
+// TestBatchCIEAddenda validates no more than 1 addenda record per entry detail record can exist
+func TestBatchCIEAddenda(t *testing.T) {
+	mockBatch := mockBatchCIE()
+	// mock batch already has one addenda. Creating two addenda should error
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda05())
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "AddendaCount" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}

--- a/batchCIE_test.go
+++ b/batchCIE_test.go
@@ -267,7 +267,7 @@ func testBatchCIEAddendaCount(t testing.TB) {
 	mockBatch.Create()
 	if err := mockBatch.Validate(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "AddendaCount" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {
@@ -324,7 +324,7 @@ func testBatchCIEInvalidAddendum(t testing.TB) {
 	mockBatch.GetEntries()[0].AddAddenda(mockAddenda02())
 	if err := mockBatch.Create(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "TypeCode" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {
@@ -430,5 +430,41 @@ func BenchmarkBatchCIECardTransactionType(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		testBatchCIECardTransactionType(b)
+	}
+}
+
+// TestBatchCIEAddendum98 validates Addenda98 returns an error
+func TestBatchCIEAddendum98(t *testing.T) {
+	mockBatch := NewBatchCIE(mockBatchCIEHeader())
+	mockBatch.AddEntry(mockCIEEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchCIEAddendum99 validates Addenda99 returns an error
+func TestBatchCIEAddendum99(t *testing.T) {
+	mockBatch := NewBatchCIE(mockBatchCIEHeader())
+	mockBatch.AddEntry(mockCIEEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
 	}
 }

--- a/batchCIE_test.go
+++ b/batchCIE_test.go
@@ -295,7 +295,7 @@ func testBatchCIEAddendaCountZero(t testing.TB) {
 	mockBatch.AddEntry(mockCIEEntryDetail())
 	if err := mockBatch.Create(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "AddendaCount" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {

--- a/batchCTX.go
+++ b/batchCTX.go
@@ -73,7 +73,7 @@ func (batch *BatchCTX) Validate() error {
 						return err
 					}
 					if len(entry.Addendum) > 9999 {
-						msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+						msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 9999, batch.Header.StandardEntryClassCode)
 						return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 					}
 				case CategoryNOC:

--- a/batchCTX.go
+++ b/batchCTX.go
@@ -46,6 +46,12 @@ func (batch *BatchCTX) Validate() error {
 
 	for _, entry := range batch.Entries {
 
+		// Trapping this error, as entry.CTXAddendaRecordsField() can not be greater than 9999
+		if len(entry.Addendum) > 9999 {
+			msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 9999, batch.Header.StandardEntryClassCode)
+			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+		}
+
 		// validate CTXAddendaRecord Field is equal to the actual number of Addenda records
 		// use 0 value if there is no Addenda records
 		addendaRecords, _ := strconv.Atoi(entry.CTXAddendaRecordsField())
@@ -71,10 +77,6 @@ func (batch *BatchCTX) Validate() error {
 				case CategoryForward:
 					if err := batch.categoryForwardAddenda05(entry, addenda); err != nil {
 						return err
-					}
-					if len(entry.Addendum) > 9999 {
-						msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 9999, batch.Header.StandardEntryClassCode)
-						return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 					}
 				case CategoryNOC:
 					if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {

--- a/batchCTX_test.go
+++ b/batchCTX_test.go
@@ -212,7 +212,7 @@ func testBatchCTXInvalidAddendum(t testing.TB) {
 	mockBatch.GetEntries()[0].AddAddenda(mockAddenda02())
 	if err := mockBatch.Create(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "TypeCode" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {
@@ -542,5 +542,41 @@ func BenchmarkBatchCTXPrenoteAddendaRecords(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		testBatchCTXPrenoteAddendaRecords(b)
+	}
+}
+
+// TestBatchCTXAddendum98 validates Addenda98 returns an error
+func TestBatchCTXAddendum98(t *testing.T) {
+	mockBatch := NewBatchCTX(mockBatchCTXHeader())
+	mockBatch.AddEntry(mockCTXEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchCTXAddendum99 validates Addenda99 returns an error
+func TestBatchCTXAddendum99(t *testing.T) {
+	mockBatch := NewBatchCTX(mockBatchCTXHeader())
+	mockBatch.AddEntry(mockCTXEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
 	}
 }

--- a/batchCTX_test.go
+++ b/batchCTX_test.go
@@ -325,7 +325,7 @@ func testBatchCTXAddenda10000(t testing.TB) {
 
 	if err := mockBatch.Create(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "AddendaCount" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {

--- a/batchPOP.go
+++ b/batchPOP.go
@@ -77,7 +77,7 @@ func (batch *BatchPOP) Validate() error {
 			switch entry.Category {
 			case CategoryForward:
 				if len(entry.Addendum) > 0 {
-					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:

--- a/batchPOP.go
+++ b/batchPOP.go
@@ -81,17 +81,13 @@ func (batch *BatchPOP) Validate() error {
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchPOP_test.go
+++ b/batchPOP_test.go
@@ -485,3 +485,39 @@ func BenchmarkBatchPOPInvalidBuild(b *testing.B) {
 		testBatchPOPInvalidBuild(b)
 	}
 }
+
+// TestBatchPOPAddendum98 validates Addenda98 returns an error
+func TestBatchPOPAddendum98(t *testing.T) {
+	mockBatch := NewBatchPOP(mockBatchPOPHeader())
+	mockBatch.AddEntry(mockPOPEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchPOPAddendum99 validates Addenda99 returns an error
+func TestBatchPOPAddendum99(t *testing.T) {
+	mockBatch := NewBatchPOP(mockBatchPOPHeader())
+	mockBatch.AddEntry(mockPOPEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -66,7 +66,12 @@ func (batch *BatchPOS) Validate() error {
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "CardTransactionType", Msg: msg}
 		}
 
-		// POS must have one Addenda Record TypeCode = 02, or there can be a NOC (98) or Return (99)
+		// POS must have one Addenda02 record
+		if len(entry.Addendum) != 1 {
+			msg := fmt.Sprintf(msgBatchRequiredAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+		}
+		// POS must have one Addenda02 but cannot have Addenda05, or there can be a NOC (98) or Return (99)
 		for _, addenda := range entry.Addendum {
 			switch entry.Category {
 			case CategoryForward:

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -66,7 +66,7 @@ func (batch *BatchPOS) Validate() error {
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "CardTransactionType", Msg: msg}
 		}
 
-		// Addendum must be equal to 1
+		// POS must have one Addenda Record TypeCode = 02, or there can be a NOC (98) or Return (99)
 		if len(entry.Addendum) != 1 {
 			msg := fmt.Sprintf(msgBatchRequiredAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -26,9 +26,6 @@ type BatchPOS struct {
 	batch
 }
 
-var msgBatchPOSAddenda = "found and 1 Addenda02 is required for SEC code POS"
-var msgBatchPOSAddendaType = "%T found where Addenda02 is required for SEC code POS"
-
 // NewBatchPOS returns a *BatchPOS
 func NewBatchPOS(bh *BatchHeader) *BatchPOS {
 	batch := new(BatchPOS)
@@ -43,9 +40,8 @@ func (batch *BatchPOS) Validate() error {
 	if err := batch.verify(); err != nil {
 		return err
 	}
-	// Add configuration based validation for this type.
 
-	// Add type specific validation.
+	// Add configuration and type specific validation for this type.
 
 	if batch.Header.StandardEntryClassCode != "POS" {
 		msg := fmt.Sprintf(msgBatchSECType, batch.Header.StandardEntryClassCode, "POS")
@@ -70,25 +66,18 @@ func (batch *BatchPOS) Validate() error {
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "CardTransactionType", Msg: msg}
 		}
 
-		// Addenda validations - POS Addenda must be Addenda02
-
 		// Addendum must be equal to 1
 		if len(entry.Addendum) != 1 {
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "Addendum", Msg: msgBatchPOSAddenda}
+			msg := fmt.Sprintf(msgBatchRequiredAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 		}
-
-		// Addenda type assertion must be Addenda02
-		addenda02, ok := entry.Addendum[0].(*Addenda02)
-		if !ok {
-			msg := fmt.Sprintf(msgBatchPOSAddendaType, entry.Addendum[0])
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "Addendum", Msg: msg}
-		}
-
-		// Addenda02 must be Validated
-		if err := addenda02.Validate(); err != nil {
-			// convert the field error in to a batch error for a consistent api
-			if e, ok := err.(*FieldError); ok {
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: e.FieldName, Msg: e.Msg}
+		for _, addenda := range entry.Addendum {
+			switch addenda.typeCode() {
+			// Addenda TypeCode valid
+			case "02", "98", "99":
+			default:
+				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "02", batch.Header.StandardEntryClassCode)
+				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
 			}
 		}
 	}

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -75,23 +75,17 @@ func (batch *BatchPOS) Validate() error {
 		for _, addenda := range entry.Addendum {
 			switch entry.Category {
 			case CategoryForward:
-				if addenda.typeCode() != "02" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "02", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryForwardAddenda02(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda02
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -67,17 +67,26 @@ func (batch *BatchPOS) Validate() error {
 		}
 
 		// POS must have one Addenda Record TypeCode = 02, or there can be a NOC (98) or Return (99)
-		if len(entry.Addendum) != 1 {
-			msg := fmt.Sprintf(msgBatchRequiredAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
-		}
 		for _, addenda := range entry.Addendum {
-			switch addenda.typeCode() {
-			// Addenda TypeCode valid
-			case "02", "98", "99":
-			default:
-				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "02", batch.Header.StandardEntryClassCode)
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+			switch entry.Category {
+			case CategoryForward:
+				if addenda.typeCode() != "02" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "02", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda02
+			case CategoryNOC:
+				if addenda.typeCode() != "98" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
+			case CategoryReturn:
+				if addenda.typeCode() != "99" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchPOS_test.go
+++ b/batchPOS_test.go
@@ -54,6 +54,16 @@ func testBatchPOSHeader(t testing.TB) {
 	}
 }
 
+// TestBatchPOSAddendum98 validates Addenda98 returns an error
+func TestBatchPOSAddendum98(t *testing.T) {
+	mockBatch := NewBatchPOS(mockBatchPOSHeader())
+	mockBatch.AddEntry(mockPOSEntryDetail())
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99())
+	if err := mockBatch.Create(); err != nil {
+		t.Errorf("%T: %s", err, err)
+	}
+}
+
 // TestBatchPOSHeader tests validating BatchPOS BatchHeader
 func TestBatchPOSHeader(t *testing.T) {
 	testBatchPOSHeader(t)
@@ -296,7 +306,7 @@ func testBatchPOSAddendaCountZero(t testing.TB) {
 	mockBatch.AddEntry(mockPOSEntryDetail())
 	if err := mockBatch.Create(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "AddendaCount" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {
@@ -325,7 +335,7 @@ func testBatchPOSInvalidAddendum(t testing.TB) {
 	mockBatch.GetEntries()[0].AddAddenda(mockAddenda05())
 	if err := mockBatch.Create(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "TypeCode" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {

--- a/batchPOS_test.go
+++ b/batchPOS_test.go
@@ -54,16 +54,6 @@ func testBatchPOSHeader(t testing.TB) {
 	}
 }
 
-// TestBatchPOSAddendum98 validates Addenda98 returns an error
-func TestBatchPOSAddendum98(t *testing.T) {
-	mockBatch := NewBatchPOS(mockBatchPOSHeader())
-	mockBatch.AddEntry(mockPOSEntryDetail())
-	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99())
-	if err := mockBatch.Create(); err != nil {
-		t.Errorf("%T: %s", err, err)
-	}
-}
-
 // TestBatchPOSHeader tests validating BatchPOS BatchHeader
 func TestBatchPOSHeader(t *testing.T) {
 	testBatchPOSHeader(t)
@@ -354,6 +344,42 @@ func BenchmarkBatchPOSInvalidAddendum(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		testBatchPOSInvalidAddendum(b)
+	}
+}
+
+// TestBatchPOSAddendum98 validates Addenda98 returns an error
+func TestBatchPOSAddendum98(t *testing.T) {
+	mockBatch := NewBatchPOS(mockBatchPOSHeader())
+	mockBatch.AddEntry(mockPOSEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchPOSAddendum99 validates Addenda99 returns an error
+func TestBatchPOSAddendum99(t *testing.T) {
+	mockBatch := NewBatchPOS(mockBatchPOSHeader())
+	mockBatch.AddEntry(mockPOSEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
 	}
 }
 

--- a/batchPPD.go
+++ b/batchPPD.go
@@ -37,26 +37,21 @@ func (batch *BatchPPD) Validate() error {
 		for _, addenda := range entry.Addendum {
 			switch entry.Category {
 			case CategoryForward:
-				if addenda.typeCode() != "05" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryForwardAddenda05(entry, addenda); err != nil {
+					return err
 				}
 				if len(entry.Addendum) > 1 {
 					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchPPD.go
+++ b/batchPPD.go
@@ -34,19 +34,29 @@ func (batch *BatchPPD) Validate() error {
 
 	for _, entry := range batch.Entries {
 		// PPD can have up to one Record TypeCode = 05, or there can be a NOC (98) or Return (99)
-		if len(entry.Addendum) > 1 {
-			msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
-		}
-
 		for _, addenda := range entry.Addendum {
-			switch addenda.typeCode() {
-			// Addenda TypeCode valid
-			case "05", "98", "99":
-				//Return error
-			default:
-				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", batch.Header.StandardEntryClassCode)
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+			switch entry.Category {
+			case CategoryForward:
+				if addenda.typeCode() != "05" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				if len(entry.Addendum) > 1 {
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+				}
+			case CategoryNOC:
+				if addenda.typeCode() != "98" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
+			case CategoryReturn:
+				if addenda.typeCode() != "99" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchPPD.go
+++ b/batchPPD.go
@@ -41,7 +41,7 @@ func (batch *BatchPPD) Validate() error {
 					return err
 				}
 				if len(entry.Addendum) > 1 {
-					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:

--- a/batchPPD.go
+++ b/batchPPD.go
@@ -25,17 +25,27 @@ func (batch *BatchPPD) Validate() error {
 	if err := batch.verify(); err != nil {
 		return err
 	}
-	// Add configuration based validation for this type.
+	// Add configuration and type specific validation for this type.
 
-	// Batch can have one addenda per entry record
-	if err := batch.isAddendaCount(1); err != nil {
-		return err
+	if batch.Header.StandardEntryClassCode != "PPD" {
+		msg := fmt.Sprintf(msgBatchSECType, batch.Header.StandardEntryClassCode, "PPD")
+		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "StandardEntryClassCode", Msg: msg}
 	}
 
 	for _, entry := range batch.Entries {
+		// PPD can have up to one Record TypeCode = 05, or there can be a NOC (98) or Return (99)
+		if len(entry.Addendum) > 1 {
+			msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+		}
+
 		for _, addenda := range entry.Addendum {
-			if (addenda.typeCode() != "05") && (addenda.typeCode() != "99") {
-				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), addenda.typeCode(), batch.Header.StandardEntryClassCode)
+			switch addenda.typeCode() {
+			// Addenda TypeCode valid
+			case "05", "98", "99":
+				//Return error
+			default:
+				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", batch.Header.StandardEntryClassCode)
 				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
 			}
 		}

--- a/batchPPD_test.go
+++ b/batchPPD_test.go
@@ -294,3 +294,54 @@ func BenchmarkBatchPPDAddendaCount(b *testing.B) {
 		testBatchPPDAddendaCount(b)
 	}
 }
+
+// TestBatchPPDAddendum98 validates Addenda98 returns an error
+func TestBatchPPDAddendum98(t *testing.T) {
+	mockBatch := NewBatchPPD(mockBatchPPDHeader())
+	mockBatch.AddEntry(mockPPDEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchPPDAddendum99 validates Addenda99 returns an error
+func TestBatchPPDAddendum99(t *testing.T) {
+	mockBatch := NewBatchPPD(mockBatchPPDHeader())
+	mockBatch.AddEntry(mockPPDEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchPPDSEC validates that the standard entry class code is PPD for batch Web
+func TestBatchPPDSEC(t *testing.T) {
+	mockBatch := mockBatchPPD()
+	mockBatch.Header.StandardEntryClassCode = "RCK"
+	if err := mockBatch.Validate(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "StandardEntryClassCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -29,12 +29,7 @@ func (batch *BatchRCK) Validate() error {
 		return err
 	}
 
-	// Batch RCK cannot have an addenda record
-	if err := batch.isAddendaCount(0); err != nil {
-		return err
-	}
-
-	// Add type specific validation.
+	// Add configuration and type specific validation for this type.
 	if batch.Header.StandardEntryClassCode != "RCK" {
 		msg := fmt.Sprintf(msgBatchSECType, batch.Header.StandardEntryClassCode, "RCK")
 		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "StandardEntryClassCode", Msg: msg}
@@ -70,6 +65,28 @@ func (batch *BatchRCK) Validate() error {
 		if entry.IdentificationNumber == "" {
 			msg := fmt.Sprintf(msgBatchCheckSerialNumber, "RCK")
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "CheckSerialNumber", Msg: msg}
+		}
+		// RCK cannot have Addenda02 or Addenda05.  There can be a NOC (98) or Return (99)
+		for _, addenda := range entry.Addendum {
+			switch entry.Category {
+			case CategoryForward:
+				if len(entry.Addendum) > 0 {
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+				}
+			case CategoryNOC:
+				if addenda.typeCode() != "98" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
+			case CategoryReturn:
+				if addenda.typeCode() != "99" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
+			}
 		}
 	}
 	return nil

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -71,7 +71,7 @@ func (batch *BatchRCK) Validate() error {
 			switch entry.Category {
 			case CategoryForward:
 				if len(entry.Addendum) > 0 {
-					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -75,17 +75,13 @@ func (batch *BatchRCK) Validate() error {
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchRCK_test.go
+++ b/batchRCK_test.go
@@ -462,3 +462,39 @@ func BenchmarkRCKBatchInvalidBuild(b *testing.B) {
 		testBatchRCKInvalidBuild(b)
 	}
 }
+
+// TestBatchRCKAddendum98 validates Addenda98 returns an error
+func TestBatchRCKAddendum98(t *testing.T) {
+	mockBatch := NewBatchRCK(mockBatchRCKHeader())
+	mockBatch.AddEntry(mockRCKEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchRCKAddendum99 validates Addenda99 returns an error
+func TestBatchRCKAddendum99(t *testing.T) {
+	mockBatch := NewBatchRCK(mockBatchRCKHeader())
+	mockBatch.AddEntry(mockRCKEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -70,7 +70,7 @@ func (batch *BatchSHR) Validate() error {
 			return &FieldError{FieldName: "CardExpirationDate", Value: year, Msg: msgValidYear}
 		}
 
-		// Addendum must be equal to 1
+		// SHR must have one Addenda record TypeCode = 02, or there can be a NOC (98) or Return (99)
 		if len(entry.Addendum) != 1 {
 			msg := fmt.Sprintf(msgBatchRequiredAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
@@ -83,7 +83,7 @@ func (batch *BatchSHR) Validate() error {
 			case "02", "98", "99":
 			// Return Error
 			default:
-				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), addenda.typeCode(), batch.Header.StandardEntryClassCode)
+				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "02", batch.Header.StandardEntryClassCode)
 				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
 			}
 		}

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -79,23 +79,17 @@ func (batch *BatchSHR) Validate() error {
 		for _, addenda := range entry.Addendum {
 			switch entry.Category {
 			case CategoryForward:
-				if addenda.typeCode() != "02" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "02", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryForwardAddenda02(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda02
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -70,7 +70,12 @@ func (batch *BatchSHR) Validate() error {
 			return &FieldError{FieldName: "CardExpirationDate", Value: year, Msg: msgValidYear}
 		}
 
-		// SHR must have one Addenda record TypeCode = 02, or there can be a NOC (98) or Return (99)
+		// SHR must have one Addenda02 record
+		if len(entry.Addendum) != 1 {
+			msg := fmt.Sprintf(msgBatchRequiredAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+		}
+		// SHR must have one Addenda02 but cannot have Addenda05, or there can be a NOC (98) or Return (99)
 		for _, addenda := range entry.Addendum {
 			switch entry.Category {
 			case CategoryForward:

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -21,9 +21,6 @@ type BatchSHR struct {
 	batch
 }
 
-var msgBatchSHRAddenda = "found and 1 Addenda02 is required for SEC code SHR"
-var msgBatchSHRAddendaType = "%T found where Addenda02 is required for SEC code SHR"
-
 // NewBatchSHR returns a *BatchSHR
 func NewBatchSHR(bh *BatchHeader) *BatchSHR {
 	batch := new(BatchSHR)
@@ -38,10 +35,8 @@ func (batch *BatchSHR) Validate() error {
 	if err := batch.verify(); err != nil {
 		return err
 	}
-	// Add configuration based validation for this type.
 
-	// Add type specific validation.
-
+	// Add configuration and type specific validation for this type.
 	if batch.Header.StandardEntryClassCode != "SHR" {
 		msg := fmt.Sprintf(msgBatchSECType, batch.Header.StandardEntryClassCode, "SHR")
 		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "StandardEntryClassCode", Msg: msg}
@@ -75,25 +70,21 @@ func (batch *BatchSHR) Validate() error {
 			return &FieldError{FieldName: "CardExpirationDate", Value: year, Msg: msgValidYear}
 		}
 
-		// Addenda validations - SHR Addenda must be Addenda02
-
 		// Addendum must be equal to 1
 		if len(entry.Addendum) != 1 {
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "Addendum", Msg: msgBatchSHRAddenda}
+			msg := fmt.Sprintf(msgBatchRequiredAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 		}
 
-		// Addenda type assertion must be Addenda02
-		addenda02, ok := entry.Addendum[0].(*Addenda02)
-		if !ok {
-			msg := fmt.Sprintf(msgBatchSHRAddendaType, entry.Addendum[0])
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "Addendum", Msg: msg}
-		}
-
-		// Addenda02 must be Validated
-		if err := addenda02.Validate(); err != nil {
-			// convert the field error in to a batch error for a consistent api
-			if e, ok := err.(*FieldError); ok {
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: e.FieldName, Msg: e.Msg}
+		// Range through Addenda
+		for _, addenda := range entry.Addendum {
+			switch addenda.typeCode() {
+			// Addenda TypeCode valid
+			case "02", "98", "99":
+			// Return Error
+			default:
+				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), addenda.typeCode(), batch.Header.StandardEntryClassCode)
+				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
 			}
 		}
 	}

--- a/batchSHR_test.go
+++ b/batchSHR_test.go
@@ -320,13 +320,39 @@ func BenchmarkBatchSHRAddendaCountZero(b *testing.B) {
 	}
 }
 
+// TestBatchSHRAddendum98 validates Addenda98 returns an error
+func TestBatchSHRAddendum98(t *testing.T) {
+	mockBatch := NewBatchSHR(mockBatchSHRHeader())
+	mockBatch.AddEntry(mockSHREntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
 // TestBatchSHRAddendum99 validates Addenda99 returns an error
 func TestBatchSHRAddendum99(t *testing.T) {
 	mockBatch := NewBatchSHR(mockBatchSHRHeader())
 	mockBatch.AddEntry(mockSHREntryDetail())
-	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
 	if err := mockBatch.Create(); err != nil {
-		t.Errorf("%T: %s", err, err)
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
 	}
 }
 

--- a/batchSHR_test.go
+++ b/batchSHR_test.go
@@ -298,7 +298,7 @@ func testBatchSHRAddendaCountZero(t testing.TB) {
 	mockBatch.AddEntry(mockSHREntryDetail())
 	if err := mockBatch.Create(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "AddendaCount" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {
@@ -320,6 +320,16 @@ func BenchmarkBatchSHRAddendaCountZero(b *testing.B) {
 	}
 }
 
+// TestBatchSHRAddendum99 validates Addenda99 returns an error
+func TestBatchSHRAddendum99(t *testing.T) {
+	mockBatch := NewBatchSHR(mockBatchSHRHeader())
+	mockBatch.AddEntry(mockSHREntryDetail())
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99())
+	if err := mockBatch.Create(); err != nil {
+		t.Errorf("%T: %s", err, err)
+	}
+}
+
 // testBatchSHRInvalidAddendum validates Addendum must be Addenda02
 func testBatchSHRInvalidAddendum(t testing.TB) {
 	mockBatch := NewBatchSHR(mockBatchSHRHeader())
@@ -327,7 +337,7 @@ func testBatchSHRInvalidAddendum(t testing.TB) {
 	mockBatch.GetEntries()[0].AddAddenda(mockAddenda05())
 	if err := mockBatch.Create(); err != nil {
 		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
+			if e.FieldName != "TypeCode" {
 				t.Errorf("%T: %s", err, err)
 			}
 		} else {

--- a/batchTEL.go
+++ b/batchTEL.go
@@ -47,17 +47,13 @@ func (batch *BatchTEL) Validate() error {
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchTEL.go
+++ b/batchTEL.go
@@ -43,7 +43,7 @@ func (batch *BatchTEL) Validate() error {
 			switch entry.Category {
 			case CategoryForward:
 				if len(entry.Addendum) > 0 {
-					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 0, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:

--- a/batchTEL_test.go
+++ b/batchTEL_test.go
@@ -209,3 +209,39 @@ func BenchmarkBatchTELPaymentType(b *testing.B) {
 		testBatchTELPaymentType(b)
 	}
 }
+
+// TestBatchTELAddendum98 validates Addenda98 returns an error
+func TestBatchTELAddendum98(t *testing.T) {
+	mockBatch := NewBatchTEL(mockBatchTELHeader())
+	mockBatch.AddEntry(mockTELEntryDetail())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchTELAddendum99 validates Addenda99 returns an error
+func TestBatchTELAddendum99(t *testing.T) {
+	mockBatch := NewBatchTEL(mockBatchTELHeader())
+	mockBatch.AddEntry(mockTELEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}

--- a/batchWEB_test.go
+++ b/batchWEB_test.go
@@ -99,10 +99,20 @@ func BenchmarkBatchWebIndividualNameRequired(b *testing.B) {
 	}
 }
 
-// testBatchWEBAddendaTypeCod validates addenda type code is 05
+// TestBatchWEBAddendum98 validates Addenda98 returns an error
+func TestBatchWEBAddendum98(t *testing.T) {
+	mockBatch := NewBatchWEB(mockBatchWEBHeader())
+	mockBatch.AddEntry(mockWEBEntryDetail())
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98())
+	if err := mockBatch.Create(); err != nil {
+		t.Errorf("%T: %s", err, err)
+	}
+}
+
+// testBatchWEBAddendaTypeCode validates addenda type code is 05
 func testBatchWEBAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchWEB()
-	mockBatch.GetEntries()[0].Addendum[0].(*Addenda05).TypeCode = "07"
+	mockBatch.GetEntries()[0].Addendum[0].(*Addenda05).TypeCode = "98"
 	if err := mockBatch.Validate(); err != nil {
 		if e, ok := err.(*BatchError); ok {
 			if e.FieldName != "TypeCode" {

--- a/batchWEB_test.go
+++ b/batchWEB_test.go
@@ -109,10 +109,10 @@ func TestBatchWEBAddendum98(t *testing.T) {
 	}
 }
 
-// testBatchWEBAddendaTypeCode validates addenda type code is 05
+// testBatchWEBAddendaTypeCode validates addenda type code is valid
 func testBatchWEBAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchWEB()
-	mockBatch.GetEntries()[0].Addendum[0].(*Addenda05).TypeCode = "98"
+	mockBatch.GetEntries()[0].Addendum[0].(*Addenda05).TypeCode = "02"
 	if err := mockBatch.Validate(); err != nil {
 		if e, ok := err.(*BatchError); ok {
 			if e.FieldName != "TypeCode" {
@@ -124,12 +124,12 @@ func testBatchWEBAddendaTypeCode(t testing.TB) {
 	}
 }
 
-// TestBatchWEBAddendaTypeCode tests validating addenda type code is 05
+// TestBatchWEBAddendaTypeCode tests validating addenda type code is valid
 func TestBatchWEBAddendaTypeCode(t *testing.T) {
 	testBatchWEBAddendaTypeCode(t)
 }
 
-// BenchmarkBatchWEBAddendaTypeCode benchmarks validating addenda type code is 05
+// BenchmarkBatchWEBAddendaTypeCode benchmarks validating addenda type code is valid
 func BenchmarkBatchWEBAddendaTypeCode(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {

--- a/batchWEB_test.go
+++ b/batchWEB_test.go
@@ -103,9 +103,35 @@ func BenchmarkBatchWebIndividualNameRequired(b *testing.B) {
 func TestBatchWEBAddendum98(t *testing.T) {
 	mockBatch := NewBatchWEB(mockBatchWEBHeader())
 	mockBatch.AddEntry(mockWEBEntryDetail())
-	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98())
+	mockAddenda98 := mockAddenda98()
+	mockAddenda98.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda98)
 	if err := mockBatch.Create(); err != nil {
-		t.Errorf("%T: %s", err, err)
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
+	}
+}
+
+// TestBatchWEBAddendum99 validates Addenda99 returns an error
+func TestBatchWEBAddendum99(t *testing.T) {
+	mockBatch := NewBatchWEB(mockBatchWEBHeader())
+	mockBatch.AddEntry(mockWEBEntryDetail())
+	mockAddenda99 := mockAddenda99()
+	mockAddenda99.TypeCode = "05"
+	mockBatch.GetEntries()[0].AddAddenda(mockAddenda99)
+	if err := mockBatch.Create(); err != nil {
+		if e, ok := err.(*BatchError); ok {
+			if e.FieldName != "TypeCode" {
+				t.Errorf("%T: %s", err, err)
+			}
+		} else {
+			t.Errorf("%T: %s", err, err)
+		}
 	}
 }
 

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -36,18 +36,19 @@ func (batch *BatchWEB) Validate() error {
 	}
 
 	for _, entry := range batch.Entries {
-		// Web can have up to one addenda per entry record
+		// Web can have up to one Record TypeCode = 05, or there can be a NOC (98) or Return (99)
 		if len(entry.Addendum) > 1 {
 			msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 		}
+
 		for _, addenda := range entry.Addendum {
 			switch addenda.typeCode() {
 			// Addenda TypeCode valid
 			case "05", "98", "99":
 			//Return error
 			default:
-				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), addenda.typeCode(), batch.Header.StandardEntryClassCode)
+				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", batch.Header.StandardEntryClassCode)
 				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
 			}
 		}

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -36,7 +36,7 @@ func (batch *BatchWEB) Validate() error {
 	}
 
 	for _, entry := range batch.Entries {
-		// Web can have up to one Record TypeCode = 05, or there can be a NOC (98) or Return (99)
+		// WEB can have up to one Record TypeCode = 05, or there can be a NOC (98) or Return (99)
 		if len(entry.Addendum) > 1 {
 			msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
 			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -36,20 +36,30 @@ func (batch *BatchWEB) Validate() error {
 	}
 
 	for _, entry := range batch.Entries {
-		// WEB can have up to one Record TypeCode = 05, or there can be a NOC (98) or Return (99)
-		if len(entry.Addendum) > 1 {
-			msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
-		}
-
+		// WEB can have up to one Addenda Record TypeCode = 05, or there can be a NOC (98) or Return (99)
 		for _, addenda := range entry.Addendum {
-			switch addenda.typeCode() {
-			// Addenda TypeCode valid
-			case "05", "98", "99":
-			//Return error
-			default:
-				msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", batch.Header.StandardEntryClassCode)
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+			switch entry.Category {
+			case CategoryForward:
+				if addenda.typeCode() != "05" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				if len(entry.Addendum) > 1 {
+					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+				}
+			case CategoryNOC:
+				if addenda.typeCode() != "98" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
+			case CategoryReturn:
+				if addenda.typeCode() != "99" {
+					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
+					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				}
+				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -36,24 +36,21 @@ func (batch *BatchWEB) Validate() error {
 		for _, addenda := range entry.Addendum {
 			switch entry.Category {
 			case CategoryForward:
-				if addenda.typeCode() != "05" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "05", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryForwardAddenda05(entry, addenda); err != nil {
+					return err
 				}
 				if len(entry.Addendum) > 1 {
 					msg := fmt.Sprintf(msgBatchAddendaCount, len(entry.Addendum), 1, batch.Header.StandardEntryClassCode)
 					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
 				}
 			case CategoryNOC:
-				if addenda.typeCode() != "98" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "98", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
+					return err
 				}
 				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
-				if addenda.typeCode() != "99" {
-					msg := fmt.Sprintf(msgBatchTypeCode, addenda.typeCode(), "99", entry.Category, batch.Header.StandardEntryClassCode)
-					return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TypeCode", Msg: msg}
+				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
+					return err
 				}
 				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -47,12 +47,10 @@ func (batch *BatchWEB) Validate() error {
 				if err := batch.categoryNOCAddenda98(entry, addenda); err != nil {
 					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda98
 			case CategoryReturn:
 				if err := batch.categoryReturnAddenda99(entry, addenda); err != nil {
 					return err
 				}
-				// Do not need a length check on entry.Addendum as addAddenda.EntryDetail only allows one Addenda99
 			}
 		}
 	}

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -11,10 +11,6 @@ type BatchWEB struct {
 	batch
 }
 
-var (
-	msgBatchWebPaymentType = "%v is not a valid payment type S (single entry) or R (recurring)"
-)
-
 // NewBatchWEB returns a *BatchWEB
 func NewBatchWEB(bh *BatchHeader) *BatchWEB {
 	batch := new(BatchWEB)

--- a/batcher.go
+++ b/batcher.go
@@ -56,6 +56,7 @@ var (
 	msgBatchAddendaTraceNumber      = "%v does not match proceeding entry detail trace number %v"
 	msgBatchEntries                 = "must have Entry Record(s) to be built"
 	msgBatchAddendaCount            = "%v addendum found where %v is allowed for batch type %v"
+	msgBatchRequiredAddendaCount    = "%v addendum found where %v is required for batch type %v"
 	msgBatchTransactionCodeCredit   = "%v a credit is not allowed"
 	msgBatchSECType                 = "header SEC type code %v for batch type %v"
 	msgBatchTypeCode                = "%v found in addenda and expecting %v for batch type %v"

--- a/batcher.go
+++ b/batcher.go
@@ -59,7 +59,7 @@ var (
 	msgBatchRequiredAddendaCount    = "%v addendum found where %v is required for batch type %v"
 	msgBatchTransactionCodeCredit   = "%v a credit is not allowed"
 	msgBatchSECType                 = "header SEC type code %v for batch type %v"
-	msgBatchTypeCode                = "%v found in addenda and expecting %v for batch type %v"
+	msgBatchTypeCode                = "%v found in addenda and expecting %v for %v, batch type %v"
 	msgBatchServiceClassCode        = "Service Class Code %v is not valid for batch type %v"
 	msgBatchForwardReturn           = "Forward and Return entries found in the same batch"
 	msgBatchAmount                  = "Amount must be less than %v for SEC code %v"


### PR DESCRIPTION
I'm going to submit a pull request for 323.  It covers all but IAT, I kind of had to do that to remove the isAddendaCount function.  I'll make a separate issue for IAT. 

I did make some generic functions for returning error message if a batch had an incorrect TypeCode for an Addenda.  I wanted that to be caught at the batch level.  

Take a look and let me know what you think.  I can tear it down if you don't like it and we can do it another way, but having a function with switches for SEC Code or typeCode assertion doesn't seem better than handling the conditions within the batchSEC type itself.   Either way we may want to look into batch and the ranging of entries for other functions as well.   Thanks in advance.