### PR TITLE
Use Has and Match from moov-io/base

### DIFF
--- a/batchACK_test.go
+++ b/batchACK_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"log"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchACKHeader creates a ACK batch header
@@ -75,7 +77,7 @@ func testBatchACKAddendumCount(t testing.TB) {
 	// Adding a second addenda to the mock entry
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAddendaCount(2, 1)) {
+	if !base.Match(err, NewErrBatchAddendaCount(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -193,7 +195,7 @@ func testBatchACKSEC(t testing.TB) {
 	mockBatch := mockBatchACK()
 	mockBatch.Header.StandardEntryClassCode = RCK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -217,7 +219,7 @@ func testBatchACKAddendaCount(t testing.TB) {
 	addenda05 := mockAddenda05()
 	mockBatch.GetEntries()[0].AddAddenda05(addenda05)
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAddendaCount(2, 1)) {
+	if !base.Match(err, NewErrBatchAddendaCount(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -295,7 +297,7 @@ func TestBatchACKAmount(t *testing.T) {
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetEntries()[0].Amount = 25000
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAmountNonZero) {
+	if !base.Match(err, ErrBatchAmountNonZero) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -306,7 +308,7 @@ func TestBatchACKTransactionCode(t *testing.T) {
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetEntries()[0].TransactionCode = CheckingCredit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchTransactionCode) {
+	if !base.Match(err, ErrBatchTransactionCode) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -319,7 +321,7 @@ func TestBatchACKAddendum99Category(t *testing.T) {
 	mockBatch.GetEntries()[0].Category = CategoryForward
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -329,7 +331,7 @@ func TestBatchACKValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchACK()
 	mockBatch.GetHeader().ServiceClassCode = DebitsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 24)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 24)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchADV_test.go
+++ b/batchADV_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"testing"
 	"time"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchADVHeader creates a ADV batch header
@@ -79,7 +81,7 @@ func testBatchADVSEC(t testing.TB) {
 	mockBatch := mockBatchADV()
 	mockBatch.Header.StandardEntryClassCode = RCK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -134,7 +136,7 @@ func TestBatchADVAddendum99Category(t *testing.T) {
 	mockBatch.GetADVEntries()[0].Category = CategoryForward
 	mockBatch.GetADVEntries()[0].Addenda99 = mockAddenda99
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -145,7 +147,7 @@ func TestBatchADVInvalidTransactionCode(t *testing.T) {
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetADVEntries()[0].TransactionCode = CheckingCredit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchTransactionCode) {
+	if !base.Match(err, ErrBatchTransactionCode) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -161,7 +163,7 @@ func TestADVMaximumEntries(t *testing.T) {
 		batch.AddADVEntry(entry)
 	}
 	err := batch.Create()
-	if !Match(err, ErrBatchADVCount) {
+	if !base.Match(err, ErrBatchADVCount) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchARC_test.go
+++ b/batchARC_test.go
@@ -4,7 +4,11 @@
 
 package ach
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moov-io/base"
+)
 
 // mockBatchARCHeader creates a BatchARC BatchHeader
 func mockBatchARCHeader() *BatchHeader {
@@ -123,7 +127,7 @@ func testBatchARCStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchARC()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -146,7 +150,7 @@ func testBatchARCServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchARC()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -169,7 +173,7 @@ func testBatchARCMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchARC()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -192,7 +196,7 @@ func testBatchARCCreditsOnly(t testing.TB) {
 	mockBatch := mockBatchARC()
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -215,7 +219,7 @@ func testBatchARCAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchARC()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -238,7 +242,7 @@ func testBatchARCAmount(t testing.TB) {
 	mockBatch := mockBatchARC()
 	mockBatch.Entries[0].Amount = 2600000
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAmount(2600000, 2500000)) {
+	if !base.Match(err, NewErrBatchAmount(2600000, 2500000)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -291,7 +295,7 @@ func BenchmarkBatchARCCheckSerialNumber(b *testing.B) {
 func testBatchARCTransactionCode(t testing.TB) {
 	mockBatch := mockBatchARCCredit()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -315,7 +319,7 @@ func testBatchARCAddendaCount(t testing.TB) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -407,7 +411,7 @@ func TestBatchARCAddendum99Category(t *testing.T) {
 	mockBatch.GetEntries()[0].Category = CategoryForward
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchATX_test.go
+++ b/batchATX_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"log"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchATXHeader creates a BatchATX BatchHeader
@@ -97,7 +99,7 @@ func testBatchATXStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchATX()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -120,7 +122,7 @@ func testBatchATXServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchATX()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -203,7 +205,7 @@ func TestBatchATXInvalidAddend02(t *testing.T) {
 	entry.Addenda02 = mockAddenda02()
 	mockBatch.AddEntry(entry)
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -299,7 +301,7 @@ func testBatchATXAddenda10000(t testing.TB) {
 
 	}
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAddendaCount(10000, 9999)) {
+	if !base.Match(err, NewErrBatchAddendaCount(10000, 9999)) {
 		t.Errorf("%T: %s", err, err)
 	}
 
@@ -497,7 +499,7 @@ func testBatchATXTransactionCode(t testing.TB) {
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchTransactionCode) {
+	if !base.Match(err, ErrBatchTransactionCode) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -544,7 +546,7 @@ func TestBatchATXAmount(t *testing.T) {
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAmountNonZero) {
+	if !base.Match(err, ErrBatchAmountNonZero) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -592,7 +594,7 @@ func TestBatchATXValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchATX()
 	mockBatch.GetHeader().ServiceClassCode = DebitsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 24)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 24)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchBOC_test.go
+++ b/batchBOC_test.go
@@ -4,7 +4,11 @@
 
 package ach
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moov-io/base"
+)
 
 // mockBatchBOCHeader creates a BatchBOC BatchHeader
 func mockBatchBOCHeader() *BatchHeader {
@@ -123,7 +127,7 @@ func testBatchBOCStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchBOC()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -146,7 +150,7 @@ func testBatchBOCServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchBOC()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -169,7 +173,7 @@ func testBatchBOCMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchBOC()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -193,7 +197,7 @@ func testBatchBOCCreditsOnly(t testing.TB) {
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -216,7 +220,7 @@ func testBatchBOCAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchBOC()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -239,7 +243,7 @@ func testBatchBOCAmount(t testing.TB) {
 	mockBatch := mockBatchBOC()
 	mockBatch.Entries[0].Amount = 2500001
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAmount(2500001, 2500000)) {
+	if !base.Match(err, NewErrBatchAmount(2500001, 2500000)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -291,7 +295,7 @@ func BenchmarkBatchBOCCheckSerialNumber(b *testing.B) {
 func testBatchBOCTransactionCode(t testing.TB) {
 	mockBatch := mockBatchBOCCredit()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -315,7 +319,7 @@ func testBatchBOCAddenda05(t testing.TB) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchCCD_test.go
+++ b/batchCCD_test.go
@@ -6,6 +6,8 @@ package ach
 
 import (
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchCCDHeader creates a CCD batch header
@@ -74,7 +76,7 @@ func testBatchCCDAddendumCount(t testing.TB) {
 	// Adding a second addenda to the mock entry
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchCalculatedControlEquality(3, 2)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(3, 2)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -192,7 +194,7 @@ func testBatchCCDSEC(t testing.TB) {
 	mockBatch := mockBatchCCD()
 	mockBatch.Header.StandardEntryClassCode = RCK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -297,7 +299,7 @@ func TestBatchCCDValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchCCD()
 	mockBatch.GetHeader().ServiceClassCode = CreditsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(CreditsOnly, 27)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(CreditsOnly, 27)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -308,7 +310,7 @@ func TestBatchCCDAddenda02(t *testing.T) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchCIE_test.go
+++ b/batchCIE_test.go
@@ -4,7 +4,11 @@
 
 package ach
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moov-io/base"
+)
 
 // mockBatchCIEHeader creates a BatchCIE BatchHeader
 func mockBatchCIEHeader() *BatchHeader {
@@ -93,7 +97,7 @@ func testBatchCIEStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -116,7 +120,7 @@ func testBatchCIEServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -139,7 +143,7 @@ func testBatchCIEMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 220)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 220)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -162,7 +166,7 @@ func testBatchCIEDebitsOnly(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.Header.ServiceClassCode = DebitsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(DebitsOnly, 220)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(DebitsOnly, 220)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -185,7 +189,7 @@ func testBatchCIEAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 220)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 220)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -208,7 +212,7 @@ func testBatchCIETransactionCode(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.GetEntries()[0].TransactionCode = CheckingDebit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -231,7 +235,7 @@ func testBatchCIEAddendaCount(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchRequiredAddendaCount(2, 1)) {
+	if !base.Match(err, NewErrBatchRequiredAddendaCount(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -254,7 +258,7 @@ func testBatchCIEAddendaCountZero(t testing.TB) {
 	mockBatch := NewBatchCIE(mockBatchCIEHeader())
 	mockBatch.AddEntry(mockCIEEntryDetail())
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchRequiredAddendaCount(0, 1)) {
+	if !base.Match(err, NewErrBatchRequiredAddendaCount(0, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -279,7 +283,7 @@ func testBatchCIEInvalidAddendum(t testing.TB) {
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchRequiredAddendaCount(0, 1)) {
+	if !base.Match(err, NewErrBatchRequiredAddendaCount(0, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -445,7 +449,7 @@ func TestBatchCIEAddenda02(t *testing.T) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchCOR_test.go
+++ b/batchCOR_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"log"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchCORHeader creates a COR BatchHeader
@@ -76,7 +78,7 @@ func testBatchCORSEC(t testing.TB) {
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -242,7 +244,7 @@ func testBatchCORTransactionCode27(t testing.TB) {
 	mockBatch := mockBatchCOR()
 	mockBatch.GetEntries()[0].TransactionCode = CheckingDebit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchTransactionCode) {
+	if !base.Match(err, ErrBatchTransactionCode) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -318,7 +320,7 @@ func testBatchCORServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchCOR()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -364,7 +366,7 @@ func TestBatchCORCategoryNOCAddenda02(t *testing.T) {
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -392,7 +394,7 @@ func TestBatchCORValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchCOR()
 	mockBatch.GetHeader().ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchServiceClassCode) {
+	if !base.Match(err, ErrBatchServiceClassCode) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchCTX_test.go
+++ b/batchCTX_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"log"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchCTXHeader creates a BatchCTX BatchHeader
@@ -97,7 +99,7 @@ func testBatchCTXStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchCTX()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -120,7 +122,7 @@ func testBatchCTXServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchCTX()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -285,7 +287,7 @@ func testBatchCTXAddenda10000(t testing.TB) {
 	}
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAddendaCount(10000, 9999)) {
+	if !base.Match(err, NewErrBatchAddendaCount(10000, 9999)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -544,7 +546,7 @@ func TestBatchCTXValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchCTX()
 	mockBatch.GetHeader().ServiceClassCode = DebitsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 22)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 22)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -555,7 +557,7 @@ func TestBatchCTXAddenda02(t *testing.T) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchDNE_test.go
+++ b/batchDNE_test.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"testing"
 	"time"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchDNEHeader creates a DNE batch header
@@ -81,7 +83,7 @@ func testBatchDNEAddendumCount(t testing.TB) {
 	// Adding a second addenda to the mock entry
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchCalculatedControlEquality(3, 2)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(3, 2)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -176,7 +178,7 @@ func testBatchDNESEC(t testing.TB) {
 	mockBatch := mockBatchDNE()
 	mockBatch.Header.StandardEntryClassCode = ACK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -257,7 +259,7 @@ func TestBatchDNEAmount(t *testing.T) {
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetEntries()[0].Amount = 25000
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAmountNonZero) {
+	if !base.Match(err, ErrBatchAmountNonZero) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -267,7 +269,7 @@ func TestBatchDNETransactionCode(t *testing.T) {
 	mockBatch := mockBatchDNE()
 	mockBatch.GetEntries()[0].TransactionCode = CheckingCredit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchTransactionCode) {
+	if !base.Match(err, ErrBatchTransactionCode) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchENR_test.go
+++ b/batchENR_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"log"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchENRHeader creates a ENR batch header
@@ -118,7 +120,7 @@ func testBatchENRCompanyEntryDescription(t testing.TB) {
 	mockBatch := mockBatchENR()
 	mockBatch.Header.CompanyEntryDescription = "bad"
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchCompanyEntryDescriptionAutoenroll) {
+	if !base.Match(err, ErrBatchCompanyEntryDescriptionAutoenroll) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -169,7 +171,7 @@ func testBatchENRSEC(t testing.TB) {
 	mockBatch := mockBatchENR()
 	mockBatch.Header.StandardEntryClassCode = ACK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -248,7 +250,7 @@ func TestBatchENRAmount(t *testing.T) {
 	mockBatch := mockBatchENR()
 	mockBatch.GetEntries()[0].Amount = 25000
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAmountNonZero) {
+	if !base.Match(err, ErrBatchAmountNonZero) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -258,7 +260,7 @@ func TestBatchENRTransactionCode(t *testing.T) {
 	mockBatch := mockBatchENR()
 	mockBatch.GetEntries()[0].TransactionCode = CheckingReturnNOCCredit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchTransactionCode) {
+	if !base.Match(err, ErrBatchTransactionCode) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -302,7 +304,7 @@ func TestBatchENRValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchENR()
 	mockBatch.GetHeader().ServiceClassCode = DebitsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 22)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 22)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -313,7 +315,7 @@ func TestBatchENRAddenda02(t *testing.T) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchErrors.go
+++ b/batchErrors.go
@@ -61,6 +61,11 @@ func (e *BatchError) Error() string {
 	return fmt.Sprintf("batch #%d (%v) %s %v: %v", e.BatchNumber, e.BatchType, e.FieldName, e.Err, e.FieldValue)
 }
 
+// Unwrap implements the base.UnwrappableError interface for BatchError
+func (e *BatchError) Unwrap() error {
+	return e.Err
+}
+
 // error returns a new BatchError based on err
 func (b *Batch) Error(field string, err error, values ...interface{}) error {
 	if err == nil {

--- a/batchMTE_test.go
+++ b/batchMTE_test.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"testing"
 	"time"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchMTEHeader creates a MTE batch header
@@ -160,7 +162,7 @@ func testBatchMTESEC(t testing.TB) {
 	mockBatch := mockBatchMTE()
 	mockBatch.Header.StandardEntryClassCode = ACK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -212,7 +214,7 @@ func TestBatchMTEAmount(t *testing.T) {
 	mockBatch := mockBatchMTE()
 	mockBatch.GetEntries()[0].Amount = 0
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAmountZero) {
+	if !base.Match(err, ErrBatchAmountZero) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -279,7 +281,7 @@ func TestBatchMTEValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchMTE()
 	mockBatch.GetHeader().ServiceClassCode = CreditsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(CreditsOnly, 27)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(CreditsOnly, 27)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -290,7 +292,7 @@ func TestBatchMTEAddenda05(t *testing.T) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchPOP_test.go
+++ b/batchPOP_test.go
@@ -4,7 +4,11 @@
 
 package ach
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moov-io/base"
+)
 
 // mockBatchPOPHeader creates a BatchPOP BatchHeader
 func mockBatchPOPHeader() *BatchHeader {
@@ -127,7 +131,7 @@ func testBatchPOPStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -150,7 +154,7 @@ func testBatchPOPServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -173,7 +177,7 @@ func testBatchPOPMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -196,7 +200,7 @@ func testBatchPOPCreditsOnly(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -219,7 +223,7 @@ func testBatchPOPAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -242,7 +246,7 @@ func testBatchPOPAmount(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	mockBatch.Entries[0].Amount = 2600000
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAmount(2600000, 2500000)) {
+	if !base.Match(err, NewErrBatchAmount(2600000, 2500000)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -370,7 +374,7 @@ func BenchmarkBatchPOPTerminalStateField(b *testing.B) {
 func testBatchPOPTransactionCode(t testing.TB) {
 	mockBatch := mockBatchPOPCredit()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchPOS_test.go
+++ b/batchPOS_test.go
@@ -4,7 +4,11 @@
 
 package ach
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moov-io/base"
+)
 
 // mockBatchPOSHeader creates a BatchPOS BatchHeader
 func mockBatchPOSHeader() *BatchHeader {
@@ -93,7 +97,7 @@ func testBatchPOSStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -116,7 +120,7 @@ func testBatchPOSServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -139,7 +143,7 @@ func testBatchPOSMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -162,7 +166,7 @@ func testBatchPOSCreditsOnly(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -185,7 +189,7 @@ func testBatchPOSAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -208,7 +212,7 @@ func testBatchPOSTransactionCode(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.GetEntries()[0].TransactionCode = CheckingCredit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -293,7 +297,7 @@ func testBatchPOSInvalidAddendum(t testing.TB) {
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -414,7 +418,7 @@ func testBatchPOSCardTransactionType(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.GetEntries()[0].DiscretionaryData = "555"
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchInvalidCardTransactionType) {
+	if !base.Match(err, ErrBatchInvalidCardTransactionType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -441,7 +445,7 @@ func TestBatchPOSAddendum99Category(t *testing.T) {
 	mockBatch.Entries[0].Category = CategoryNOC
 	mockBatch.Entries[0].Addenda99 = mockAddenda99
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -491,7 +495,7 @@ func TestBatchPOSTerminalState(t *testing.T) {
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality("225", "200")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("225", "200")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchPPD_test.go
+++ b/batchPPD_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"testing"
 	"time"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchPPDHeader creates a PPD batch header
@@ -112,7 +114,7 @@ func testBatchServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchPPD()
 	mockBatch.GetControl().ServiceClassCode = DebitsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -195,7 +197,7 @@ func testBatchCompanyIdentification(t testing.TB) {
 	mockBatch := mockBatchPPD()
 	mockBatch.GetControl().CompanyIdentification = "XYZ Inc"
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality("121042882", "XYZ Inc")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("121042882", "XYZ Inc")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -218,7 +220,7 @@ func testBatchODFIIDMismatch(t testing.TB) {
 	mockBatch := mockBatchPPD()
 	mockBatch.GetControl().ODFIIdentification = "987654321"
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality("12104288", "987654321")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("12104288", "987654321")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -269,7 +271,7 @@ func testBatchPPDAddendaCount(t testing.TB) {
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchCalculatedControlEquality(3, 1)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(3, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -330,7 +332,7 @@ func TestBatchPPDSEC(t *testing.T) {
 	mockBatch := mockBatchPPD()
 	mockBatch.Header.StandardEntryClassCode = RCK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -340,7 +342,7 @@ func TestBatchPPDValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchPPD()
 	mockBatch.GetHeader().ServiceClassCode = DebitsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 22)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 22)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -351,7 +353,7 @@ func TestBatchPPDAddenda02(t *testing.T) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchRCK_test.go
+++ b/batchRCK_test.go
@@ -4,7 +4,11 @@
 
 package ach
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moov-io/base"
+)
 
 // mockBatchRCKHeader creates a BatchRCK BatchHeader
 func mockBatchRCKHeader() *BatchHeader {
@@ -123,7 +127,7 @@ func testBatchRCKStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -146,7 +150,7 @@ func testBatchRCKServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -169,7 +173,7 @@ func testBatchRCKMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -192,7 +196,7 @@ func testBatchRCKCreditsOnly(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -215,7 +219,7 @@ func testBatchRCKAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -266,7 +270,7 @@ func testBatchRCKAmount(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.Entries[0].Amount = 250001
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAmount(250001, 250000)) {
+	if !base.Match(err, NewErrBatchAmount(250001, 250000)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -319,7 +323,7 @@ func BenchmarkBatchRCKCheckSerialNumber(b *testing.B) {
 func testBatchRCKTransactionCode(t testing.TB) {
 	mockBatch := mockBatchRCKCredit()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchSHR_test.go
+++ b/batchSHR_test.go
@@ -6,6 +6,8 @@ package ach
 
 import (
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchSHRHeader creates a BatchSHR BatchHeader
@@ -96,7 +98,7 @@ func testBatchSHRStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -119,7 +121,7 @@ func testBatchSHRServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -142,7 +144,7 @@ func testBatchSHRMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -165,7 +167,7 @@ func testBatchSHRCreditsOnly(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -188,7 +190,7 @@ func testBatchSHRAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -211,7 +213,7 @@ func testBatchSHRTransactionCode(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.GetEntries()[0].TransactionCode = CheckingCredit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -265,7 +267,7 @@ func testBatchSHRAddendaCountZero(t testing.TB) {
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality("225", "200")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("225", "200")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -329,7 +331,7 @@ func testBatchSHRInvalidAddendum(t testing.TB) {
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -412,7 +414,7 @@ func testBatchSHRCardTransactionType(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.GetEntries()[0].DiscretionaryData = "555"
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchInvalidCardTransactionType) {
+	if !base.Match(err, ErrBatchInvalidCardTransactionType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -570,7 +572,7 @@ func TestBatchSHRAddendum99Category(t *testing.T) {
 	mockBatch.Entries[0].Category = CategoryNOC
 	mockBatch.Entries[0].Addenda99 = mockAddenda99
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -584,7 +586,7 @@ func TestBatchSHRTerminalState(t *testing.T) {
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality("225", "200")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("225", "200")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchTEL_test.go
+++ b/batchTEL_test.go
@@ -6,6 +6,8 @@ package ach
 
 import (
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchTELHeader creates a TEL batch header
@@ -102,7 +104,7 @@ func testBatchTELAddendaCount(t testing.TB) {
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchCalculatedControlEquality(2, 1)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -125,7 +127,7 @@ func testBatchTELSEC(t testing.TB) {
 	mockBatch := mockBatchTEL()
 	mockBatch.Header.StandardEntryClassCode = RCK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -148,7 +150,7 @@ func testBatchTELDebit(t testing.TB) {
 	mockBatch := mockBatchTEL()
 	mockBatch.GetEntries()[0].TransactionCode = CheckingCredit
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -241,7 +243,7 @@ func TestBatchTELValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchTEL()
 	mockBatch.GetHeader().ServiceClassCode = CreditsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(CreditsOnly, 27)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(CreditsOnly, 27)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchTRC_test.go
+++ b/batchTRC_test.go
@@ -4,7 +4,11 @@
 
 package ach
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moov-io/base"
+)
 
 // mockBatchTRCHeader creates a BatchTRC BatchHeader
 func mockBatchTRCHeader() *BatchHeader {
@@ -126,7 +130,7 @@ func testBatchTRCStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchTRC()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -149,7 +153,7 @@ func testBatchTRCServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchTRC()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -172,7 +176,7 @@ func testBatchTRCMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchTRC()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -195,7 +199,7 @@ func testBatchTRCCreditsOnly(t testing.TB) {
 	mockBatch := mockBatchTRC()
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -218,7 +222,7 @@ func testBatchTRCAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchTRC()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -271,7 +275,7 @@ func BenchmarkBatchTRCCheckSerialNumber(b *testing.B) {
 func testBatchTRCTransactionCode(t testing.TB) {
 	mockBatch := mockBatchTRCCredit()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -295,7 +299,7 @@ func testBatchTRCAddendaCount(t testing.TB) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -387,7 +391,7 @@ func TestBatchTRCAddendum99Category(t *testing.T) {
 	mockBatch.GetEntries()[0].Category = CategoryForward
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchTRX_test.go
+++ b/batchTRX_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"log"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchTRXHeader creates a BatchTRX BatchHeader
@@ -131,7 +133,7 @@ func testBatchTRXStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchTRX()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -154,7 +156,7 @@ func testBatchTRXServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchTRX()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -349,7 +351,7 @@ func testBatchTRXAddenda10000(t testing.TB) {
 	}
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAddendaCount(10000, 9999)) {
+	if !base.Match(err, NewErrBatchAddendaCount(10000, 9999)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -518,7 +520,7 @@ func BenchmarkBatchTRXZeroAddendaRecords(b *testing.B) {
 func testBatchTRXTransactionCode(t testing.TB) {
 	mockBatch := mockBatchTRXCredit()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -579,7 +581,7 @@ func testBatchTRXCreditsOnly(t testing.TB) {
 	mockBatch := mockBatchTRX()
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -602,7 +604,7 @@ func testBatchTRXAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchTRX()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -626,7 +628,7 @@ func TestBatchTRXAddenda02(t *testing.T) {
 	mockBatch.Entries[0].Addenda02 = mockAddenda02()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchWEB_test.go
+++ b/batchWEB_test.go
@@ -6,6 +6,8 @@ package ach
 
 import (
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchWEBHeader creates a WEB batch header
@@ -52,7 +54,7 @@ func testBatchWebAddenda(t testing.TB) {
 	// mock batch already has one addenda. Creating two addenda should error
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAddendaCount(2, 1)) {
+	if !base.Match(err, NewErrBatchAddendaCount(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -173,7 +175,7 @@ func testBatchWebSEC(t testing.TB) {
 	mockBatch := mockBatchWEB()
 	mockBatch.Header.StandardEntryClassCode = RCK
 	err := mockBatch.Validate()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -294,7 +296,7 @@ func TestBatchWEBAddendum99Category(t *testing.T) {
 	mockBatch.Entries[0].Category = CategoryForward
 	mockBatch.Entries[0].Addenda99 = mockAddenda99
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -308,7 +310,7 @@ func TestBatchWEBCategoryReturn(t *testing.T) {
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05)
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -322,7 +324,7 @@ func TestBatchWEBCategoryReturnAddenda98(t *testing.T) {
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -332,7 +334,7 @@ func TestBatchWEBValidTranCodeForServiceClassCode(t *testing.T) {
 	mockBatch := mockBatchWEB()
 	mockBatch.GetHeader().ServiceClassCode = DebitsOnly
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 22)) {
+	if !base.Match(err, NewErrBatchServiceClassTranCode(DebitsOnly, 22)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchXCK_test.go
+++ b/batchXCK_test.go
@@ -4,7 +4,11 @@
 
 package ach
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/moov-io/base"
+)
 
 // mockBatchXCKHeader creates a BatchXCK BatchHeader
 func mockBatchXCKHeader() *BatchHeader {
@@ -126,7 +130,7 @@ func testBatchXCKStandardEntryClassCode(t testing.TB) {
 	mockBatch := mockBatchXCK()
 	mockBatch.Header.StandardEntryClassCode = WEB
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchSECType) {
+	if !base.Match(err, ErrBatchSECType) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -149,7 +153,7 @@ func testBatchXCKServiceClassCodeEquality(t testing.TB) {
 	mockBatch := mockBatchXCK()
 	mockBatch.GetControl().ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(220, MixedDebitsAndCredits)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -172,7 +176,7 @@ func testBatchXCKMixedCreditsAndDebits(t testing.TB) {
 	mockBatch := mockBatchXCK()
 	mockBatch.Header.ServiceClassCode = MixedDebitsAndCredits
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(MixedDebitsAndCredits, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -195,7 +199,7 @@ func testBatchXCKCreditsOnly(t testing.TB) {
 	mockBatch := mockBatchXCK()
 	mockBatch.Header.ServiceClassCode = CreditsOnly
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -218,7 +222,7 @@ func testBatchXCKAutomatedAccountingAdvices(t testing.TB) {
 	mockBatch := mockBatchXCK()
 	mockBatch.Header.ServiceClassCode = AutomatedAccountingAdvices
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(AutomatedAccountingAdvices, 225)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -271,7 +275,7 @@ func BenchmarkBatchXCKCheckSerialNumber(b *testing.B) {
 func testBatchXCKTransactionCode(t testing.TB) {
 	mockBatch := mockBatchXCKCredit()
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchDebitOnly) {
+	if !base.Match(err, ErrBatchDebitOnly) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -392,7 +396,7 @@ func TestBatchXCKAddendum99Category(t *testing.T) {
 	mockBatch.GetEntries()[0].Category = CategoryForward
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaCategory) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -436,7 +440,7 @@ func TestBatchXCKAmount(t *testing.T) {
 	mockBatch := mockBatchXCK()
 	mockBatch.Entries[0].Amount = 260000
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchAmount(260000, 250000)) {
+	if !base.Match(err, NewErrBatchAmount(260000, 250000)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/moov-io/base"
 )
 
 // batch should never be used directly.
@@ -112,7 +114,7 @@ func testBatchNumberMismatch(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.GetControl().BatchNumber = 2
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality(1, 2)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(1, 2)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -149,7 +151,7 @@ func testCreditBatchIsBatchAmount(t testing.TB) {
 
 	mockBatch.GetControl().TotalCreditEntryDollarAmount = 1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCalculatedControlEquality(200, 1)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(200, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -188,7 +190,7 @@ func testSavingsBatchIsBatchAmount(t testing.TB) {
 
 	mockBatch.GetControl().TotalDebitEntryDollarAmount = 1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCalculatedControlEquality(200, 1)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(200, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -210,7 +212,7 @@ func testBatchIsEntryHash(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.GetControl().EntryHash = 1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCalculatedControlEquality(12104288, 1)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(12104288, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -237,7 +239,7 @@ func testBatchDNEMismatch(t testing.TB) {
 	mockBatch.GetHeader().OriginatorStatusCode = 1
 	mockBatch.GetEntries()[0].TransactionCode = CheckingPrenoteCredit
 	err := mockBatch.verify()
-	if !Match(err, ErrBatchOriginatorDNE) {
+	if !base.Match(err, ErrBatchOriginatorDNE) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -257,7 +259,7 @@ func testBatchTraceNumberNotODFI(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.GetEntries()[0].SetTraceNumber("12345678", 1)
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchTraceNumberNotODFI("12104288", "12345678")) {
+	if !base.Match(err, NewErrBatchTraceNumberNotODFI("12104288", "12345678")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -286,7 +288,7 @@ func testBatchEntryCountEquality(t testing.TB) {
 
 	mockBatch.GetControl().EntryAddendaCount = 1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCalculatedControlEquality(3, 1)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(3, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -308,7 +310,7 @@ func testBatchAddendaIndicator(t testing.TB) {
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 0
 	mockBatch.GetControl().EntryAddendaCount = 2
 	err := mockBatch.verify()
-	if !Match(err, ErrBatchAddendaIndicator) {
+	if !base.Match(err, ErrBatchAddendaIndicator) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -334,7 +336,7 @@ func testBatchIsAddendaSeqAscending(t testing.TB) {
 	mockBatch.GetEntries()[0].Addenda05[0].SequenceNumber = 2
 	mockBatch.GetEntries()[0].Addenda05[1].SequenceNumber = 1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchAscending(2, 1)) {
+	if !base.Match(err, NewErrBatchAscending(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -356,7 +358,7 @@ func testBatchIsSequenceAscending(t testing.TB) {
 	mockBatch.AddEntry(e3)
 	mockBatch.GetControl().EntryAddendaCount = 2
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchAscending(121042880000001, 1)) {
+	if !base.Match(err, NewErrBatchAscending(121042880000001, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -381,7 +383,7 @@ func testBatchAddendaTraceNumber(t testing.TB) {
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Addenda05[0].EntryDetailSequenceNumber = 99
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchAscending("1", "1")) {
+	if !base.Match(err, NewErrBatchAscending("1", "1")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -466,7 +468,7 @@ func testBatchCategoryForwardReturn(t testing.TB) {
 		t.Errorf("%T: %s", err, err)
 	}
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCategory("Return", "Forward")) {
+	if !base.Match(err, NewErrBatchCategory("Return", "Forward")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -558,13 +560,13 @@ func BenchmarkBatchInvalidTraceNumberODFI(b *testing.B) {
 func testBatchNoEntry(t testing.TB) {
 	mockBatch := mockBatchNoEntry()
 	err := mockBatch.build()
-	if !Match(err, ErrBatchNoEntries) {
+	if !base.Match(err, ErrBatchNoEntries) {
 		t.Errorf("%T: %s", err, err)
 	}
 
 	// test verify
 	err = mockBatch.verify()
-	if !Match(err, ErrBatchNoEntries) {
+	if !base.Match(err, ErrBatchNoEntries) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -587,7 +589,7 @@ func testBatchControl(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.Control.ODFIIdentification = ""
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality("12104288", "")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("12104288", "")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -644,7 +646,7 @@ func TestBatchADVInvalidServiceClassCode(t *testing.T) {
 	}
 	mockBatch.ADVControl.ServiceClassCode = CreditsOnly
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality("280", "220")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("280", "220")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -657,7 +659,7 @@ func TestBatchADVInvalidODFIIdentification(t *testing.T) {
 	}
 	mockBatch.ADVControl.ODFIIdentification = "231380104"
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality("12104288", "231380104")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("12104288", "231380104")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -670,7 +672,7 @@ func TestBatchADVInvalidBatchNumber(t *testing.T) {
 	}
 	mockBatch.ADVControl.BatchNumber = 2
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality("1", "2")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("1", "2")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -683,7 +685,7 @@ func TestBatchADVInvalidEntryAddendaCount(t *testing.T) {
 	}
 	mockBatch.ADVControl.EntryAddendaCount = CheckingCredit
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchCalculatedControlEquality(1, 22)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(1, 22)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -697,7 +699,7 @@ func TestBatchADVInvalidTotalDebitEntryDollarAmount(t *testing.T) {
 	}
 	mockBatch.ADVControl.TotalDebitEntryDollarAmount = 2200
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchCalculatedControlEquality(50000, 2200)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(50000, 2200)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -710,7 +712,7 @@ func TestBatchADVInvalidTotalCreditEntryDollarAmount(t *testing.T) {
 	}
 	mockBatch.ADVControl.TotalCreditEntryDollarAmount = 2200
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchCalculatedControlEquality(50000, 2200)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(50000, 2200)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -723,7 +725,7 @@ func TestBatchADVInvalidEntryHash(t *testing.T) {
 	}
 	mockBatch.ADVControl.EntryHash = 2200233
 	err := mockBatch.Validate()
-	if !Match(err, NewErrBatchCalculatedControlEquality(23138010, 2200233)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(23138010, 2200233)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -733,7 +735,7 @@ func TestBatchAddenda98InvalidAddendaRecordIndicator(t *testing.T) {
 	mockBatch := mockBatchCOR()
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 0
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaIndicator) {
+	if !base.Match(err, ErrBatchAddendaIndicator) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -743,7 +745,7 @@ func TestBatchAddenda02InvalidAddendaRecordIndicator(t *testing.T) {
 	mockBatch := mockBatchPOS()
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 0
 	err := mockBatch.Create()
-	if !Match(err, ErrBatchAddendaIndicator) {
+	if !base.Match(err, ErrBatchAddendaIndicator) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -770,7 +772,7 @@ func TestBatchADVCategory(t *testing.T) {
 
 	mockBatch.AddADVEntry(entryOne)
 	err := mockBatch.Create()
-	if !Match(err, NewErrBatchCategory("Return", "Forward")) {
+	if !base.Match(err, NewErrBatchCategory("Return", "Forward")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -825,7 +827,7 @@ func TestBatchDishonoredReturnsCategory(t *testing.T) {
 	batch.AddEntry(entryOne)
 
 	err := batch.Create()
-	if !Match(err, NewErrBatchCategory("Return", "DishonoredReturn")) {
+	if !base.Match(err, NewErrBatchCategory("Return", "DishonoredReturn")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/fileErrors.go
+++ b/fileErrors.go
@@ -7,9 +7,6 @@ package ach
 import (
 	"errors"
 	"fmt"
-	"reflect"
-
-	"github.com/moov-io/base"
 )
 
 var (
@@ -107,50 +104,4 @@ func NewErrFileCalculatedControlEquality(field string, calculated, control int) 
 
 func (e ErrFileCalculatedControlEquality) Error() string {
 	return e.Message
-}
-
-func Match(errA, errB error) bool {
-	if errA == nil {
-		return false
-	}
-
-	// typed errors can be compared by type
-	if reflect.TypeOf(errA) == reflect.TypeOf(errB) {
-		simpleError := errors.New("simple error")
-		if reflect.TypeOf(errB) == reflect.TypeOf(simpleError) {
-			// simple errors all have the same type, so we need to compare them directly
-			return errA == errB
-		}
-		return true
-	}
-
-	// match wrapped errors
-	parseError := &base.ParseError{}
-	batchError := &BatchError{}
-	if reflect.TypeOf(errA) == reflect.TypeOf(parseError) {
-		pErr := errA.(*base.ParseError)
-		return Match(pErr.Err, errB)
-	}
-	if reflect.TypeOf(errA) == reflect.TypeOf(batchError) {
-		pErr := errA.(*BatchError)
-		return Match(pErr.Err, errB)
-	}
-	return false
-}
-
-// Has takes in a (potential) list of errors, and an error to check for. If any of the errors
-// in the list have the same type as the error to check, it returns true. If the "list" isn't
-// actually a list (typically because it is nil), or no errors in the list match the other error
-// it returns false. So it can be used as an easy way to check for a particular kind of error.
-func Has(list error, err error) bool {
-	el, ok := list.(base.ErrorList)
-	if !ok {
-		return false
-	}
-	for i := 0; i < len(el); i++ {
-		if Match(el[i], err) {
-			return true
-		}
-	}
-	return false
 }

--- a/file_test.go
+++ b/file_test.go
@@ -76,15 +76,15 @@ func TestFileError(t *testing.T) {
 func testHas(t testing.TB) {
 	err := errors.New("Non list error")
 
-	if Has(err, err) {
+	if base.Has(err, err) {
 		t.Error("Has should return false when given a non-list error as the first arg")
 	}
 
-	if Has(nil, err) {
+	if base.Has(nil, err) {
 		t.Error("Has should not return true if there are no errors")
 	}
 
-	if Has(base.ErrorList([]error{}), err) {
+	if base.Has(base.ErrorList([]error{}), err) {
 		t.Error("Has should not return true if there are no errors")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
-	github.com/moov-io/base v0.3.1
+	github.com/moov-io/base v0.8.0
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20190109181635-f287a105a20e // indirect
 	github.com/prometheus/common v0.0.0-20190107103113-2998b132700a // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/moov-io/base v0.3.1 h1:D1Jei3/bOrKSFOtDEKfKvnZ0o/XhHUTR5WaX/xOFX6Y=
 github.com/moov-io/base v0.3.1/go.mod h1:pPu/TAc9PkaaegbREVEeDHsGqyAlvji9vqTuARuAnd0=
+github.com/moov-io/base v0.8.0 h1:2GO0fr72ZK4vLgmQLkfCrOIS/o6MHT7wbSmqsqE1LTw=
+github.com/moov-io/base v0.8.0/go.mod h1:pPu/TAc9PkaaegbREVEeDHsGqyAlvji9vqTuARuAnd0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/iatBatch_test.go
+++ b/iatBatch_test.go
@@ -381,7 +381,7 @@ func testAddenda10EntryDetailSequenceNumber(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda10.EntryDetailSequenceNumber = 00000005
 	err := iatBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -407,7 +407,7 @@ func testAddenda11EntryDetailSequenceNumber(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda11.EntryDetailSequenceNumber = 00000005
 	err := iatBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -433,7 +433,7 @@ func testAddenda12EntryDetailSequenceNumber(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda12.EntryDetailSequenceNumber = 00000005
 	err := iatBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -459,7 +459,7 @@ func testAddenda13EntryDetailSequenceNumber(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda13.EntryDetailSequenceNumber = 00000005
 	err := iatBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -485,7 +485,7 @@ func testAddenda14EntryDetailSequenceNumber(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda14.EntryDetailSequenceNumber = 00000005
 	err := iatBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -511,7 +511,7 @@ func testAddenda15EntryDetailSequenceNumber(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda15.EntryDetailSequenceNumber = 00000005
 	err := iatBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -537,7 +537,7 @@ func testAddenda16EntryDetailSequenceNumber(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda16.EntryDetailSequenceNumber = 00000005
 	err := iatBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000005", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -562,7 +562,7 @@ func testIATBatchNumberMismatch(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.GetControl().BatchNumber = 2
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality(1, 2)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(1, 2)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -585,7 +585,7 @@ func testIATServiceClassCodeMismatch(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.GetControl().ServiceClassCode = DebitsOnly
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, DebitsOnly)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(CreditsOnly, DebitsOnly)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -626,7 +626,7 @@ func testIATBatchCreditIsBatchAmount(t testing.TB) {
 
 	mockBatch.GetControl().TotalCreditEntryDollarAmount = 1000
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCalculatedControlEquality(105000, 1000)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(105000, 1000)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -669,7 +669,7 @@ func testIATBatchDebitIsBatchAmount(t testing.TB) {
 
 	mockBatch.GetControl().TotalDebitEntryDollarAmount = 1000
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCalculatedControlEquality(105000, 1000)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(105000, 1000)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -772,7 +772,7 @@ func testIATODFIIdentificationMismatch(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.GetControl().ODFIIdentification = "53158020"
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality(23138010, 53158020)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(23138010, 53158020)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -823,7 +823,7 @@ func testIATBatchInvalidTraceNumberODFI(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.GetEntries()[0].SetTraceNumber("9928272", 1)
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchTraceNumberNotODFI("23138010", "09928272")) {
+	if !base.Match(err, NewErrBatchTraceNumberNotODFI("23138010", "09928272")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -846,7 +846,7 @@ func testIATBatchControl(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.Control.ODFIIdentification = ""
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality("23138010", "")) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality("23138010", "")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -873,7 +873,7 @@ func testIATBatchEntryCountEquality(t testing.TB) {
 
 	mockBatch.GetControl().EntryAddendaCount = 1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCalculatedControlEquality(8, 1)) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality(8, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -896,7 +896,7 @@ func testIATBatchisEntryHash(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.GetControl().EntryHash = 1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchCalculatedControlEquality("0012104288", "1")) {
+	if !base.Match(err, NewErrBatchCalculatedControlEquality("0012104288", "1")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -929,7 +929,7 @@ func testIATBatchIsSequenceAscending(t testing.TB) {
 	mockBatch.Entries[1].Addenda16 = mockAddenda16()
 	mockBatch.GetControl().EntryAddendaCount = 16
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchAscending("231380100000001", "1")) {
+	if !base.Match(err, NewErrBatchAscending("231380100000001", "1")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1302,7 +1302,7 @@ func testIATBatchValidate(t testing.TB) {
 	mockBatch.GetHeader().ServiceClassCode = DebitsOnly
 
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchHeaderControlEquality(DebitsOnly, CreditsOnly)) {
+	if !base.Match(err, NewErrBatchHeaderControlEquality(DebitsOnly, CreditsOnly)) {
 		t.Errorf("%T: %s", err, err)
 	}
 
@@ -1396,7 +1396,7 @@ func testIATBatchAddenda17EDSequenceNumber(t testing.TB) {
 	addenda17B.SequenceNumber = 1
 	addenda17B.EntryDetailSequenceNumber = 0000002
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000002", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000002", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1443,7 +1443,7 @@ func testIATBatchAddenda17Sequence(t testing.TB) {
 
 	addenda17B.SequenceNumber = -1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchAscending("-1", "1")) {
+	if !base.Match(err, NewErrBatchAscending("-1", "1")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1507,7 +1507,7 @@ func testIATBatchAddenda18EDSequenceNumber(t testing.TB) {
 	addenda18B.SequenceNumber = 1
 	addenda18B.EntryDetailSequenceNumber = 0000002
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchAddendaTraceNumber("0000002", "0000001")) {
+	if !base.Match(err, NewErrBatchAddendaTraceNumber("0000002", "0000001")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1570,7 +1570,7 @@ func testIATBatchAddenda18Sequence(t testing.TB) {
 
 	addenda18B.SequenceNumber = -1
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchAscending("-1", "1")) {
+	if !base.Match(err, NewErrBatchAscending("-1", "1")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1593,7 +1593,7 @@ func testIATNoEntry(t testing.TB) {
 	mockBatch := IATBatch{}
 	mockBatch.SetHeader(mockIATBatchHeaderFF())
 	err := mockBatch.verify()
-	if !Match(err, ErrBatchNoEntries) {
+	if !base.Match(err, ErrBatchNoEntries) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1797,7 +1797,7 @@ func testIATBatchBHODFI(t testing.TB) {
 	mockBatch.GetEntries()[0].SetTraceNumber("39387337", 1)
 
 	err := mockBatch.verify()
-	if !Match(err, NewErrBatchTraceNumberNotODFI("23138010", "39387337")) {
+	if !base.Match(err, NewErrBatchTraceNumberNotODFI("23138010", "39387337")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -229,7 +229,7 @@ func testRecordTypeUnknown(t testing.TB) {
 	var line = "301 076401251 0764012510807291511A094101achdestname            companyname                    "
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if !Has(err, NewErrUnknownRecordType("3")) {
+	if !base.Has(err, NewErrUnknownRecordType("3")) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -254,7 +254,7 @@ func testTwoFileHeaders(t testing.TB) {
 	r := NewReader(strings.NewReader(twoHeaders))
 	_, err := r.Read()
 
-	if !Has(err, ErrFileHeader) {
+	if !base.Has(err, ErrFileHeader) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -287,7 +287,7 @@ func testTwoFileControls(t testing.TB) {
 	r.File.Control.EntryHash = 5320001
 
 	_, err := r.Read()
-	if !Has(err, ErrFileControl) {
+	if !base.Has(err, ErrFileControl) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -310,7 +310,7 @@ func testFileLineEmpty(t testing.TB) {
 	line := ""
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if !Has(err, ErrFileHeader) {
+	if !base.Has(err, ErrFileHeader) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -334,7 +334,7 @@ func testFileLineShort(t testing.TB) {
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
 
-	if !Has(err, NewRecordWrongLengthErr(70)) {
+	if !base.Has(err, NewRecordWrongLengthErr(70)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -358,7 +358,7 @@ func testFileLineLong(t testing.TB) {
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
 
-	if !Has(err, NewRecordWrongLengthErr(100)) {
+	if !base.Has(err, NewRecordWrongLengthErr(100)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -451,7 +451,7 @@ func testFileBatchHeaderDuplicate(t testing.TB) {
 	r.addCurrentBatch(NewBatchPPD(bh))
 	// read should fail because it is parsing a second batch header and there can only be one.
 	_, err := r.Read()
-	if !Has(err, ErrFileBatchHeaderInsideBatch) {
+	if !base.Has(err, ErrFileBatchHeaderInsideBatch) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -474,7 +474,7 @@ func testFileEntryDetailOutsideBatch(t testing.TB) {
 	ed := mockEntryDetail()
 	r := NewReader(strings.NewReader(ed.String()))
 	_, err := r.Read()
-	if !Has(err, ErrFileEntryOutsideBatch) {
+	if !base.Has(err, ErrFileEntryOutsideBatch) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -501,7 +501,7 @@ func testFileEntryDetail(t testing.TB) {
 	r.addCurrentBatch(NewBatchPPD(mockBatchPPDHeader()))
 	r.currentBatch.SetHeader(mockBatchHeader())
 	_, err := r.Read()
-	if !Has(err, NewRecordWrongLengthErr(93)) {
+	if !base.Has(err, NewRecordWrongLengthErr(93)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -804,7 +804,7 @@ func testFileAddendaOutsideBatch(t testing.TB) {
 
 	// Note that the entry doesn't get counted since it is rejected due to being outside of a batch
 	// So the parser considers the addenda to be outside of an entry since there are no valid entries
-	if !Has(err, ErrFileAddendaOutsideEntry) {
+	if !base.Has(err, ErrFileAddendaOutsideEntry) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -925,7 +925,7 @@ func testFileBatchControlNoCurrentBatch(t testing.TB) {
 	bc := mockBatchControl()
 	r := NewReader(strings.NewReader(bc.String()))
 	_, err := r.Read()
-	if !Has(err, ErrFileBatchControlOutsideBatch) {
+	if !base.Has(err, ErrFileBatchControlOutsideBatch) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1049,7 +1049,7 @@ func testFileAddendaOutsideEntry(t testing.TB) {
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
 
-	if !Has(err, ErrFileAddendaOutsideEntry) {
+	if !base.Has(err, ErrFileAddendaOutsideEntry) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1831,7 +1831,7 @@ func TestADVInvalidBatchEntries(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if !Has(err, ErrFileAddendaOutsideEntry) {
+	if !base.Has(err, ErrFileAddendaOutsideEntry) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1846,7 +1846,7 @@ func TestADVNoFileControl(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if !Has(err, ErrFileControl) {
+	if !base.Has(err, ErrFileControl) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -1899,7 +1899,7 @@ func testACHFileIATBH(t testing.TB) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if !Has(err, ErrFileBatchHeaderInsideBatch) {
+	if !base.Has(err, ErrFileBatchHeaderInsideBatch) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -2019,7 +2019,7 @@ func TestTwoFileADVControls(t *testing.T) {
 	r.File.ADVControl.EntryHash = 5320001
 
 	_, err := r.Read()
-	if !Has(err, ErrFileControl) {
+	if !base.Has(err, ErrFileControl) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -2037,7 +2037,7 @@ func testACHFileTooLongErr(t testing.TB) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if !Has(err, ErrFileTooLong) {
+	if !base.Has(err, ErrFileTooLong) {
 		t.Errorf("%T: %s", err, err)
 	}
 

--- a/vendor/github.com/moov-io/base/.travis.yml
+++ b/vendor/github.com/moov-io/base/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 sudo: required
+services:
+- docker
 os:
 - linux
 - osx
@@ -8,13 +10,10 @@ go:
 - 1.11
 dist: xenial # Ubuntu 16.04
 osx_image: xcode9.1
-matrix:
-  allow_failures:
-    - os: windows
 before_install:
 - go get -u github.com/client9/misspell/cmd/misspell
 - go get -u golang.org/x/lint/golint
-- go get -u honnef.co/go/tools/cmd/megacheck
+- go get -u honnef.co/go/tools/cmd/staticcheck
 - go get github.com/fzipp/gocyclo
 - go get golang.org/x/tools/cmd/cover
 # Install gcc, from https://travis-ci.community/t/go-cant-find-gcc-with-go1-11-1-on-windows/293/5
@@ -30,6 +29,6 @@ script:
 - misspell -error -locale US $GOFILES
 - gocyclo -over 19 $GOFILES
 - golint -set_exit_status $GOFILES
-- megacheck ./...
+- staticcheck ./...
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+- bash <(curl -s https://codecov.io/bash) -X fix

--- a/vendor/github.com/moov-io/base/CHANGELOG.md
+++ b/vendor/github.com/moov-io/base/CHANGELOG.md
@@ -1,5 +1,69 @@
-## v0.3.0 
+## v0.8.0 (Released 2019-02-01)
+
+ADDITIONS
+
+- Added `Has` and `Match` functions to support type-based error handling
+
+## v0.7.0 (Released 2019-01-31)
+
+ADDITIONS
+
+- Add `ID() string` to return a random identifier.
+
+## v0.6.0 (Released 2019-01-25)
+
+ADDITIONS
+
+- admin: [`Server.AddHandler`](https://godoc.org/github.com/moov-io/base/admin#Server.AddHandler) for extendable commands
+- http/bind: Add [Fed](https://github.com/moov-io/fed) service
+
+## v0.5.1 (Released 2019-01-17)
+
+BUG FIXES
+
+- http: fix panic in ResponseWriter.WriteHeader
+
+## v0.5.0 (Released 2019-01-17)
+
+BUG FIXES
+
+- http: don't panic if nil idempotent.Recorder is passed to ResponseWriter
+
+ADDITIONS
+
+- http/bind: Add [OFAC](https://github.com/moov-io/ofac) and [GL](https://github.com/moov-io/gl) services
+- k8s: Add [`Inside()`](https://godoc.org/github.com/moov-io/base/k8s#Inside) for cluster awareness.
+- docker: Add [`Enabled()`](https://godoc.org/github.com/moov-io/base/docker#Enabled) for compatability checks.
+
+## v0.4.0 (Released 2019-01-11)
+
+BREAKING CHANGES
+
+- time: default times to UTC rather than Eastern.
+
+## v0.3.1 (Released 2019-01-09)
+
+- error: Add `ParseError` and `ErrorList` types.
+- time: Prevent negative times in `NewTime(t time.Time)`
+
+## v0.3.0 (Released 2019-01-07)
 
 ADDITIONS
 
 - Add ParseError and ErrorList. (See: [moov-io/base #23](https://github.com/moov-io/base/issues/23))
+
+## v0.2.1 (Released 2019-01-03)
+
+BUG FIXES
+
+- http: Add OPTIONS to Access-Control-Allow-Methods
+
+## v0.2.0 (Released 2018-12-18)
+
+ADDITIONS
+
+- Add `base.Time` as an embedded `time.Time` with banktime methods. (AddBankingDay, IsWeekend)
+
+## v0.1.0 (Released 2018-12-17)
+
+- Initial release

--- a/vendor/github.com/moov-io/base/admin/README.md
+++ b/vendor/github.com/moov-io/base/admin/README.md
@@ -1,0 +1,31 @@
+## moov-io/base/admin
+
+Package admin implements an `http.Server` which can be used for operations and monitoring tools. It's designed to be shipped (and ran) inside an existing Go service.
+
+Here's an example of adding `admin.Server` to serve Prometheus metrics:
+
+```Go
+import (
+    "fmt"
+    "os"
+
+    "github.com/moov-io/base/admin"
+
+    "github.com/go-kit/kit/log"
+)
+
+var logger log.Logger
+
+// in main.go or cmd/server/main.go
+
+adminServer := admin.NewServer(*adminAddr)
+go func() {
+	logger.Log("admin", fmt.Sprintf("listening on %s", adminServer.BindAddr()))
+	if err := adminServer.Listen(); err != nil {
+		err = fmt.Errorf("problem starting admin http: %v", err)
+		logger.Log("admin", err)
+		// errs <- err // send err to shutdown channel
+	}
+}()
+defer adminServer.Shutdown()
+```

--- a/vendor/github.com/moov-io/base/http/bind/bind.go
+++ b/vendor/github.com/moov-io/base/http/bind/bind.go
@@ -24,6 +24,9 @@ var serviceBinds = map[string]string{
 	"auth":    ":8081",
 	"paygate": ":8082",
 	"x9":      ":8083",
+	"ofac":    ":8084",
+	"gl":      ":8085",
+	"fed":     ":8086",
 }
 
 // HTTP returns the local bind address for a Moov service.

--- a/vendor/github.com/moov-io/base/http/server.go
+++ b/vendor/github.com/moov-io/base/http/server.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/gorilla/mux"
 )
@@ -111,11 +110,4 @@ func GetRequestId(r *http.Request) string {
 // GetUserId returns the Moov userId from HTTP headers
 func GetUserId(r *http.Request) string {
 	return r.Header.Get("X-User-Id")
-}
-
-func truncate(s string) string {
-	if utf8.RuneCountInString(s) > maxHeaderLength {
-		return s[:maxHeaderLength]
-	}
-	return s
 }

--- a/vendor/github.com/moov-io/base/id.go
+++ b/vendor/github.com/moov-io/base/id.go
@@ -1,0 +1,22 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package base
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+)
+
+// ID creates a new random string for Moov systems.
+// Do not assume anything about these ID's other than they are non-empty strings.
+func ID() string {
+	bs := make([]byte, 20)
+	n, err := rand.Read(bs)
+	if err != nil || n == 0 {
+		return ""
+	}
+	return strings.ToLower(hex.EncodeToString(bs))
+}

--- a/vendor/github.com/moov-io/base/time.go
+++ b/vendor/github.com/moov-io/base/time.go
@@ -5,7 +5,6 @@
 package base
 
 import (
-	"sync"
 	"time"
 
 	"github.com/rickar/cal"
@@ -13,13 +12,6 @@ import (
 
 const (
 	iso8601Format = "2006-01-02T15:04:05Z07:00"
-)
-
-var (
-	// DefaultLocation is the *time.Location used when creating a BankTime instance.
-	// By default America/New_York is populated here.
-	DefaultLocation *time.Location
-	setup           sync.Once
 )
 
 // Time is an time.Time struct that encodes and decodes in ISO 8601.
@@ -51,21 +43,10 @@ func Now() Time {
 	cal.AddUsHolidays(calendar)
 	calendar.Observed = cal.ObservedMonday
 
-	loc := getNYCLocation()
-
 	return Time{
 		cal:  calendar,
-		Time: time.Now().In(loc).Truncate(1 * time.Second),
+		Time: time.Now().UTC().Truncate(1 * time.Second),
 	}
-}
-
-func getNYCLocation() *time.Location {
-	loc := DefaultLocation
-	setup.Do(func() {
-		loc, _ = time.LoadLocation("America/New_York")
-		DefaultLocation = loc
-	})
-	return loc
 }
 
 // NewTime wraps a time.Time value in Moov's base.Time struct.
@@ -76,18 +57,8 @@ func getNYCLocation() *time.Location {
 // now := Now()
 // fmt.Println(start.Sub(now.Time))
 func NewTime(t time.Time) Time {
-	tt := Now() // sets DefaultLocation via sync.Once
-	tt.Time = t.In(DefaultLocation)
-
-	if tt.Time.Before(time.Time{}) {
-		// The conversion can fall negative due to reading 0000
-		// and calling .In with a timezone that shifts backwards.
-		//
-		// If that happens we need to reset to Time.IsZero() and then
-		// set our America/New_York timezone.
-		tt.Time = (time.Time{}).In(DefaultLocation)
-	}
-
+	tt := Now()
+	tt.Time = t.UTC() // overwrite underlying Time
 	return tt
 }
 
@@ -114,8 +85,7 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 		*t = NewTime(tt)
 	}
 
-	loc := getNYCLocation()
-	t.Time = tt.In(loc).Truncate(1 * time.Second) // convert to our location and drop millis
+	t.Time = tt.UTC().Truncate(1 * time.Second) // convert to UTC and drop millis
 
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,7 +19,7 @@ github.com/gorilla/mux
 github.com/kr/logfmt
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/moov-io/base v0.3.1
+# github.com/moov-io/base v0.8.0
 github.com/moov-io/base
 github.com/moov-io/base/admin
 github.com/moov-io/base/http/bind


### PR DESCRIPTION
This updates the ach repo to use the Has and Match functions from moov-io/base. 