### PR TITLE
all: mention TraceNumberField() in TraceNumber struct members

### DIFF
--- a/addenda02.go
+++ b/addenda02.go
@@ -45,6 +45,8 @@ type Addenda02 struct {
 	// TerminalState Identifies the state in which the electronic terminal is located
 	TerminalState string `json:"terminalState"`
 	// TraceNumber Standard Entry Detail Trace Number
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber int `json:"traceNumber,omitempty"`
 	// validator is composed for data validation
 	validator

--- a/addenda98.go
+++ b/addenda98.go
@@ -30,6 +30,8 @@ type Addenda98 struct {
 	// CorrectedData
 	CorrectedData string `json:"correctedData"`
 	// TraceNumber matches the Entry Detail Trace Number of the entry being returned.
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber int `json:"traceNumber,omitempty"`
 
 	// validator is composed for data validation

--- a/addenda99.go
+++ b/addenda99.go
@@ -52,6 +52,8 @@ type Addenda99 struct {
 	// AddendaInformation
 	AddendaInformation string `json:"addendaInformation,omitempty"`
 	// TraceNumber matches the Entry Detail Trace Number of the entry being returned.
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber int `json:"traceNumber,omitempty"`
 
 	// validator is composed for data validation

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -66,6 +66,8 @@ type EntryDetail struct {
 	// For addenda Records, the Trace Number will be identical to the Trace Number
 	// in the associated Entry Detail Record, since the Trace Number is associated
 	// with an entry or item rather than a physical record.
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber int `json:"traceNumber,omitempty"`
 	// Addenda02 for use with StandardEntryClassCode MTE, POS, and SHR
 	Addenda02 *Addenda02 `json:"addenda02,omitempty"`

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -62,6 +62,8 @@ type IATEntryDetail struct {
 	// For addenda Records, the Trace Number will be identical to the Trace Number
 	// in the associated Entry Detail Record, since the Trace Number is associated
 	// with an entry or item rather than a physical record.
+	//
+	// Use TraceNumberField() for a properly formatted string representation.
 	TraceNumber int `json:"traceNumber,omitempty"`
 	// Addenda10 is mandatory for IAT entries
 	//


### PR DESCRIPTION
This should point users towards getting the proper value rather than using the int (which has known bugs).

Issue: https://github.com/moov-io/ach/issues/366