### PR TITLE
server: add TTL config for expiring old Files from in-mem repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Examples: [Go](examples/http/main.go) | [Ruby](https://github.com/moov-io/ruby-a
 - [Running ACH Server](https://docs.moov.io/en/latest/tutorials/ach-server/)
 - [ACH Server metrics](documentation/metrics.md)
 
+### Configuration
+
+| Environmental Variable | Description | Default |
+|-----|-----|-----|
+| `ACH_FILE_TTL` | Time to live (TTL) for `*ach.File` objects stored in the in-memory repository. | 0 = No TTL / Never delete files |
+
 ### From Source
 
 This project uses [Go Modules](https://github.com/golang/go/wiki/Modules) and thus requires Go 1.11+. You can download the source code and we offer [tagged and released versions](https://github.com/moov-io/ach/releases) as well. We highly recommend you use a tagged release for production.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,7 +69,15 @@ func main() {
 	logger.Log("startup", fmt.Sprintf("Starting ach server version %s", ach.Version))
 
 	// Setup underlying ach service
-	r := server.NewRepositoryInMemory()
+	var achFileTTL time.Duration
+	if v := os.Getenv("ACH_FILE_TTL"); v != "" {
+		dur, err := time.ParseDuration(v)
+		if err == nil {
+			achFileTTL = dur
+			logger.Log("main", fmt.Sprintf("Using %v as ach.File TTL", achFileTTL))
+		}
+	}
+	r := server.NewRepositoryInMemory(achFileTTL)
 	svc = server.NewService(r)
 
 	// Create HTTP server

--- a/server/batches_test.go
+++ b/server/batches_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFiles__createBatchEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -27,7 +27,7 @@ func TestFiles__createBatchEndpoint(t *testing.T) {
 }
 
 func TestFiles__getBatchesEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -43,7 +43,7 @@ func TestFiles__getBatchesEndpoint(t *testing.T) {
 }
 
 func TestFiles__getBatchEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -59,7 +59,7 @@ func TestFiles__getBatchEndpoint(t *testing.T) {
 }
 
 func TestFiles__deleteBatchEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFiles__createFileEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -28,7 +28,7 @@ func TestFiles__createFileEndpoint(t *testing.T) {
 }
 
 func TestFiles__getFilesEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -41,7 +41,7 @@ func TestFiles__getFilesEndpoint(t *testing.T) {
 }
 
 func TestFiles__getFileEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -58,7 +58,7 @@ func TestFiles__getFileEndpoint(t *testing.T) {
 }
 
 func TestFiles__getFileContentsEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -75,7 +75,7 @@ func TestFiles__getFileContentsEndpoint(t *testing.T) {
 }
 
 func TestFiles__validateFileEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory()
+	repo := NewRepositoryInMemory(testTTLDuration)
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)

--- a/server/mock_test.go
+++ b/server/mock_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func mockServiceInMemory() Service {
-	repository := NewRepositoryInMemory()
+	repository := NewRepositoryInMemory(testTTLDuration)
 	repository.StoreFile(&ach.File{ID: "98765"})
 	repository.StoreBatch("98765", mockBatchWEB())
 	return NewService(repository)

--- a/server/repository_test.go
+++ b/server/repository_test.go
@@ -6,12 +6,17 @@ package server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/moov-io/ach"
 )
 
+var (
+	testTTLDuration = 0 * time.Second // disable TTL expiry
+)
+
 func TestRepositoryFiles(t *testing.T) {
-	r := NewRepositoryInMemory()
+	r := NewRepositoryInMemory(testTTLDuration)
 
 	if v := len(r.FindAllFiles()); v != 0 {
 		t.Errorf("unexpected length: %d", v)
@@ -41,7 +46,7 @@ func TestRepositoryFiles(t *testing.T) {
 }
 
 func TestRepositoryBatches(t *testing.T) {
-	r := NewRepositoryInMemory()
+	r := NewRepositoryInMemory(testTTLDuration)
 
 	// make sure our tests are setup
 	if v := len(r.FindAllFiles()); v != 0 {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -82,7 +82,7 @@ func TestServer__CreateFileEndpoint(t *testing.T) {
 			t.Fatalf("file %s had error against HTTP decode: %v", file.ACHFilepath, err)
 		}
 
-		repo := NewRepositoryInMemory()
+		repo := NewRepositoryInMemory(testTTLDuration)
 		s := NewService(repo)
 
 		endpoint := createFileEndpoint(s, repo, nil) // nil logger

--- a/test/server-example/main.go
+++ b/test/server-example/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/moov-io/ach/server"
 
@@ -17,7 +18,7 @@ import (
 
 func TestServer__CreateFile(t *testing.T) {
 	// Local server setup - usually ach would be running on another machine.
-	repo := server.NewRepositoryInMemory()
+	repo := server.NewRepositoryInMemory(24 * time.Hour)
 	service := server.NewService(repo)
 	logger := log.NewLogfmtLogger(os.Stderr)
 	handler := server.MakeHTTPHandler(service, repo, logger)


### PR DESCRIPTION
We're seeing lots of test files accumulate and so we should provide a way to expire old files.

Issue: https://github.com/moov-io/ach/issues/275