### PR TITLE
internal: use filepath.Join for cross-platform paths in codegen

### DIFF
--- a/internal/iso3166/iso3166.go
+++ b/internal/iso3166/iso3166.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
 
-// Generated on 2018-11-06T03:52:02Z by adam, any modifications will be overwritten
+// Generated on 2019-01-21T12:30:39Z by adam, any modifications will be overwritten
 package iso3166
 
 var countryCodes = map[string]bool{

--- a/internal/iso3166/iso3166_gen.go
+++ b/internal/iso3166/iso3166_gen.go
@@ -25,15 +25,15 @@ import (
 	"log"
 	"net/http"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"time"
 )
 
-const (
+var (
 	// From https://datahub.io/core/country-list#data
-	downloadUrl = "https://datahub.io/core/country-list/r/data.json"
-
-	outputFilename = "internal/iso3166/iso3166.go"
+	downloadUrl    = "https://datahub.io/core/country-list/r/data.json"
+	outputFilename = filepath.Join("internal", "iso3166", "iso3166.go")
 )
 
 // [{"Code": "AF", "Name": "Afghanistan"}, ...]

--- a/internal/iso4217/iso4217.go
+++ b/internal/iso4217/iso4217.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an Apache License
 // license that can be found in the LICENSE file.
 
-// Generated on 2018-11-06T03:52:05Z by adam, any modifications will be overwritten
+// Generated on 2019-01-21T12:30:42Z by adam, any modifications will be overwritten
 package iso4217
 
 var currencyCodes = map[string]bool{

--- a/internal/iso4217/iso4217_gen.go
+++ b/internal/iso4217/iso4217_gen.go
@@ -25,14 +25,14 @@ import (
 	"log"
 	"net/http"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"time"
 )
 
-const (
-	downloadUrl = "https://datahub.io/core/currency-codes/r/codes-all.json"
-
-	outputFilename = "internal/iso4217/iso4217.go"
+var (
+	downloadUrl    = "https://datahub.io/core/currency-codes/r/codes-all.json"
+	outputFilename = filepath.Join("internal", "iso4217", "iso4217.go")
 )
 
 // {"AlphabeticCode": "AFN", "Currency": "Afghani", ... }


### PR DESCRIPTION
Noticed during https://github.com/moov-io/gl/pull/3 