### PR TITLE
build: use -mod=vendor to always pickup vendor/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
 env:
   global:
     secure: QPkcX77j8QEqTwOYyLGItqvxYwE6Na5WaSZWjmhp48OlxYatWRHxJBwcFYSn1OWD5FMn+3oW39fHknReIxtrnhXMaNvI7x3/0gy4zujD/xZ2xAg7NsQ+l5buvEFO8/LEwwo0fp4knItFcBv8xH/ziJBJyXvgfMtj7Is4Q/pB1p6pWDdVy1vtAj3zH02bcqh1yXXS3HvcD8UhTszfU017gVNXDN1ow0rp1L3ainr3btrVK9izUxZfKvb7PlWJO1ogah7xNr/dIOJLsx2SfKgzKp+3H28L2WegtbzON74Op4jXvRywCwqjmUt/nwJ/Y9anunMNHT136h+ye4ziG1i/VdbWq0Q4PopQ8yYqinujG7SjfQio+wNCV2cwc2r/WjNBjbH0N9/Pflogq3RHvgy/9VtPif1tY+RrZCSntohoEZbYpVcFQFE1xDyf6xq/uLxVeEcCU33gqq7cKEfpcUgyCITa+yCPfBdtgkLBJ8h7Sew1j08D1kTKUW6g3D1epmwlCh/Z16oHG5VwSnCLGDjJy8wm/hQk1i/g7qeP7g24CfNzffzlFBCy88HhjzmrhUpcaTyfVVDf4h8wK6Zu/J3dHjHXQYwfiQRqpMa+2DYyjGgZhniccuh4GWolGZauDQdmO9SD4Ugyt9PEMk02i32ax3A4XE/Q6VNOam+qszviX3Q=
+  matrix:
+    - GO111MODULE=auto
 before_install:
 - go get -u github.com/client9/misspell/cmd/misspell
 - go get -u golang.org/x/lint/golint
@@ -32,5 +34,5 @@ script:
 - golint -set_exit_status $GOFILES
 - megacheck ./...
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
-  - make docker
+- bash <(curl -s https://codecov.io/bash)
+- make docker

--- a/makefile
+++ b/makefile
@@ -5,9 +5,9 @@ VERSION := $(shell grep -Eo '(v[0-9]+[\.][0-9]+[\.][0-9]+([-a-zA-Z0-9]*)?)' vers
 build:
 	go fmt ./...
 	@mkdir -p ./bin/
-	go build github.com/moov-io/ach
-	go build -o bin/examples-http github.com/moov-io/ach/examples/http
-	CGO_ENABLED=0 go build -o ./bin/server github.com/moov-io/ach/cmd/server
+	go build -mod=vendor github.com/moov-io/ach
+	go build -o bin/examples-http -mod=vendor github.com/moov-io/ach/examples/http
+	CGO_ENABLED=0 go build -o ./bin/server -mod=vendor github.com/moov-io/ach/cmd/server
 
 generate: clean
 	@go run internal/iso3166/iso3166_gen.go
@@ -21,7 +21,7 @@ docker: clean
 	docker tag moov/ach:$(VERSION) moov/ach:latest
 
 release: docker generate AUTHORS
-	go test ./...
+	go test ./... -mod=vendor
 	git tag -f $(VERSION)
 
 release-push:


### PR DESCRIPTION
The use of `vendor/` depends on `GO111MODULE`'s value. (environment variable) 

if `GO111MODULE=on` then `go` uses the module cache, which means Go will download all those deps, even though they're in the project. 