### PR TITLE
batch: tabulate on build/create calls

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -50,7 +50,7 @@ func (e *BatchError) Error() string {
 var (
 	// generic messages
 	msgBatchHeaderControlEquality     = "header %v is not equal to control %v"
-	msgBatchCalculatedControlEquality = "calculated %v is out-of-balance with control %v"
+	msgBatchCalculatedControlEquality = "calculated %v is out-of-balance with batch control %v"
 	msgBatchAscending                 = "%v is less than last %v. Must be in ascending order"
 	// specific messages for error
 	msgBatchCompanyEntryDescription = "Company entry description %v is not valid for batch type %v"

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -497,3 +497,22 @@ func (ed *EntryDetail) CreditOrDebit() string {
 func (ed *EntryDetail) AddAddenda05(addenda05 *Addenda05) {
 	ed.Addenda05 = append(ed.Addenda05, addenda05)
 }
+
+// addendaCount returns the count of Addenda records added onto this EntryDetail
+func (ed *EntryDetail) addendaCount() (n int) {
+	if ed.Addenda02 != nil {
+		n += 1
+	}
+	for i := range ed.Addenda05 {
+		if ed.Addenda05[i] != nil {
+			n += 1
+		}
+	}
+	if ed.Addenda98 != nil {
+		n += 1
+	}
+	if ed.Addenda99 != nil {
+		n += 1
+	}
+	return n
+}

--- a/file_test.go
+++ b/file_test.go
@@ -401,6 +401,14 @@ func TestFile__readFromJson(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Ensure the file is valid
+	if err := file.Create(); err != nil {
+		t.Error(err)
+	}
+	if err := file.Validate(); err != nil {
+		t.Error(err)
+	}
+
 	if file.ID != "adam-01" {
 		t.Errorf("file.ID: %s", file.ID)
 	}
@@ -422,7 +430,7 @@ func TestFile__readFromJson(t *testing.T) {
 	}
 	batch := file.Batches[0]
 	batchControl := batch.GetControl()
-	if batchControl.EntryAddendaCount != 2 {
+	if batchControl.EntryAddendaCount != 1 {
 		t.Errorf("EntryAddendaCount: %d", batchControl.EntryAddendaCount)
 	}
 
@@ -430,7 +438,7 @@ func TestFile__readFromJson(t *testing.T) {
 	if file.Control.BatchCount != 1 {
 		t.Errorf("BatchCount: %d", file.Control.BatchCount)
 	}
-	if file.Control.EntryAddendaCount != 2 {
+	if file.Control.EntryAddendaCount != 1 {
 		t.Errorf("File Control EntryAddendaCount: %d", file.Control.EntryAddendaCount)
 	}
 	if file.Control.TotalDebitEntryDollarAmountInFile != 0 || file.Control.TotalCreditEntryDollarAmountInFile != 100000 {
@@ -446,5 +454,31 @@ func TestFile__readFromJson(t *testing.T) {
 
 	if err := file.Validate(); err != nil {
 		t.Error(err)
+	}
+}
+
+// TestFile__jsonFileNoControlBlobs will read an ach.File from its JSON form, but the JSON has no
+// batchControl or fileControl sub-objects.
+func TestFile__jsonFileNoControlBlobs(t *testing.T) {
+	path := filepath.Join("test", "testdata", "ppd-no-control-blobs-valid.json")
+	bs, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := FileFromJSON(bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := file.Create(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	if file.ID != "adam-01" {
+		t.Errorf("file.ID: %s", file.ID)
 	}
 }

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+([-a-zA-Z0-9]*)?)' vers
 build:
 	go fmt ./...
 	@mkdir -p ./bin/
+	go build github.com/moov-io/ach
 	CGO_ENABLED=0 go build -o ./bin/server github.com/moov-io/ach/cmd/server
 
 generate: clean

--- a/reader.go
+++ b/reader.go
@@ -151,7 +151,7 @@ func NewReader(r io.Reader) *Reader {
 // on the first character of each line. It also enforces ACH formatting rules and returns
 // the appropriate error if issues are found.
 //
-// A parsed file may not be valid and callers should confirm with Validate(). Invalid files may
+// A parsed file may not be valid and callers should confirm with Create() Validate(). Invalid files may
 // be rejected by other Financial Institutions or ACH tools.
 func (r *Reader) Read() (File, error) {
 	r.lineNum = 0

--- a/test/testdata/ppd-no-control-blobs-valid.json
+++ b/test/testdata/ppd-no-control-blobs-valid.json
@@ -34,34 +34,23 @@
                     "identificationNumber": "#83738AB#      ",
                     "individualName": "Steven Tander         ",
                     "discretionaryData": "  ",
-                    "addendaRecordIndicator": 0,
+                    "addendaRecordIndicator": 1,
                     "traceNumber": "121042880000001",
-                    "category": "Forward"
+                    "category": "Forward",
+                    "addenda05": [
+                      {
+                        "entryDetailSequenceNumber": 1,
+                        "sequenceNumber": 1,
+                        "paymentRelatedInformation": "Bonus for working on #OSS!",
+                        "typeCode": "",
+                        "id": "gvluehibyuuqdoajiqfn"
+                      }
+                    ]
                 }
-            ],
-            "batchControl": {
-                "id": "adam-01",
-                "serviceClassCode": 200,
-                "entryAddendaÇount": 0,
-                "entryHash": 23138010,
-                "totalDebit": 0,
-                "totalCredit": 100000,
-                "companyIdentification": "121042882",
-                "ODFIIdentification": "12104288",
-                "batchNumber": 1
-            }
+            ]
         }
     ],
     "IATBatches": null,
-    "fileControl": {
-        "id": "adam-01",
-        "batchCount": 1,
-        "blockCount": 1,
-        "entryAddendaCount": 0,
-        "entryHash": 23138010,
-        "totalDebit": 0,
-        "totalCredit": 100000
-    },
     "NotificationOfChange": null,
     "ReturnEntries": null
 }


### PR DESCRIPTION
This change gets rid of the requirements to provide a `batchControl` and/or `fileControl` objects in the JSON for an `ach.File` object. 

Part of: https://github.com/moov-io/moov-io/pull/12