### PR TITLE
Add maximum lines per file limit to reader

### DIFF
--- a/file.go
+++ b/file.go
@@ -39,6 +39,7 @@ var (
 	msgFileNoneSEC       = "%v Standard Entry Class Code is not implemented"
 	msgFileIATSEC        = "%v Standard Entry Class Code should use iatBatch"
 	msgFileADV           = "file can only have ADV Batches"
+	msgFileTooLong       = "file has exceeded the maximum possible number of lines"
 )
 
 // FileError is an error describing issues validating a file


### PR DESCRIPTION
Fixes https://github.com/moov-io/ach/issues/413

The maximum number of lines is limited by the EntryAddendaCount field which has 8 digits, and the BatchCount field which has 6 digits in the File Control Record. So we can have at most the 2 file records, 2 records for each of 10^6 batches, 10^8 entry and addenda records, and 8 lines of 9's to round it up to the nearest multiple of 10.

If this limit is exceeded, `Read()` returns a `FileTooLong` error.