### PR TITLE
Proof of concept for type-based error handling

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - "*Error.go"  # ignore error files

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,4 +26,4 @@ comment:
   require_changes: no
 
 ignore:
-  - "*Error.go"  # ignore error files
+  - "*Errors.go"  # ignore error files

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ script:
 - golint -set_exit_status $GOFILES
 - staticcheck ./...
 after_success:
-- bash <(curl -s https://codecov.io/bash) -X fix
+- bash <(curl -s https://codecov.io/bash)
 - make docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ script:
 - golint -set_exit_status $GOFILES
 - staticcheck ./...
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+- bash <(curl -s https://codecov.io/bash) -X fix
 - make docker

--- a/batch.go
+++ b/batch.go
@@ -157,8 +157,7 @@ func NewBatch(bh *BatchHeader) (Batcher, error) {
 	case ENR:
 		return NewBatchENR(bh), nil
 	case IAT:
-		msg := fmt.Sprintf(msgFileIATSEC, bh.StandardEntryClassCode)
-		return nil, &FileError{FieldName: "StandardEntryClassCode", Value: bh.StandardEntryClassCode, Msg: msg}
+		return nil, ErrFileIATSEC
 	case MTE:
 		return NewBatchMTE(bh), nil
 	case POP:
@@ -183,8 +182,7 @@ func NewBatch(bh *BatchHeader) (Batcher, error) {
 		return NewBatchXCK(bh), nil
 	default:
 	}
-	msg := fmt.Sprintf(msgFileNoneSEC, bh.StandardEntryClassCode)
-	return nil, &FileError{FieldName: "StandardEntryClassCode", Value: bh.StandardEntryClassCode, Msg: msg}
+	return nil, NewErrFileUnknownSEC(bh.StandardEntryClassCode)
 }
 
 // Create will tabulate and assemble an ACH batch into a valid state. This includes

--- a/batch_test.go
+++ b/batch_test.go
@@ -456,11 +456,7 @@ func BenchmarkBatchAddendaTraceNumber(b *testing.B) {
 func testNewBatchDefault(t testing.TB) {
 	_, err := NewBatch(mockBatchInvalidSECHeader())
 
-	if e, ok := err.(*FileError); ok {
-		if e.FieldName != "StandardEntryClassCode" {
-			t.Errorf("%T: %s", err, err)
-		}
-	} else {
+	if err != NewErrFileUnknownSEC("NIL") {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -698,11 +694,7 @@ func testIATBatch(t testing.TB) {
 
 	_, err := NewBatch(bh)
 
-	if e, ok := err.(*FileError); ok {
-		if e.FieldName != "StandardEntryClassCode" {
-			t.Errorf("%T: %s", err, err)
-		}
-	} else {
+	if err != ErrFileIATSEC {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/fileErrors.go
+++ b/fileErrors.go
@@ -12,8 +12,26 @@ import (
 	"github.com/moov-io/base"
 )
 
-// ErrFileTooLong is the error given when a file exceeds the maximum possible length
-var ErrFileTooLong = errors.New("file exceeds maximum possible number of lines")
+var (
+	// ErrFileTooLong is the error given when a file exceeds the maximum possible length
+	ErrFileTooLong = errors.New("file exceeds maximum possible number of lines")
+	// ErrFileHeader is the error given if there is the wrong number of file headers
+	ErrFileHeader = errors.New("none or more than one file headers exists")
+	// ErrFileControl is the error given if there is the wrong number of file control records
+	ErrFileControl = errors.New("none or more than one file control exists")
+	// ErrFileEntryOutsideBatch is the error given if an entry is outside of a batch
+	ErrFileEntryOutsideBatch = errors.New("entry outside of batch")
+	// ErrFileAddendaOutsideEntry is the error given if an addenda is outside of an entry
+	ErrFileAddendaOutsideEntry = errors.New("addenda outside of entry")
+	// ErrFileBatchControlOutsideBatch is the error given if a batch control record is outside of a batch
+	ErrFileBatchControlOutsideBatch = errors.New("batch control outside of batch")
+	// ErrFileBatchHeaderInsideBatch is the error given if a batch header record is inside of a batch
+	ErrFileBatchHeaderInsideBatch = errors.New("batch header inside of batch")
+	// ErrFileADVOnly is the error given if an ADV only file has a non-ADV batch
+	ErrFileADVOnly = errors.New("file can only have ADV Batches")
+	// ErrFileIATSEC is the error given if an IAT batch uses the normal NewBatch
+	ErrFileIATSEC = errors.New("IAT Standard Entry Class Code should use iatBatch")
+)
 
 // RecordWrongLengthErr is the error given when a record is the wrong length
 type RecordWrongLengthErr struct {
@@ -33,6 +51,64 @@ func (e RecordWrongLengthErr) Error() string {
 	return e.Message
 }
 
+// ErrUnknownRecordType is the error given when a record does not have a known type
+type ErrUnknownRecordType struct {
+	Message string
+	Type    string
+}
+
+// NewErrUnknownRecordType creates a new error of the ErrUnknownRecordType type
+func NewErrUnknownRecordType(recordType string) ErrUnknownRecordType {
+	return ErrUnknownRecordType{
+		Message: fmt.Sprintf("%s is an unknown record type", recordType),
+		Type:    recordType,
+	}
+}
+
+func (e ErrUnknownRecordType) Error() string {
+	return e.Message
+}
+
+// ErrFileUnknownSEC is the error given when a record does not have a known type
+type ErrFileUnknownSEC struct {
+	Message string
+	SEC     string
+}
+
+// NewErrFileUnknownSEC creates a new error of the ErrFileUnknownSEC type
+func NewErrFileUnknownSEC(secType string) ErrFileUnknownSEC {
+	return ErrFileUnknownSEC{
+		Message: fmt.Sprintf("%s Standard Entry Class Code is not implemented", secType),
+		SEC:     secType,
+	}
+}
+
+func (e ErrFileUnknownSEC) Error() string {
+	return e.Message
+}
+
+// ErrFileCalculatedControlEquality is the error given when the control record does not match the calculated value
+type ErrFileCalculatedControlEquality struct {
+	Message         string
+	Field           string
+	CalculatedValue int
+	ControlValue    int
+}
+
+// NewErrFileCalculatedControlEquality creates a new error of the ErrFileCalculatedControlEquality type
+func NewErrFileCalculatedControlEquality(field string, calculated, control int) ErrFileCalculatedControlEquality {
+	return ErrFileCalculatedControlEquality{
+		Message:         fmt.Sprintf("%v calculated %v is out-of-balance with file control %v", field, calculated, control),
+		Field:           field,
+		CalculatedValue: calculated,
+		ControlValue:    control,
+	}
+}
+
+func (e ErrFileCalculatedControlEquality) Error() string {
+	return e.Message
+}
+
 // Has takes in a (potential) list of errors, and an error to check for. If any of the errors
 // in the list have the same type as the error to check, it returns true. If the "list" isn't
 // actually a list (typically because it is nil), or no errors in the list match the other error
@@ -43,11 +119,17 @@ func Has(list error, err error) bool {
 		return false
 	}
 	for i := 0; i < len(el); i++ {
-		if el[i] == err {
-			return true
-		}
-		if reflect.TypeOf(el[i]) == reflect.TypeOf(err) {
-			return true
+		simpleError := errors.New("simple error")
+		if reflect.TypeOf(err) == reflect.TypeOf(simpleError) {
+			// simple errors all have the same type, so we need to compare them directly
+			if el[i] == err {
+				return true
+			}
+		} else {
+			// typed errors can be compared by type
+			if reflect.TypeOf(el[i]) == reflect.TypeOf(err) {
+				return true
+			}
 		}
 	}
 	return false

--- a/fileErrors.go
+++ b/fileErrors.go
@@ -5,18 +5,15 @@
 package ach
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
 	"github.com/moov-io/base"
 )
 
-// FileTooLongErr is the error given when a file exceeds the maximum possible length
-type FileTooLongErr string
-
-func (e FileTooLongErr) Error() string {
-	return string(e)
-}
+// ErrFileTooLong is the error given when a file exceeds the maximum possible length
+var ErrFileTooLong = errors.New("file exceeds maximum possible number of lines")
 
 // RecordWrongLengthErr is the error given when a record is the wrong length
 type RecordWrongLengthErr struct {
@@ -46,6 +43,9 @@ func Has(list error, err error) bool {
 		return false
 	}
 	for i := 0; i < len(el); i++ {
+		if el[i] == err {
+			return true
+		}
 		if reflect.TypeOf(el[i]) == reflect.TypeOf(err) {
 			return true
 		}

--- a/fileErrors.go
+++ b/fileErrors.go
@@ -1,0 +1,54 @@
+// Copyright 2018 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package ach
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/moov-io/base"
+)
+
+// FileTooLongErr is the error given when a file exceeds the maximum possible length
+type FileTooLongErr string
+
+func (e FileTooLongErr) Error() string {
+	return string(e)
+}
+
+// RecordWrongLengthErr is the error given when a record is the wrong length
+type RecordWrongLengthErr struct {
+	Message string
+	Length  int
+}
+
+// NewRecordWrongLengthErr creates a new error of the RecordWrongLengthErr type
+func NewRecordWrongLengthErr(length int) RecordWrongLengthErr {
+	return RecordWrongLengthErr{
+		Message: fmt.Sprintf("must be 94 characters and found %d", length),
+		Length:  length,
+	}
+}
+
+func (e RecordWrongLengthErr) Error() string {
+	return e.Message
+}
+
+// Has takes in a (potential) list of errors, and an error to check for. If any of the errors
+// in the list have the same type as the error to check, it returns true. If the "list" isn't
+// actually a list (typically because it is nil), or no errors in the list match the other error
+// it returns false. So it can be used as an easy way to check for a particular kind of error.
+func Has(list error, err error) bool {
+	el, ok := list.(base.ErrorList)
+	if !ok {
+		return false
+	}
+	for i := 0; i < len(el); i++ {
+		if reflect.TypeOf(el[i]) == reflect.TypeOf(err) {
+			return true
+		}
+	}
+	return false
+}

--- a/file_test.go
+++ b/file_test.go
@@ -96,14 +96,9 @@ func testFileBatchCount(t testing.TB) {
 
 	// More batches than the file control count.
 	file.AddBatch(mockBatchPPD())
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "BatchCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("BatchCount", 2, 1) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -126,14 +121,9 @@ func testFileEntryAddenda(t testing.TB) {
 
 	// more entries than the file control
 	file.Control.EntryAddendaCount = 5
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "EntryAddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("EntryAddendaCount", 1, 5) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -156,14 +146,9 @@ func testFileDebitAmount(t testing.TB) {
 
 	// inequality in total debit amount
 	file.Control.TotalDebitEntryDollarAmountInFile = 63
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "TotalDebitEntryDollarAmountInFile" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("TotalDebitEntryDollarAmountInFile", 0, 63) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -186,14 +171,9 @@ func testFileCreditAmount(t testing.TB) {
 
 	// inequality in total credit amount
 	file.Control.TotalCreditEntryDollarAmountInFile = 63
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "TotalCreditEntryDollarAmountInFile" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("TotalCreditEntryDollarAmountInFile", 100000000, 63) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -218,14 +198,9 @@ func testFileEntryHash(t testing.TB) {
 		t.Fatal(err)
 	}
 	file.Control.EntryHash = 63
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "EntryHash" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("EntryHash", 46276020, 63) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -591,16 +566,10 @@ func TestFileADVInvalid__StandardEntryClassCode(t *testing.T) {
 	file.SetHeader(fh)
 	file.AddBatch(batchADV)
 	file.AddBatch(batchPPD)
-	if err := file.Create(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "StandardEntryClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err = file.Create()
+	if err != ErrFileADVOnly {
+		t.Errorf("%T: %s", err, err)
 	}
-
 }
 
 // TestFileADVEntryHash validates entry hash
@@ -611,14 +580,9 @@ func TestFileADVEntryHash(t *testing.T) {
 		t.Fatal(err)
 	}
 	file.ADVControl.EntryHash = 63
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "EntryHash" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("EntryHash", 46276020, 63) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -628,14 +592,9 @@ func TestFileADVDebitAmount(t *testing.T) {
 
 	// inequality in total debit amount
 	file.ADVControl.TotalDebitEntryDollarAmountInFile = 06
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "TotalDebitEntryDollarAmountInFile" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("TotalDebitEntryDollarAmountInFile", 0, 6) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -645,14 +604,9 @@ func TestFileADVCreditAmount(t *testing.T) {
 
 	// inequality in total credit amount
 	file.ADVControl.TotalCreditEntryDollarAmountInFile = 07
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "TotalCreditEntryDollarAmountInFile" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("TotalCreditEntryDollarAmountInFile", 50000, 7) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -662,14 +616,9 @@ func TestFileADVEntryAddenda(t *testing.T) {
 
 	// more entries than the file control
 	file.ADVControl.EntryAddendaCount = 5
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "EntryAddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("EntryAddendaCount", 1, 5) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -679,14 +628,9 @@ func TestFileADVBatchCount(t *testing.T) {
 
 	// More batches than the file control count.
 	file.AddBatch(mockBatchADV())
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "BatchCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	if err != NewErrFileCalculatedControlEquality("BatchCount", 2, 1) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -6,11 +6,14 @@ package ach
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockFilePPD creates an ACH file with PPD batch and entry
@@ -67,6 +70,28 @@ func testFileError(t testing.TB) {
 // TestFileError tests validating a file error
 func TestFileError(t *testing.T) {
 	testFileError(t)
+}
+
+// testHas validates the Has error function
+func testHas(t testing.TB) {
+	err := errors.New("Non list error")
+
+	if Has(err, err) {
+		t.Error("Has should return false when given a non-list error as the first arg")
+	}
+
+	if Has(nil, err) {
+		t.Error("Has should not return true if there are no errors")
+	}
+
+	if Has(base.ErrorList([]error{}), err) {
+		t.Error("Has should not return true if there are no errors")
+	}
+}
+
+// TestHas validates the Has error function
+func TestHas(t *testing.T) {
+	testHas(t)
 }
 
 // BenchmarkFileError benchmarks validating a file error

--- a/reader.go
+++ b/reader.go
@@ -95,7 +95,7 @@ func (r *Reader) Read() (File, error) {
 		line := r.scanner.Text()
 		r.lineNum++
 		if r.lineNum > maxLines {
-			r.errors.Add(FileTooLongErr("file has exceeded the maximum possible number of lines"))
+			r.errors.Add(ErrFileTooLong)
 			break
 		}
 

--- a/reader.go
+++ b/reader.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 
 	"github.com/moov-io/base"
@@ -96,8 +95,7 @@ func (r *Reader) Read() (File, error) {
 		line := r.scanner.Text()
 		r.lineNum++
 		if r.lineNum > maxLines {
-			err := &FileError{FieldName: "FileLength", Value: strconv.Itoa(r.lineNum), Msg: msgFileTooLong}
-			r.errors.Add(r.parseError(err))
+			r.errors.Add(FileTooLongErr("file has exceeded the maximum possible number of lines"))
 			break
 		}
 
@@ -109,9 +107,7 @@ func (r *Reader) Read() (File, error) {
 				r.errors.Add(err)
 			}
 		case lineLength != RecordLength:
-			msg := fmt.Sprintf(msgRecordLength, lineLength)
-			err := &FileError{FieldName: "RecordLength", Value: strconv.Itoa(lineLength), Msg: msg}
-			r.errors.Add(r.parseError(err))
+			r.errors.Add(NewRecordWrongLengthErr(lineLength))
 		default:
 			r.line = line
 			if err := r.parseLine(); err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -359,14 +359,8 @@ func testFileLineShort(t testing.TB) {
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
 
-	if p, ok := err.(*base.ParseError); ok {
-		if e, ok := p.Err.(*FileError); ok {
-			if e.FieldName != "RecordLength" {
-				t.Errorf("%T: %s", e, e)
-			}
-		} else {
-			t.Errorf("%T: %s", e, e)
-		}
+	if !Has(err, NewRecordWrongLengthErr(70)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -388,14 +382,9 @@ func testFileLineLong(t testing.TB) {
 	var line = "1 line is 100 characters ..........................................................................!"
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if p, ok := err.(*base.ParseError); ok {
-		if e, ok := p.Err.(*FileError); ok {
-			if e.FieldName != "RecordLength" {
-				t.Errorf("%T: %s", e, e)
-			}
-		} else {
-			t.Errorf("%T: %s", p.Err, p.Err)
-		}
+
+	if !Has(err, NewRecordWrongLengthErr(100)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -2159,18 +2148,8 @@ func testACHFileTooLongErr(t testing.TB) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if el, ok := err.(base.ErrorList); ok {
-		if p, ok := el.Err().(*base.ParseError); ok {
-			if e, ok := p.Err.(*FileError); ok {
-				if e.Msg != msgFileTooLong {
-					t.Errorf("%T: %s", e, e)
-				}
-			}
-		} else {
-			t.Errorf("%T: %s", el, el)
-		}
-	} else {
-		t.Errorf("No error even though file was too long")
+	if !Has(err, FileTooLongErr("file too long")) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 	// reset maxLines to its original value

--- a/reader_test.go
+++ b/reader_test.go
@@ -2148,7 +2148,7 @@ func testACHFileTooLongErr(t testing.TB) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if !Has(err, FileTooLongErr("file too long")) {
+	if !Has(err, ErrFileTooLong) {
 		t.Errorf("%T: %s", err, err)
 	}
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -90,14 +90,9 @@ func testFileWriteErr(t testing.TB) {
 	b := &bytes.Buffer{}
 	f := NewWriter(b)
 
-	if err := f.Write(file); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "EntryAddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := f.Write(file)
+	if err != NewErrFileCalculatedControlEquality("EntryAddendaCount", 10, 2) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 


### PR DESCRIPTION
Here's a potential way we could improve error handling. Each type of error is now literally its own type implementing the `Error` interface. A helper function is provided (and which would likely be moved into `moov-io/base` if we decided to use this) which lets us easily check whether the error list returned has the specific error we are expecting. This is demonstrated in the updated tests.

The downside of this method is that each new kind of error has to have its own type and `Error()` function, along with a constructor if the error has details. This can be a bit cumbersome.

The upside is that using errors becomes significantly easier. It also will make localization easier down the road, since all the error messages will be in one place and can depend on a locale configuration variable.

Let me know if this seems reasonable to you, or if you have any other kinds of comments or suggestions!