### PR TITLE
server: assign a random ID to File's without one during Create

### DIFF
--- a/server/common.go
+++ b/server/common.go
@@ -1,0 +1,25 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package server
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+)
+
+// NextID generates a new resource ID.
+// Do not assume anything about the data structure.
+//
+// Multiple calls to NextID() have no concern about producing
+// lexicographically ordered output.
+func NextID() string {
+	bs := make([]byte, 20)
+	rand.Reader.Read(bs)
+
+	h := sha1.New()
+	h.Write(bs)
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}

--- a/server/files.go
+++ b/server/files.go
@@ -47,19 +47,15 @@ func createFileEndpoint(s Service, r Repository) endpoint.Endpoint {
 			filesCreated.With("destination", req.File.Header.ImmediateDestination, "origin", req.File.Header.ImmediateOrigin).Add(1)
 		}
 
+		// Create a random file ID if none was provided
 		if req.File.ID == "" {
-			// No File ID, so create the file
-			id, e := s.CreateFile(&req.File.Header)
-			return createFileResponse{
-				ID:  id,
-				Err: e,
-			}, nil
-		} else {
-			return createFileResponse{
-				ID:  req.File.ID,
-				Err: r.StoreFile(req.File),
-			}, nil
+			req.File.ID = NextID()
 		}
+
+		return createFileResponse{
+			ID:  req.File.ID,
+			Err: r.StoreFile(req.File),
+		}, nil
 	}
 }
 

--- a/server/service.go
+++ b/server/service.go
@@ -6,9 +6,6 @@ package server
 
 import (
 	"bytes"
-	"crypto/rand"
-	"crypto/sha1"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -164,18 +161,4 @@ func (s *service) GetBatches(fileID string) []ach.Batcher {
 
 func (s *service) DeleteBatch(fileID string, batchID string) error {
 	return s.store.DeleteBatch(fileID, batchID)
-}
-
-// NextID generates a new resource ID.
-// Do not assume anything about the data structure.
-//
-// Multiple calls to NextID() have no concern about producing
-// lexicographically ordered output.
-func NextID() string {
-	bs := make([]byte, 20)
-	rand.Reader.Read(bs)
-
-	h := sha1.New()
-	h.Write(bs)
-	return hex.EncodeToString(h.Sum(nil))[:16]
 }


### PR DESCRIPTION
Previously we were only reading out the `FileHeader` which meant any `Batch` objects weren't included in the stored file. 

Issue: https://github.com/moov-io/ach/issues/401