### PR TITLE
docs: mention Validate method in records with Parse

### DIFF
--- a/addenda02.go
+++ b/addenda02.go
@@ -61,6 +61,8 @@ func NewAddenda02() *Addenda02 {
 }
 
 // Parse takes the input record string and parses the Addenda02 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda02 *Addenda02) Parse(record string) {
 	// 1-1 Always "7"
 	addenda02.recordType = "7"

--- a/addenda05.go
+++ b/addenda05.go
@@ -45,6 +45,8 @@ func NewAddenda05() *Addenda05 {
 }
 
 // Parse takes the input record string and parses the Addenda05 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda05 *Addenda05) Parse(record string) {
 	// 1-1 Always "7"
 	addenda05.recordType = "7"

--- a/addenda10.go
+++ b/addenda10.go
@@ -58,6 +58,8 @@ func NewAddenda10() *Addenda10 {
 }
 
 // Parse takes the input record string and parses the Addenda10 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda10 *Addenda10) Parse(record string) {
 	// 1-1 Always "7"
 	addenda10.recordType = "7"

--- a/addenda11.go
+++ b/addenda11.go
@@ -49,6 +49,8 @@ func NewAddenda11() *Addenda11 {
 }
 
 // Parse takes the input record string and parses the Addenda11 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda11 *Addenda11) Parse(record string) {
 	// 1-1 Always "7"
 	addenda11.recordType = "7"

--- a/addenda12.go
+++ b/addenda12.go
@@ -54,6 +54,8 @@ func NewAddenda12() *Addenda12 {
 }
 
 // Parse takes the input record string and parses the Addenda12 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda12 *Addenda12) Parse(record string) {
 	// 1-1 Always "7"
 	addenda12.recordType = "7"

--- a/addenda13.go
+++ b/addenda13.go
@@ -70,6 +70,8 @@ func NewAddenda13() *Addenda13 {
 }
 
 // Parse takes the input record string and parses the Addenda13 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda13 *Addenda13) Parse(record string) {
 	// 1-1 Always "7"
 	addenda13.recordType = "7"

--- a/addenda14.go
+++ b/addenda14.go
@@ -66,6 +66,8 @@ func NewAddenda14() *Addenda14 {
 }
 
 // Parse takes the input record string and parses the Addenda14 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda14 *Addenda14) Parse(record string) {
 	// 1-1 Always "7"
 	addenda14.recordType = "7"

--- a/addenda15.go
+++ b/addenda15.go
@@ -50,6 +50,8 @@ func NewAddenda15() *Addenda15 {
 }
 
 // Parse takes the input record string and parses the Addenda15 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda15 *Addenda15) Parse(record string) {
 	// 1-1 Always "7"
 	addenda15.recordType = "7"

--- a/addenda16.go
+++ b/addenda16.go
@@ -53,6 +53,8 @@ func NewAddenda16() *Addenda16 {
 }
 
 // Parse takes the input record string and parses the Addenda16 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda16 *Addenda16) Parse(record string) {
 	// 1-1 Always "7"
 	addenda16.recordType = "7"

--- a/addenda17.go
+++ b/addenda17.go
@@ -49,6 +49,8 @@ func NewAddenda17() *Addenda17 {
 }
 
 // Parse takes the input record string and parses the Addenda17 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda17 *Addenda17) Parse(record string) {
 	// 1-1 Always "7"
 	addenda17.recordType = "7"

--- a/addenda18.go
+++ b/addenda18.go
@@ -67,6 +67,8 @@ func NewAddenda18() *Addenda18 {
 }
 
 // Parse takes the input record string and parses the Addenda18 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda18 *Addenda18) Parse(record string) {
 	// 1-1 Always "7"
 	addenda18.recordType = "7"

--- a/addenda98.go
+++ b/addenda98.go
@@ -67,6 +67,8 @@ func NewAddenda98() *Addenda98 {
 }
 
 // Parse takes the input record string and parses the Addenda98 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (addenda98 *Addenda98) Parse(record string) {
 	// 1-1 Always "7"
 	addenda98.recordType = "7"

--- a/addenda99.go
+++ b/addenda99.go
@@ -77,6 +77,8 @@ func NewAddenda99() *Addenda99 {
 }
 
 // Parse takes the input record string and parses the Addenda99 values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (Addenda99 *Addenda99) Parse(record string) {
 	// 1-1 Always "7"
 	Addenda99.recordType = "7"

--- a/batchControl.go
+++ b/batchControl.go
@@ -72,6 +72,8 @@ type BatchControl struct {
 }
 
 // Parse takes the input record string and parses the EntryDetail values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (bc *BatchControl) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -118,6 +118,8 @@ func NewBatchHeader() *BatchHeader {
 }
 
 // Parse takes the input record string and parses the BatchHeader values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (bh *BatchHeader) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -103,6 +103,8 @@ func NewEntryDetail() *EntryDetail {
 }
 
 // Parse takes the input record string and parses the EntryDetail values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (ed *EntryDetail) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/file.go
+++ b/file.go
@@ -94,6 +94,9 @@ type fileControl struct {
 // FileFromJson attempts to return a *File object assuming the input is valid JSON.
 //
 // Callers should always check for a nil-error before using the returned file.
+//
+// The File returned may not be valid and callers should confirm with Validate(). Invalid files may
+// be rejected by other Financial Institutions or ACH tools.
 func FileFromJson(bs []byte) (*File, error) {
 	if len(bs) == 0 {
 		return nil, errors.New("no JSON data provided")

--- a/fileControl.go
+++ b/fileControl.go
@@ -45,6 +45,8 @@ type FileControl struct {
 }
 
 // Parse takes the input record string and parses the FileControl values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (fc *FileControl) Parse(record string) {
 	if utf8.RuneCountInString(record) < 55 {
 		return

--- a/fileHeader.go
+++ b/fileHeader.go
@@ -107,6 +107,8 @@ func NewFileHeader() FileHeader {
 }
 
 // Parse takes the input record string and parses the FileHeader values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (fh *FileHeader) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/iatBatchHeader.go
+++ b/iatBatchHeader.go
@@ -170,6 +170,8 @@ func NewIATBatchHeader() *IATBatchHeader {
 }
 
 // Parse takes the input record string and parses the BatchHeader values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (iatBh *IATBatchHeader) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -131,6 +131,8 @@ func NewIATEntryDetail() *IATEntryDetail {
 }
 
 // Parse takes the input record string and parses the EntryDetail values
+//
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
 func (ed *IATEntryDetail) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/reader.go
+++ b/reader.go
@@ -148,6 +148,9 @@ func NewReader(r io.Reader) *Reader {
 // Read reads each line of the ACH file and defines which parser to use based
 // on the first character of each line. It also enforces ACH formatting rules and returns
 // the appropriate error if issues are found.
+//
+// A parsed file may not be valid and callers should confirm with Validate(). Invalid files may
+// be rejected by other Financial Institutions or ACH tools.
 func (r *Reader) Read() (File, error) {
 	r.lineNum = 0
 	// read through the entire file


### PR DESCRIPTION
Brooke and I talked about Parse returning an error, but there only
seems to be one check that could error. The other errors (related to
invalid files and blank struct members) are checked by Validate.