### PR TITLE
server: drop content-length check on create file

### DIFF
--- a/server/routing.go
+++ b/server/routing.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,8 +25,6 @@ var (
 	// ErrBadRouting is returned when an expected path variable is missing, which is always programmer error.
 	ErrBadRouting = fmt.Errorf("inconsistent mapping between route and handler, %s", bugReportHelp)
 	ErrFoundABug  = fmt.Errorf("Snuck into encodeError with err == nil, %s", bugReportHelp)
-
-	MaxContentLength = 1 * 1024 * 1024 // bytes
 )
 
 // contextKey is a unique (and compariable) type we use
@@ -183,11 +180,6 @@ func MakeHTTPHandler(s Service, repo Repository, logger log.Logger) http.Handler
 
 //** FILES ** //
 func decodeCreateFileRequest(_ context.Context, request *http.Request) (interface{}, error) {
-	// Make sure content-length is small enough
-	if !acceptableContentLength(request.Header) {
-		return nil, errors.New("request body is too large")
-	}
-
 	var r io.Reader
 	var req createFileRequest
 
@@ -402,12 +394,4 @@ func codeFrom(err error) int {
 	// TODO(adam): this should really probably be a 4xx error
 	// TODO(adam): on GET /files/:id/validate a "bad" file returns 500
 	return http.StatusInternalServerError
-}
-
-func acceptableContentLength(headers http.Header) bool {
-	h := headers.Get("Content-Length")
-	if v, err := strconv.Atoi(h); err == nil {
-		return v <= MaxContentLength
-	}
-	return false
 }

--- a/server/routing_test.go
+++ b/server/routing_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -47,24 +46,6 @@ func TestEncodeTextResponse(t *testing.T) {
 
 	if v := w.Header().Get("content-type"); v != "text/plain" {
 		t.Errorf("got %q", v)
-	}
-}
-
-func TestAcceptableContentLength(t *testing.T) {
-	h := make(http.Header)
-
-	if acceptableContentLength(h) { // reject if missing header
-		t.Error("wanted unacceptable")
-	}
-
-	h.Set("Content-Length", "1000")
-	if !acceptableContentLength(h) {
-		t.Error("should have accepted")
-	}
-
-	h.Set("Content-Length", "10000000000000")
-	if acceptableContentLength(h) {
-		t.Error("should have rejected")
 	}
 }
 


### PR DESCRIPTION
This was throwing problems locally and we should approach this in a uniform across all our apps. I'm thinking something along the LB tier.

Issue: https://github.com/moov-io/paygate/issues/8 