### PR TITLE
Change TraceNumber and OriginalTrace to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BREAKING CHANGES
 
 - `TraceNumber` has been changed from `int` to a `string`. (See [#366](https://github.com/moov-io/ach/issues/366))
    - Previously zero-prefixed ABA routing numbers would have their leading zero truncated.
+- `OriginalTrace` has been changed from `int` to a `string`. (See [#366](https://github.com/moov-io/ach/issues/366))
 
 ## v0.4.1 (Unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.5.0 (Unreleased)
+
+BREAKING CHANGES
+
+- `TraceNumber` has been changed from `int` to a `string`. (See [#366](https://github.com/moov-io/ach/issues/366))
+   - Previously zero-prefixed ABA routing numbers would have their leading zero truncated.
+
 ## v0.4.1 (Unreleased)
 
 ADDITIONS

--- a/addenda02.go
+++ b/addenda02.go
@@ -45,6 +45,8 @@ type Addenda02 struct {
 	// TerminalState Identifies the state in which the electronic terminal is located
 	TerminalState string `json:"terminalState"`
 	// TraceNumber Standard Entry Detail Trace Number
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 	// validator is composed for data validation
 	validator

--- a/addenda02.go
+++ b/addenda02.go
@@ -45,7 +45,7 @@ type Addenda02 struct {
 	// TerminalState Identifies the state in which the electronic terminal is located
 	TerminalState string `json:"terminalState"`
 	// TraceNumber Standard Entry Detail Trace Number
-	TraceNumber int `json:"traceNumber,omitempty"`
+	TraceNumber string `json:"traceNumber,omitempty"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters
@@ -87,7 +87,7 @@ func (addenda02 *Addenda02) Parse(record string) {
 	// 78-79
 	addenda02.TerminalState = strings.TrimSpace(record[77:79])
 	// 80-94
-	addenda02.TraceNumber = addenda02.parseNumField(record[79:94])
+	addenda02.TraceNumber = strings.TrimSpace(record[79:94])
 }
 
 // String writes the Addenda02 struct to a 94 character string.
@@ -257,7 +257,7 @@ func (addenda02 *Addenda02) TerminalStateField() string {
 	return addenda02.alphaField(addenda02.TerminalState, 2)
 }
 
-// TraceNumberField returns a space padded traceNumber string
+// TraceNumberField returns a space padded TraceNumber string
 func (addenda02 *Addenda02) TraceNumberField() string {
-	return addenda02.numericField(addenda02.TraceNumber, 15)
+	return addenda02.stringField(addenda02.TraceNumber, 15)
 }

--- a/addenda02_test.go
+++ b/addenda02_test.go
@@ -21,7 +21,7 @@ func mockAddenda02() *Addenda02 {
 	addenda02.TerminalLocation = "Target Store 0049"
 	addenda02.TerminalCity = "PHILADELPHIA"
 	addenda02.TerminalState = "PA"
-	addenda02.TraceNumber = 121042880000123
+	addenda02.TraceNumber = "121042880000123"
 	return addenda02
 }
 

--- a/addenda98.go
+++ b/addenda98.go
@@ -30,7 +30,7 @@ type Addenda98 struct {
 	// CorrectedData
 	CorrectedData string `json:"correctedData"`
 	// TraceNumber matches the Entry Detail Trace Number of the entry being returned.
-	TraceNumber int `json:"traceNumber,omitempty"`
+	TraceNumber string `json:"traceNumber,omitempty"`
 
 	// validator is composed for data validation
 	validator
@@ -83,7 +83,7 @@ func (addenda98 *Addenda98) Parse(record string) {
 	// 36-64
 	addenda98.CorrectedData = strings.TrimSpace(record[35:64])
 	// 80-94
-	addenda98.TraceNumber = addenda98.parseNumField(record[79:94])
+	addenda98.TraceNumber = strings.TrimSpace(record[79:94])
 }
 
 // String writes the Addenda98 struct to a 94 character string
@@ -151,7 +151,7 @@ func (addenda98 *Addenda98) CorrectedDataField() string {
 
 // TraceNumberField returns a zero padded traceNumber string
 func (addenda98 *Addenda98) TraceNumberField() string {
-	return addenda98.numericField(addenda98.TraceNumber, 15)
+	return addenda98.stringField(addenda98.TraceNumber, 15)
 }
 
 func makeChangeCodeDict() map[string]*changeCode {

--- a/addenda98.go
+++ b/addenda98.go
@@ -30,6 +30,8 @@ type Addenda98 struct {
 	// CorrectedData
 	CorrectedData string `json:"correctedData"`
 	// TraceNumber matches the Entry Detail Trace Number of the entry being returned.
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 
 	// validator is composed for data validation

--- a/addenda98.go
+++ b/addenda98.go
@@ -24,7 +24,7 @@ type Addenda98 struct {
 	// OriginalTrace This field contains the Trace Number as originally included on the forward Entry or Prenotification.
 	// The RDFI must include the Original Entry Trace Number in the Addenda Record of an Entry being returned to an ODFI,
 	// in the Addenda Record of an 98, within an Acknowledgment Entry, or with an RDFI request for a copy of an authorization.
-	OriginalTrace int `json:"originalTrace"`
+	OriginalTrace string `json:"originalTrace"`
 	// OriginalDFI field contains the Receiving DFI Identification (addenda.RDFIIdentification) as originally included on the forward Entry or Prenotification that the RDFI is returning or correcting.
 	OriginalDFI string `json:"originalDFI"`
 	// CorrectedData
@@ -77,7 +77,7 @@ func (addenda98 *Addenda98) Parse(record string) {
 	// 4-6
 	addenda98.ChangeCode = record[3:6]
 	// 7-21
-	addenda98.OriginalTrace = addenda98.parseNumField(record[6:21])
+	addenda98.OriginalTrace = strings.TrimSpace(record[6:21])
 	// 28-35
 	addenda98.OriginalDFI = addenda98.parseStringField(record[27:35])
 	// 36-64
@@ -136,7 +136,7 @@ func (addenda98 *Addenda98) Validate() error {
 
 // OriginalTraceField returns a zero padded OriginalTrace string
 func (addenda98 *Addenda98) OriginalTraceField() string {
-	return addenda98.numericField(addenda98.OriginalTrace, 15)
+	return addenda98.stringField(addenda98.OriginalTrace, 15)
 }
 
 // OriginalDFIField returns a zero padded OriginalDFI string

--- a/addenda98_test.go
+++ b/addenda98_test.go
@@ -14,7 +14,7 @@ func mockAddenda98() *Addenda98 {
 	addenda98.OriginalTrace = 12345
 	addenda98.OriginalDFI = "9101298"
 	addenda98.CorrectedData = "1918171614"
-	addenda98.TraceNumber = 91012980000088
+	addenda98.TraceNumber = "91012980000088"
 
 	return addenda98
 }
@@ -42,8 +42,8 @@ func testAddenda98Parse(t testing.TB) {
 	if addenda98.CorrectedData != "1918171614" {
 		t.Errorf("expected %v got %v", "1918171614", addenda98.CorrectedData)
 	}
-	if addenda98.TraceNumber != 91012980000088 {
-		t.Errorf("expected %v got %v", 91012980000088, addenda98.TraceNumber)
+	if addenda98.TraceNumber != "091012980000088" {
+		t.Errorf("expected %v got %v", "091012980000088", addenda98.TraceNumber)
 	}
 }
 

--- a/addenda98_test.go
+++ b/addenda98_test.go
@@ -11,7 +11,7 @@ import (
 func mockAddenda98() *Addenda98 {
 	addenda98 := NewAddenda98()
 	addenda98.ChangeCode = "C01"
-	addenda98.OriginalTrace = 12345
+	addenda98.OriginalTrace = "12345"
 	addenda98.OriginalDFI = "9101298"
 	addenda98.CorrectedData = "1918171614"
 	addenda98.TraceNumber = "91012980000088"
@@ -33,8 +33,8 @@ func testAddenda98Parse(t testing.TB) {
 	if addenda98.ChangeCode != "C01" {
 		t.Errorf("expected %v got %v", "C01", addenda98.ChangeCode)
 	}
-	if addenda98.OriginalTrace != 99912340000015 {
-		t.Errorf("expected %v got %v", 99912340000015, addenda98.OriginalTrace)
+	if addenda98.OriginalTrace != "099912340000015" {
+		t.Errorf("expected %v got %v", "099912340000015", addenda98.OriginalTrace)
 	}
 	if addenda98.OriginalDFI != "09101298" {
 		t.Errorf("expected %s got %s", "09101298", addenda98.OriginalDFI)

--- a/addenda99.go
+++ b/addenda99.go
@@ -52,7 +52,7 @@ type Addenda99 struct {
 	// AddendaInformation
 	AddendaInformation string `json:"addendaInformation,omitempty"`
 	// TraceNumber matches the Entry Detail Trace Number of the entry being returned.
-	TraceNumber int `json:"traceNumber,omitempty"`
+	TraceNumber string `json:"traceNumber,omitempty"`
 
 	// validator is composed for data validation
 	validator
@@ -95,7 +95,7 @@ func (Addenda99 *Addenda99) Parse(record string) {
 	// 36-79
 	Addenda99.AddendaInformation = strings.TrimSpace(record[35:79])
 	// 80-94
-	Addenda99.TraceNumber = Addenda99.parseNumField(record[79:94])
+	Addenda99.TraceNumber = strings.TrimSpace(record[79:94])
 }
 
 // String writes the Addenda99 struct to a 94 character string
@@ -186,9 +186,9 @@ func (Addenda99 *Addenda99) IATAddendaInformationField() string {
 	return Addenda99.alphaField(Addenda99.AddendaInformation[9:44], 34)
 }
 
-// TraceNumberField returns a zero padded traceNumber string
+// TraceNumberField returns a zero padded TraceNumber string
 func (Addenda99 *Addenda99) TraceNumberField() string {
-	return Addenda99.numericField(Addenda99.TraceNumber, 15)
+	return Addenda99.stringField(Addenda99.TraceNumber, 15)
 }
 
 func makeReturnCodeDict() map[string]*returnCode {

--- a/addenda99.go
+++ b/addenda99.go
@@ -52,6 +52,8 @@ type Addenda99 struct {
 	// AddendaInformation
 	AddendaInformation string `json:"addendaInformation,omitempty"`
 	// TraceNumber matches the Entry Detail Trace Number of the entry being returned.
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 
 	// validator is composed for data validation

--- a/addenda99.go
+++ b/addenda99.go
@@ -44,7 +44,7 @@ type Addenda99 struct {
 	// OriginalTrace This field contains the Trace Number as originally included on the forward Entry or Prenotification.
 	// The RDFI must include the Original Entry Trace Number in the Addenda Record of an Entry being returned to an ODFI,
 	// in the Addenda Record of an 98, within an Acknowledgment Entry, or with an RDFI request for a copy of an authorization.
-	OriginalTrace int `json:"originalTrace"`
+	OriginalTrace string `json:"originalTrace"`
 	// DateOfDeath The field date of death is to be supplied on Entries being returned for reason of death (return reason codes R14 and R15).
 	DateOfDeath time.Time `json:"dateOfDeath"`
 	// OriginalDFI field contains the Receiving DFI Identification (addenda.RDFIIdentification) as originally included on the forward Entry or Prenotification that the RDFI is returning or correcting.
@@ -87,7 +87,7 @@ func (Addenda99 *Addenda99) Parse(record string) {
 	// 4-6
 	Addenda99.ReturnCode = record[3:6]
 	// 7-21
-	Addenda99.OriginalTrace = Addenda99.parseNumField(record[6:21])
+	Addenda99.OriginalTrace = strings.TrimSpace(record[6:21])
 	// 22-27, might be a date or blank
 	Addenda99.DateOfDeath = Addenda99.parseSimpleDate(record[21:27])
 	// 28-35
@@ -140,7 +140,7 @@ func (Addenda99 *Addenda99) Validate() error {
 
 // OriginalTraceField returns a zero padded OriginalTrace string
 func (Addenda99 *Addenda99) OriginalTraceField() string {
-	return Addenda99.numericField(Addenda99.OriginalTrace, 15)
+	return Addenda99.stringField(Addenda99.OriginalTrace, 15)
 }
 
 // DateOfDeathField returns a space padded DateOfDeath string

--- a/addenda99_test.go
+++ b/addenda99_test.go
@@ -45,8 +45,8 @@ func testAddenda99Parse(t testing.TB) {
 	if addenda99.AddendaInformation != "Authorization revoked" {
 		t.Errorf("expected: %v got: %v", "Authorization revoked", addenda99.AddendaInformation)
 	}
-	if addenda99.TraceNumber != 91012980000066 {
-		t.Errorf("expected: %v got: %v", 91012980000066, addenda99.TraceNumber)
+	if addenda99.TraceNumber != "091012980000066" {
+		t.Errorf("expected: %v got: %v", "091012980000066", addenda99.TraceNumber)
 	}
 }
 
@@ -240,7 +240,7 @@ func BenchmarkAddenda99AddendaInformationField(b *testing.B) {
 
 func testAddenda99TraceNumberField(t testing.TB) {
 	addenda99 := mockAddenda99()
-	addenda99.TraceNumber = 91012980000066
+	addenda99.TraceNumber = "91012980000066"
 	exp := "091012980000066"
 	if addenda99.TraceNumberField() != exp {
 		t.Errorf("expected %v received %v", exp, addenda99.TraceNumberField())

--- a/addenda99_test.go
+++ b/addenda99_test.go
@@ -12,7 +12,7 @@ import (
 func mockAddenda99() *Addenda99 {
 	addenda99 := NewAddenda99()
 	addenda99.ReturnCode = "R07"
-	addenda99.OriginalTrace = 99912340000015
+	addenda99.OriginalTrace = "99912340000015"
 	addenda99.AddendaInformation = "Authorization Revoked"
 	addenda99.OriginalDFI = "9101298"
 
@@ -33,8 +33,8 @@ func testAddenda99Parse(t testing.TB) {
 	if addenda99.ReturnCode != "R07" {
 		t.Errorf("expected %v got %v", "R07", addenda99.ReturnCode)
 	}
-	if addenda99.OriginalTrace != 99912340000015 {
-		t.Errorf("expected: %v got: %v", 99912340000015, addenda99.OriginalTrace)
+	if addenda99.OriginalTrace != "099912340000015" {
+		t.Errorf("expected: %v got: %v", "099912340000015", addenda99.OriginalTrace)
 	}
 	if !addenda99.DateOfDeath.IsZero() {
 		t.Errorf("expected: %v got: %v", time.Time{}, addenda99.DateOfDeath)
@@ -160,7 +160,7 @@ func BenchmarkAddenda99ValidateReturnCodeFalse(b *testing.B) {
 
 func testAddenda99OriginalTraceField(t testing.TB) {
 	addenda99 := mockAddenda99()
-	addenda99.OriginalTrace = 12345
+	addenda99.OriginalTrace = "12345"
 	if addenda99.OriginalTraceField() != "000000000012345" {
 		t.Errorf("expected %v received %v", "000000000012345", addenda99.OriginalTraceField())
 	}

--- a/batch.go
+++ b/batch.go
@@ -486,10 +486,8 @@ func (batch *Batch) calculateADVBatchAmounts() (credit int, debit int) {
 // isSequenceAscending Individual Entry Detail Records within individual batches must
 // be in ascending Trace Number order (although Trace Numbers need not necessarily be consecutive).
 func (batch *Batch) isSequenceAscending() error {
-
-	lastSeq := -1
-
 	if !batch.IsADV() {
+		lastSeq := "0"
 		for _, entry := range batch.Entries {
 			if entry.TraceNumber <= lastSeq {
 				msg := fmt.Sprintf(msgBatchAscending, entry.TraceNumber, lastSeq)

--- a/batchControl_test.go
+++ b/batchControl_test.go
@@ -58,7 +58,7 @@ func testParseBatchControl(t testing.TB) {
 		ODFIIdentification:    "7640125"}
 	r.addCurrentBatch(NewBatchPPD(&bh))
 
-	r.currentBatch.AddEntry(&EntryDetail{TransactionCode: 27, Amount: 10500, RDFIIdentification: "5320001", TraceNumber: 76401255655291})
+	r.currentBatch.AddEntry(&EntryDetail{TransactionCode: 27, Amount: 10500, RDFIIdentification: "5320001", TraceNumber: "76401255655291"})
 	if err := r.parseBatchControl(); err != nil {
 		t.Errorf("%T: %s", err, err)
 	}
@@ -123,7 +123,7 @@ func testBCString(t testing.TB) {
 		ODFIIdentification:    "7640125"}
 	r.addCurrentBatch(NewBatchPPD(&bh))
 
-	r.currentBatch.AddEntry(&EntryDetail{TransactionCode: 27, Amount: 10500, RDFIIdentification: "5320001", TraceNumber: 76401255655291})
+	r.currentBatch.AddEntry(&EntryDetail{TransactionCode: 27, Amount: 10500, RDFIIdentification: "5320001", TraceNumber: "76401255655291"})
 	if err := r.parseBatchControl(); err != nil {
 		t.Errorf("%T: %s", err, err)
 	}

--- a/batch_test.go
+++ b/batch_test.go
@@ -101,7 +101,8 @@ func testCreditBatchIsBatchAmount(t testing.TB) {
 	e2 := mockEntryDetail()
 	e2.TransactionCode = 22
 	e2.Amount = 100
-	e2.TraceNumber = e1.TraceNumber + 10
+	// replace last 2 of TraceNumber
+	e2.TraceNumber = e1.TraceNumber[:13] + "10"
 	mockBatch.AddEntry(e2)
 	if err := mockBatch.build(); err != nil {
 		t.Errorf("%T: %s", err, err)
@@ -143,7 +144,8 @@ func testSavingsBatchIsBatchAmount(t testing.TB) {
 	e2 := mockEntryDetail()
 	e2.TransactionCode = 37
 	e2.Amount = 100
-	e2.TraceNumber = e1.TraceNumber + 10
+	// replace last 2 of TraceNumber
+	e2.TraceNumber = e1.TraceNumber[:13] + "10"
 
 	mockBatch.AddEntry(e2)
 	if err := mockBatch.build(); err != nil {
@@ -351,7 +353,7 @@ func BenchmarkBatchIsAddendaSeqAscending(b *testing.B) {
 func testBatchIsSequenceAscending(t testing.TB) {
 	mockBatch := mockBatch()
 	e3 := mockEntryDetail()
-	e3.TraceNumber = 1
+	e3.TraceNumber = "1"
 	mockBatch.AddEntry(e3)
 	mockBatch.GetControl().EntryAddendaCount = 2
 	if err := mockBatch.verify(); err != nil {
@@ -471,7 +473,8 @@ func testBatchCategoryForwardReturn(t testing.TB) {
 	entry := mockEntryDetail()
 	entry.Addenda99 = mockAddenda99()
 	entry.Category = CategoryReturn
-	entry.TraceNumber = entry.TraceNumber + 10
+	// replace last 2 of TraceNumber
+	entry.TraceNumber = entry.TraceNumber[:13] + "10"
 	entry.AddendaRecordIndicator = 1
 	mockBatch.AddEntry(entry)
 	if err := mockBatch.build(); err != nil {

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -66,7 +66,7 @@ type EntryDetail struct {
 	// For addenda Records, the Trace Number will be identical to the Trace Number
 	// in the associated Entry Detail Record, since the Trace Number is associated
 	// with an entry or item rather than a physical record.
-	TraceNumber int `json:"traceNumber,omitempty"`
+	TraceNumber string `json:"traceNumber,omitempty"`
 	// Addenda02 for use with StandardEntryClassCode MTE, POS, and SHR
 	Addenda02 *Addenda02 `json:"addenda02,omitempty"`
 	// Addenda05 for use with StandardEntryClassCode: ACK, ATX, CCD, CIE, CTX, DNE, ENR, WEB, PPD, TRX.
@@ -134,7 +134,7 @@ func (ed *EntryDetail) Parse(record string) {
 	ed.AddendaRecordIndicator = ed.parseNumField(record[78:79])
 	// 80-94 An internal identification (alphanumeric) that you use to uniquely identify
 	// this Entry Detail Record This number should be unique to the transaction and will help identify the transaction in case of an inquiry
-	ed.TraceNumber = ed.parseNumField(record[79:94])
+	ed.TraceNumber = strings.TrimSpace(record[79:94])
 }
 
 // String writes the EntryDetail struct to a 94 character string.
@@ -233,7 +233,7 @@ func (ed *EntryDetail) fieldInclusion() error {
 			Msg:       msgFieldInclusion + ", did you use NewEntryDetail()?",
 		}
 	}
-	if ed.TraceNumber == 0 {
+	if ed.TraceNumber == "" {
 		return &FieldError{
 			FieldName: "TraceNumber",
 			Value:     ed.TraceNumberField(),
@@ -253,8 +253,7 @@ func (ed *EntryDetail) SetRDFI(rdfi string) *EntryDetail {
 
 // SetTraceNumber takes first 8 digits of ODFI and concatenates a sequence number onto the TraceNumber
 func (ed *EntryDetail) SetTraceNumber(ODFIIdentification string, seq int) {
-	trace := ed.stringField(ODFIIdentification, 8) + ed.numericField(seq, 7)
-	ed.TraceNumber = ed.parseNumField(trace)
+	ed.TraceNumber = ed.stringField(ODFIIdentification, 8) + ed.numericField(seq, 7)
 }
 
 // RDFIIdentificationField get the rdfiIdentification with zero padding
@@ -502,7 +501,7 @@ func (ed *EntryDetail) ItemTypeIndicator() string {
 
 // TraceNumberField returns a zero padded TraceNumber string
 func (ed *EntryDetail) TraceNumberField() string {
-	return ed.numericField(ed.TraceNumber, 15)
+	return ed.stringField(ed.TraceNumber, 15)
 }
 
 // CreditOrDebit returns a "C" for credit or "D" for debit based on the entry TransactionCode

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -66,6 +66,8 @@ type EntryDetail struct {
 	// For addenda Records, the Trace Number will be identical to the Trace Number
 	// in the associated Entry Detail Record, since the Trace Number is associated
 	// with an entry or item rather than a physical record.
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 	// Addenda02 for use with StandardEntryClassCode MTE, POS, and SHR
 	Addenda02 *Addenda02 `json:"addenda02,omitempty"`

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -41,7 +41,7 @@ func testMockEntryDetail(t testing.TB) {
 	if entry.IndividualName != "Wade Arnold" {
 		t.Error("IndividualName dependent default value has changed")
 	}
-	if entry.TraceNumber != 121042880000001 {
+	if entry.TraceNumber != "121042880000001" {
 		t.Errorf("TraceNumber dependent default value has changed %v", entry.TraceNumber)
 	}
 }
@@ -519,7 +519,7 @@ func BenchmarkEDFieldInclusionIndividualName(b *testing.B) {
 // testEDFieldInclusionTraceNumber validates trace number field inclusion
 func testEDFieldInclusionTraceNumber(t testing.TB) {
 	entry := mockEntryDetail()
-	entry.TraceNumber = 0
+	entry.TraceNumber = "0"
 	if err := entry.Validate(); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if !strings.Contains(e.Msg, msgFieldInclusion) {

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -342,7 +342,7 @@ func (batch *IATBatch) calculateBatchAmounts() (credit int, debit int) {
 // isSequenceAscending Individual Entry Detail Records within individual batches must
 // be in ascending Trace Number order (although Trace Numbers need not necessarily be consecutive).
 func (batch *IATBatch) isSequenceAscending() error {
-	lastSeq := -1
+	lastSeq := "-1"
 	for _, entry := range batch.Entries {
 		if entry.TraceNumber <= lastSeq {
 			msg := fmt.Sprintf(msgBatchAscending, entry.TraceNumber, lastSeq)

--- a/iatBatch_test.go
+++ b/iatBatch_test.go
@@ -116,7 +116,7 @@ func mockIATAddenda98() *Addenda98 {
 	addenda98.OriginalTrace = 231380100000001
 	addenda98.OriginalDFI = "12104288"
 	addenda98.CorrectedData = "89722-C3"
-	addenda98.TraceNumber = 121042880000001
+	addenda98.TraceNumber = "121042880000001"
 	return addenda98
 }
 
@@ -618,7 +618,8 @@ func testIATBatchCreditIsBatchAmount(t testing.TB) {
 	e2 := mockIATEntryDetail()
 	e2.TransactionCode = 22
 	e2.Amount = 5000
-	e2.TraceNumber = e1.TraceNumber + 10
+	// replace last 2 of TraceNumber
+	e2.TraceNumber = e1.TraceNumber[:13] + "10"
 	mockBatch.AddEntry(e2)
 	mockBatch.Entries[1].Addenda10 = mockAddenda10()
 	mockBatch.Entries[1].Addenda11 = mockAddenda11()
@@ -665,7 +666,8 @@ func testIATBatchDebitIsBatchAmount(t testing.TB) {
 	e2 := mockIATEntryDetail()
 	e2.TransactionCode = 27
 	e2.Amount = 5000
-	e2.TraceNumber = e1.TraceNumber + 10
+	// replace last 2 of TraceNumber
+	e2.TraceNumber = e1.TraceNumber[:13] + "10"
 	mockBatch.AddEntry(e2)
 	mockBatch.Entries[1].Addenda10 = mockAddenda10()
 	mockBatch.Entries[1].Addenda11 = mockAddenda11()
@@ -959,7 +961,7 @@ func BenchmarkIATBatchisEntryHash(b *testing.B) {
 func testIATBatchIsSequenceAscending(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	e2 := mockIATEntryDetail()
-	e2.TraceNumber = 1
+	e2.TraceNumber = "1"
 	mockBatch.AddEntry(e2)
 	mockBatch.Entries[1].Addenda10 = mockAddenda10()
 	mockBatch.Entries[1].Addenda11 = mockAddenda11()

--- a/iatBatch_test.go
+++ b/iatBatch_test.go
@@ -103,7 +103,7 @@ func mockInvalidAddenda17() *Addenda17 {
 func mockIATAddenda99() *Addenda99 {
 	addenda99 := NewAddenda99()
 	addenda99.ReturnCode = "R07"
-	addenda99.OriginalTrace = 231380100000001
+	addenda99.OriginalTrace = "231380100000001"
 	addenda99.OriginalDFI = "12104288"
 	addenda99.IATPaymentAmount("0000100000")
 	addenda99.IATAddendaInformation("Authorization Revoked")
@@ -113,7 +113,7 @@ func mockIATAddenda99() *Addenda99 {
 func mockIATAddenda98() *Addenda98 {
 	addenda98 := NewAddenda98()
 	addenda98.ChangeCode = "C01"
-	addenda98.OriginalTrace = 231380100000001
+	addenda98.OriginalTrace = "231380100000001"
 	addenda98.OriginalDFI = "12104288"
 	addenda98.CorrectedData = "89722-C3"
 	addenda98.TraceNumber = "121042880000001"

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -62,6 +62,8 @@ type IATEntryDetail struct {
 	// For addenda Records, the Trace Number will be identical to the Trace Number
 	// in the associated Entry Detail Record, since the Trace Number is associated
 	// with an entry or item rather than a physical record.
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 	// Addenda10 is mandatory for IAT entries
 	//

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -62,7 +62,7 @@ type IATEntryDetail struct {
 	// For addenda Records, the Trace Number will be identical to the Trace Number
 	// in the associated Entry Detail Record, since the Trace Number is associated
 	// with an entry or item rather than a physical record.
-	TraceNumber int `json:"traceNumber,omitempty"`
+	TraceNumber string `json:"traceNumber,omitempty"`
 	// Addenda10 is mandatory for IAT entries
 	//
 	// The Addenda10 Record identifies the Receiver of the transaction and the dollar amount of
@@ -165,7 +165,7 @@ func (ed *IATEntryDetail) Parse(record string) {
 	ed.AddendaRecordIndicator = ed.parseNumField(record[78:79])
 	// 80-94 An internal identification (alphanumeric) that you use to uniquely identify
 	// this Entry Detail Record This number should be unique to the transaction and will help identify the transaction in case of an inquiry
-	ed.TraceNumber = ed.parseNumField(record[79:94])
+	ed.TraceNumber = strings.TrimSpace(record[79:94])
 }
 
 // String writes the EntryDetail struct to a 94 character string.
@@ -263,7 +263,7 @@ func (ed *IATEntryDetail) fieldInclusion() error {
 			Msg:       msgFieldInclusion + ", did you use NewIATEntryDetail()?",
 		}
 	}
-	if ed.TraceNumber == 0 {
+	if ed.TraceNumber == "" {
 		return &FieldError{
 			FieldName: "TraceNumber",
 			Value:     ed.TraceNumberField(),
@@ -283,8 +283,7 @@ func (ed *IATEntryDetail) SetRDFI(rdfi string) *IATEntryDetail {
 
 // SetTraceNumber takes first 8 digits of ODFI and concatenates a sequence number onto the TraceNumber
 func (ed *IATEntryDetail) SetTraceNumber(ODFIIdentification string, seq int) {
-	trace := ed.stringField(ODFIIdentification, 8) + ed.numericField(seq, 7)
-	ed.TraceNumber = ed.parseNumField(trace)
+	ed.TraceNumber = ed.stringField(ODFIIdentification, 8) + ed.numericField(seq, 7)
 }
 
 // RDFIIdentificationField get the rdfiIdentification with zero padding
@@ -292,7 +291,7 @@ func (ed *IATEntryDetail) RDFIIdentificationField() string {
 	return ed.stringField(ed.RDFIIdentification, 8)
 }
 
-// AddendaRecordsField returns a zero padded TraceNumber string
+// AddendaRecordsField returns a zero padded AddendaRecords string
 func (ed *IATEntryDetail) AddendaRecordsField() string {
 	return ed.numericField(ed.AddendaRecords, 4)
 }
@@ -328,7 +327,7 @@ func (ed *IATEntryDetail) SecondaryOFACSreeningIndicatorField() string {
 
 // TraceNumberField returns a zero padded TraceNumber string
 func (ed *IATEntryDetail) TraceNumberField() string {
-	return ed.numericField(ed.TraceNumber, 15)
+	return ed.stringField(ed.TraceNumber, 15)
 }
 
 // AddAddenda17 appends an Addenda17 to the IATEntryDetail

--- a/iatEntryDetail_test.go
+++ b/iatEntryDetail_test.go
@@ -56,7 +56,7 @@ func testMockIATEntryDetail(t testing.TB) {
 	if entry.Amount != 100000 {
 		t.Error("Amount dependent default value has changed")
 	}
-	if entry.TraceNumber != 231380100000001 {
+	if entry.TraceNumber != "231380100000001" {
 		t.Errorf("TraceNumber dependent default value has changed %v", entry.TraceNumber)
 	}
 }
@@ -452,7 +452,7 @@ func BenchmarkIATEDDFIAccountNumber(b *testing.B) {
 // testIATEDTraceNumber validates IATEntryDetail TraceNumber fieldInclusion
 func testIATEDTraceNumber(t testing.TB) {
 	iatEd := mockIATEntryDetail()
-	iatEd.TraceNumber = 0
+	iatEd.TraceNumber = "0"
 	if err := iatEd.Validate(); err != nil {
 		if e, ok := err.(*FieldError); ok {
 			if e.FieldName != "TraceNumber" {

--- a/reader_test.go
+++ b/reader_test.go
@@ -695,7 +695,7 @@ func testFileAddenda98invalid(t testing.TB) {
 	bh := mockBatchPPDHeader()
 	ed := mockPPDEntryDetail()
 	addenda98 := mockAddenda98()
-	addenda98.TraceNumber = 0000001
+	addenda98.TraceNumber = "0000001"
 	addenda98.ChangeCode = "C50"
 	addenda98.CorrectedData = "ACME One Corporation"
 	ed.Category = CategoryNOC
@@ -736,7 +736,7 @@ func testFileAddenda98(t testing.TB) {
 	bh := mockBatchHeader()
 	ed := mockEntryDetail()
 	addenda98 := mockAddenda98()
-	addenda98.TraceNumber = 0000001
+	addenda98.TraceNumber = "0000001"
 	addenda98.ChangeCode = "C10"
 	addenda98.CorrectedData = "ACME One Corporation"
 	ed.Category = CategoryNOC
@@ -777,7 +777,7 @@ func testFileAddenda99invalid(t testing.TB) {
 	bh := mockBatchPPDHeader()
 	ed := mockPPDEntryDetail()
 	addenda99 := mockAddenda99()
-	addenda99.TraceNumber = 0000001
+	addenda99.TraceNumber = "0000001"
 	addenda99.ReturnCode = "100"
 	ed.Category = CategoryReturn
 	ed.Addenda99 = addenda99
@@ -817,7 +817,7 @@ func testFileAddenda99(t testing.TB) {
 	bh := mockBatchHeader()
 	ed := mockEntryDetail()
 	addenda99 := mockAddenda99()
-	addenda99.TraceNumber = 0000001
+	addenda99.TraceNumber = "0000001"
 	addenda99.ReturnCode = "R02"
 	ed.Category = CategoryReturn
 	ed.Addenda99 = addenda99

--- a/test/ach-pos-write/main.go
+++ b/test/ach-pos-write/main.go
@@ -53,7 +53,7 @@ func main() {
 	addenda02.TerminalLocation = "Target Store 0049"
 	addenda02.TerminalCity = "PHILADELPHIA"
 	addenda02.TerminalState = "PA"
-	addenda02.TraceNumber = 121042880000001
+	addenda02.TraceNumber = "121042880000001"
 
 	// build the batch
 	batch := ach.NewBatchPOS(bh)

--- a/test/ach-shr-write/main.go
+++ b/test/ach-shr-write/main.go
@@ -55,7 +55,7 @@ func main() {
 	addenda02.TerminalLocation = "Target Store 0049"
 	addenda02.TerminalCity = "PHILADELPHIA"
 	addenda02.TerminalState = "PA"
-	addenda02.TraceNumber = 121042880000001
+	addenda02.TraceNumber = "121042880000001"
 
 	// build the batch
 	batch := ach.NewBatchSHR(bh)

--- a/test/testdata/ppd-valid.json
+++ b/test/testdata/ppd-valid.json
@@ -35,7 +35,7 @@
                     "individualName": "Steven Tander         ",
                     "discretionaryData": "  ",
                     "addendaRecordIndicator": 1,
-                    "traceNumber": 121042880000001,
+                    "traceNumber": "121042880000001",
                     "category": "Forward"
                 }
             ],


### PR DESCRIPTION
Having these values as `int`'s exposes bugs (leading zero gets truncated). 

Issue: https://github.com/moov-io/ach/issues/366