### PR TITLE
Use new error system consistently

### DIFF
--- a/addenda02_test.go
+++ b/addenda02_test.go
@@ -38,14 +38,10 @@ func TestMockAddenda02(t *testing.T) {
 func testAddenda02ValidRecordType(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.recordType = "63"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -66,14 +62,9 @@ func BenchmarkAddenda02ValidRecordType(b *testing.B) {
 func testAddenda02ValidTypeCode(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TypeCode = "65"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -94,14 +85,9 @@ func BenchmarkAddenda02ValidTypeCode(b *testing.B) {
 func testAddenda02TypeCode02(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TypeCode = "05"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -332,14 +318,9 @@ func BenchmarkAddenda02String(b *testing.B) {
 func testAddenda02TransactionDateMonth(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TransactionDate = "1306"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrValidMonth) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -360,14 +341,10 @@ func BenchmarkAddenda02TransactionDateMonth(b *testing.B) {
 func testAddenda02TransactionDateDay(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TransactionDate = "0205"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -388,14 +365,9 @@ func BenchmarkAddenda02TransactionDateDay(b *testing.B) {
 func testAddenda02TransactionDateFeb(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TransactionDate = "0230"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrValidDay) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -416,14 +388,10 @@ func BenchmarkAddenda02TransactionDateFeb(b *testing.B) {
 func testAddenda02TransactionDate30Day(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TransactionDate = "0630"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -444,14 +412,10 @@ func BenchmarkAddenda02TransactionDate30Day(b *testing.B) {
 func testAddenda02TransactionDate31Day(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TransactionDate = "0131"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -472,14 +436,9 @@ func BenchmarkAddenda02TransactionDate31Day(b *testing.B) {
 func testAddenda02TransactionDateInvalidDay(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TransactionDate = "1039"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrValidDay) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -500,12 +459,9 @@ func BenchmarkAddenda02TransactionDateInvalidDay(b *testing.B) {
 func testReferenceInformationOneAlphaNumeric(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.ReferenceInformationOne = "®"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReferenceInformationOne" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -526,12 +482,9 @@ func BenchmarkReferenceInformationOneAlphaNumeric(b *testing.B) {
 func testReferenceInformationTwoAlphaNumeric(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.ReferenceInformationTwo = "®"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReferenceInformationTwo" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -552,12 +505,9 @@ func BenchmarkReferenceInformationTwoAlphaNumeric(b *testing.B) {
 func testTerminalIdentificationCodeAlphaNumeric(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TerminalIdentificationCode = "®"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TerminalIdentificationCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -578,12 +528,9 @@ func BenchmarkTerminalIdentificationCodeAlphaNumeric(b *testing.B) {
 func testTransactionSerialNumberAlphaNumeric(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TransactionSerialNumber = "®"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionSerialNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -604,12 +551,9 @@ func BenchmarkTransactionSerialNumberAlphaNumeric(b *testing.B) {
 func testAuthorizationCodeOrExpireDateAlphaNumeric(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.AuthorizationCodeOrExpireDate = "®"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "AuthorizationCodeOrExpireDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -630,12 +574,9 @@ func BenchmarkAuthorizationCodeOrExpireDateAlphaNumeric(b *testing.B) {
 func testTerminalLocationAlphaNumeric(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TerminalLocation = "®"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TerminalLocation" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -656,12 +597,9 @@ func BenchmarkTerminalLocationAlphaNumeric(b *testing.B) {
 func testTerminalCityAlphaNumeric(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TerminalCity = "®"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TerminalCity" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -682,12 +620,9 @@ func BenchmarkTerminalCityAlphaNumeric(b *testing.B) {
 func testTerminalStateAlphaNumeric(t testing.TB) {
 	addenda02 := mockAddenda02()
 	addenda02.TerminalState = "®"
-	if err := addenda02.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TerminalState" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda02.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda05_test.go
+++ b/addenda05_test.go
@@ -108,48 +108,37 @@ func BenchmarkAddenda05String(b *testing.B) {
 func TestValidateAddenda05RecordType(t *testing.T) {
 	addenda05 := mockAddenda05()
 	addenda05.recordType = "63"
-	if err := addenda05.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda05.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestValidateAddenda05TypeCode(t *testing.T) {
 	addenda05 := mockAddenda05()
 	addenda05.TypeCode = "23"
-	if err := addenda05.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda05.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda05FieldInclusion(t *testing.T) {
 	addenda05 := mockAddenda05()
 	addenda05.EntryDetailSequenceNumber = 0
-	if err := addenda05.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "EntryDetailSequenceNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda05.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda05FieldInclusionSequenceNumber(t *testing.T) {
 	addenda05 := mockAddenda05()
 	addenda05.SequenceNumber = 0
-	if err := addenda05.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "SequenceNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda05.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -165,24 +154,18 @@ func TestAddenda05FieldInclusionRecordType(t *testing.T) {
 func TestAddenda05PaymentRelatedInformationAlphaNumeric(t *testing.T) {
 	addenda05 := mockAddenda05()
 	addenda05.PaymentRelatedInformation = "®©"
-	if err := addenda05.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "PaymentRelatedInformation" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda05.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func testAddenda05TypeCodeNil(t testing.TB) {
 	addenda05 := mockAddenda05()
 	addenda05.TypeCode = ""
-	if err := addenda05.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda05.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -201,14 +184,9 @@ func BenchmarkAddenda05TypeCodeNil(b *testing.B) {
 func testAddenda05TypeCode05(t testing.TB) {
 	addenda05 := mockAddenda05()
 	addenda05.TypeCode = "99"
-	if err := addenda05.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda05.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda10_test.go
+++ b/addenda10_test.go
@@ -78,14 +78,10 @@ func BenchmarkAddenda10Parse(b *testing.B) {
 func testAddenda10ValidRecordType(t testing.TB) {
 	addenda10 := mockAddenda10()
 	addenda10.recordType = "63"
-	if err := addenda10.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda10.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -106,14 +102,9 @@ func BenchmarkAddenda10ValidRecordType(b *testing.B) {
 func testAddenda10ValidTypeCode(t testing.TB) {
 	addenda10 := mockAddenda10()
 	addenda10.TypeCode = "65"
-	if err := addenda10.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda10.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -134,14 +125,9 @@ func BenchmarkAddenda10ValidTypeCode(b *testing.B) {
 func testAddenda10TypeCode10(t testing.TB) {
 	addenda10 := mockAddenda10()
 	addenda10.TypeCode = "05"
-	if err := addenda10.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda10.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -162,14 +148,9 @@ func BenchmarkAddenda10TypeCode10(b *testing.B) {
 func testAddenda10TransactionTypeCode(t testing.TB) {
 	addenda10 := mockAddenda10()
 	addenda10.TransactionTypeCode = "ABC"
-	if err := addenda10.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionTypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda10.Validate()
+	if !base.Match(err, ErrTransactionTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -190,12 +171,9 @@ func BenchmarkAddenda10TransactionTypeCode(b *testing.B) {
 func testForeignTraceNumberAlphaNumeric(t testing.TB) {
 	addenda10 := mockAddenda10()
 	addenda10.ForeignTraceNumber = "®"
-	if err := addenda10.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignTraceNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda10.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -216,12 +194,9 @@ func BenchmarkForeignTraceNumberAlphaNumeric(b *testing.B) {
 func testNameAlphaNumeric(t testing.TB) {
 	addenda10 := mockAddenda10()
 	addenda10.Name = "Jas®n"
-	if err := addenda10.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "Name" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda10.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda11_test.go
+++ b/addenda11_test.go
@@ -70,14 +70,10 @@ func BenchmarkAddenda11Parse(b *testing.B) {
 func testAddenda11ValidRecordType(t testing.TB) {
 	addenda11 := mockAddenda11()
 	addenda11.recordType = "63"
-	if err := addenda11.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda11.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -98,14 +94,9 @@ func BenchmarkAddenda11ValidRecordType(b *testing.B) {
 func testAddenda11ValidTypeCode(t testing.TB) {
 	addenda11 := mockAddenda11()
 	addenda11.TypeCode = "65"
-	if err := addenda11.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda11.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -126,14 +117,9 @@ func BenchmarkAddenda11ValidTypeCode(b *testing.B) {
 func testAddenda11TypeCode11(t testing.TB) {
 	addenda11 := mockAddenda11()
 	addenda11.TypeCode = "05"
-	if err := addenda11.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda11.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -154,12 +140,9 @@ func BenchmarkAddenda11TypeCode11(b *testing.B) {
 func testOriginatorNameAlphaNumeric(t testing.TB) {
 	addenda11 := mockAddenda11()
 	addenda11.OriginatorName = "BEK S®lutions"
-	if err := addenda11.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda11.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -180,12 +163,9 @@ func BenchmarkOriginatorNameAlphaNumeric(b *testing.B) {
 func testOriginatorStreetAddressAlphaNumeric(t testing.TB) {
 	addenda11 := mockAddenda11()
 	addenda11.OriginatorStreetAddress = "15 W®st"
-	if err := addenda11.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorStreetAddress" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda11.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda12_test.go
+++ b/addenda12_test.go
@@ -70,14 +70,10 @@ func BenchmarkAddenda12Parse(b *testing.B) {
 func testAddenda12ValidRecordType(t testing.TB) {
 	addenda12 := mockAddenda12()
 	addenda12.recordType = "63"
-	if err := addenda12.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda12.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -98,14 +94,9 @@ func BenchmarkAddenda12ValidRecordType(b *testing.B) {
 func testAddenda12ValidTypeCode(t testing.TB) {
 	addenda12 := mockAddenda12()
 	addenda12.TypeCode = "65"
-	if err := addenda12.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda12.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -126,14 +117,9 @@ func BenchmarkAddenda12ValidTypeCode(b *testing.B) {
 func testAddenda12TypeCode12(t testing.TB) {
 	addenda12 := mockAddenda12()
 	addenda12.TypeCode = "05"
-	if err := addenda12.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda12.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -154,12 +140,9 @@ func BenchmarkAddenda12TypeCode12(b *testing.B) {
 func testOriginatorCityStateProvinceAlphaNumeric(t testing.TB) {
 	addenda12 := mockAddenda12()
 	addenda12.OriginatorCityStateProvince = "Jacobs®Town*PA"
-	if err := addenda12.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorCityStateProvince" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda12.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -180,12 +163,9 @@ func BenchmarkOriginatorCityStateProvinceAlphaNumeric(b *testing.B) {
 func testOriginatorCountryPostalCodeAlphaNumeric(t testing.TB) {
 	addenda12 := mockAddenda12()
 	addenda12.OriginatorCountryPostalCode = "US19®305"
-	if err := addenda12.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorCountryPostalCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda12.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda13_test.go
+++ b/addenda13_test.go
@@ -78,14 +78,10 @@ func TestMockAddenda13(t *testing.T) {
 func testAddenda13ValidRecordType(t testing.TB) {
 	addenda13 := mockAddenda13()
 	addenda13.recordType = "63"
-	if err := addenda13.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda13.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -106,14 +102,9 @@ func BenchmarkAddenda13ValidRecordType(b *testing.B) {
 func testAddenda13ValidTypeCode(t testing.TB) {
 	addenda13 := mockAddenda13()
 	addenda13.TypeCode = "65"
-	if err := addenda13.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda13.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -134,14 +125,9 @@ func BenchmarkAddenda13ValidTypeCode(b *testing.B) {
 func testAddenda13TypeCode13(t testing.TB) {
 	addenda13 := mockAddenda13()
 	addenda13.TypeCode = "05"
-	if err := addenda13.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda13.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -162,12 +148,9 @@ func BenchmarkAddenda13TypeCode13(b *testing.B) {
 func testODFINameAlphaNumeric(t testing.TB) {
 	addenda13 := mockAddenda13()
 	addenda13.ODFIName = "Wells®Fargo"
-	if err := addenda13.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ODFIName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda13.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -188,12 +171,9 @@ func BenchmarkODFINameAlphaNumeric(b *testing.B) {
 func testODFIIDNumberQualifierValid(t testing.TB) {
 	addenda13 := mockAddenda13()
 	addenda13.ODFIIDNumberQualifier = "®1"
-	if err := addenda13.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ODFIIDNumberQualifier" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda13.Validate()
+	if !base.Match(err, ErrIDNumberQualifier) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -214,12 +194,9 @@ func BenchmarkODFIIDNumberQualifierValid(b *testing.B) {
 func testODFIIdentificationAlphaNumeric(t testing.TB) {
 	addenda13 := mockAddenda13()
 	addenda13.ODFIIdentification = "®121042882"
-	if err := addenda13.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ODFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda13.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -240,12 +217,9 @@ func BenchmarkODFIIdentificationAlphaNumeric(b *testing.B) {
 func testODFIBranchCountryCodeAlphaNumeric(t testing.TB) {
 	addenda13 := mockAddenda13()
 	addenda13.ODFIBranchCountryCode = "U®"
-	if err := addenda13.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ODFIBranchCountryCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda13.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda14_test.go
+++ b/addenda14_test.go
@@ -78,14 +78,10 @@ func BenchmarkAddenda14Parse(b *testing.B) {
 func testAddenda14ValidRecordType(t testing.TB) {
 	addenda14 := mockAddenda14()
 	addenda14.recordType = "63"
-	if err := addenda14.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda14.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -106,14 +102,9 @@ func BenchmarkAddenda14ValidRecordType(b *testing.B) {
 func testAddenda14ValidTypeCode(t testing.TB) {
 	addenda14 := mockAddenda14()
 	addenda14.TypeCode = "65"
-	if err := addenda14.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda14.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -134,14 +125,9 @@ func BenchmarkAddenda14ValidTypeCode(b *testing.B) {
 func testAddenda14TypeCode14(t testing.TB) {
 	addenda14 := mockAddenda14()
 	addenda14.TypeCode = "05"
-	if err := addenda14.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda14.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -162,12 +148,9 @@ func BenchmarkAddenda14TypeCode14(b *testing.B) {
 func testRDFINameAlphaNumeric(t testing.TB) {
 	addenda14 := mockAddenda14()
 	addenda14.RDFIName = "Wells®Fargo"
-	if err := addenda14.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "RDFIName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda14.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -188,12 +171,9 @@ func BenchmarkRDFINameAlphaNumeric(b *testing.B) {
 func testRDFIIDNumberQualifierValid(t testing.TB) {
 	addenda14 := mockAddenda14()
 	addenda14.RDFIIDNumberQualifier = "®1"
-	if err := addenda14.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "RDFIIDNumberQualifier" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda14.Validate()
+	if !base.Match(err, ErrIDNumberQualifier) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -214,12 +194,9 @@ func BenchmarkRDFIIDNumberQualifierValid(b *testing.B) {
 func testRDFIIdentificationAlphaNumeric(t testing.TB) {
 	addenda14 := mockAddenda14()
 	addenda14.RDFIIdentification = "®121042882"
-	if err := addenda14.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "RDFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda14.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -240,12 +217,9 @@ func BenchmarkRDFIIdentificationAlphaNumeric(b *testing.B) {
 func testRDFIBranchCountryCodeAlphaNumeric(t testing.TB) {
 	addenda14 := mockAddenda14()
 	addenda14.RDFIBranchCountryCode = "U®"
-	if err := addenda14.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "RDFIBranchCountryCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda14.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda15_test.go
+++ b/addenda15_test.go
@@ -70,14 +70,10 @@ func BenchmarkAddenda15Parse(b *testing.B) {
 func testAddenda15ValidRecordType(t testing.TB) {
 	addenda15 := mockAddenda15()
 	addenda15.recordType = "63"
-	if err := addenda15.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda15.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -98,14 +94,9 @@ func BenchmarkAddenda15ValidRecordType(b *testing.B) {
 func testAddenda15ValidTypeCode(t testing.TB) {
 	addenda15 := mockAddenda15()
 	addenda15.TypeCode = "65"
-	if err := addenda15.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda15.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -126,14 +117,9 @@ func BenchmarkAddenda15ValidTypeCode(b *testing.B) {
 func testAddenda15TypeCode15(t testing.TB) {
 	addenda15 := mockAddenda15()
 	addenda15.TypeCode = "05"
-	if err := addenda15.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda15.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -154,12 +140,9 @@ func BenchmarkAddenda15TypeCode15(b *testing.B) {
 func testReceiverIDNumberAlphaNumeric(t testing.TB) {
 	addenda15 := mockAddenda15()
 	addenda15.ReceiverIDNumber = "9874654932®1398"
-	if err := addenda15.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReceiverIDNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda15.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -180,12 +163,9 @@ func BenchmarkReceiverIDNumberAlphaNumeric(b *testing.B) {
 func testReceiverStreetAddressAlphaNumeric(t testing.TB) {
 	addenda15 := mockAddenda15()
 	addenda15.ReceiverStreetAddress = "2121 Fr®nt Street"
-	if err := addenda15.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReceiverStreetAddress" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda15.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda16_test.go
+++ b/addenda16_test.go
@@ -70,14 +70,10 @@ func BenchmarkAddenda16Parse(b *testing.B) {
 func testAddenda16ValidRecordType(t testing.TB) {
 	addenda16 := mockAddenda16()
 	addenda16.recordType = "63"
-	if err := addenda16.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda16.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -98,14 +94,9 @@ func BenchmarkAddenda16ValidRecordType(b *testing.B) {
 func testAddenda16ValidTypeCode(t testing.TB) {
 	addenda16 := mockAddenda16()
 	addenda16.TypeCode = "65"
-	if err := addenda16.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda16.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -126,14 +117,9 @@ func BenchmarkAddenda16ValidTypeCode(b *testing.B) {
 func testAddenda16TypeCode16(t testing.TB) {
 	addenda16 := mockAddenda16()
 	addenda16.TypeCode = "05"
-	if err := addenda16.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda16.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -154,12 +140,9 @@ func BenchmarkAddenda16TypeCode16(b *testing.B) {
 func testReceiverCityStateProvinceAlphaNumeric(t testing.TB) {
 	addenda16 := mockAddenda16()
 	addenda16.ReceiverCityStateProvince = "Jacobs®Town*PA"
-	if err := addenda16.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReceiverCityStateProvince" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda16.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -180,12 +163,9 @@ func BenchmarkReceiverCityStateProvinceAlphaNumeric(b *testing.B) {
 func testReceiverCountryPostalCodeAlphaNumeric(t testing.TB) {
 	addenda16 := mockAddenda16()
 	addenda16.ReceiverCountryPostalCode = "US19®305"
-	if err := addenda16.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReceiverCountryPostalCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda16.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda17_test.go
+++ b/addenda17_test.go
@@ -102,48 +102,37 @@ func BenchmarkAddenda17String(b *testing.B) {
 func TestValidateAddenda17RecordType(t *testing.T) {
 	addenda17 := mockAddenda17()
 	addenda17.recordType = "63"
-	if err := addenda17.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda17.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda17FieldInclusionTypeCode(t *testing.T) {
 	addenda17 := mockAddenda17()
 	addenda17.TypeCode = ""
-	if err := addenda17.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda17.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda17FieldInclusion(t *testing.T) {
 	addenda17 := mockAddenda17()
 	addenda17.EntryDetailSequenceNumber = 0
-	if err := addenda17.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "EntryDetailSequenceNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda17.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda17FieldInclusionSequenceNumber(t *testing.T) {
 	addenda17 := mockAddenda17()
 	addenda17.SequenceNumber = 0
-	if err := addenda17.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "SequenceNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda17.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -160,12 +149,9 @@ func TestAddenda17FieldInclusionRecordType(t *testing.T) {
 func testAddenda17PaymentRelatedInformationAlphaNumeric(t testing.TB) {
 	addenda17 := mockAddenda17()
 	addenda17.PaymentRelatedInformation = "®©"
-	if err := addenda17.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "PaymentRelatedInformation" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda17.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -187,14 +173,9 @@ func BenchmarkAddenda17PaymentRelatedInformationAlphaNumeric(b *testing.B) {
 func testAddenda17ValidTypeCode(t testing.TB) {
 	addenda17 := mockAddenda17()
 	addenda17.TypeCode = "65"
-	if err := addenda17.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda17.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -215,14 +196,9 @@ func BenchmarkAddenda17ValidTypeCode(b *testing.B) {
 func testAddenda17TypeCode17(t testing.TB) {
 	addenda17 := mockAddenda17()
 	addenda17.TypeCode = "05"
-	if err := addenda17.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda17.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda18_test.go
+++ b/addenda18_test.go
@@ -6,6 +6,8 @@ package ach
 
 import (
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockAddenda18 creates a mock Addenda18 record
@@ -170,108 +172,82 @@ func BenchmarkAddenda18String(b *testing.B) {
 func TestValidateAddenda18RecordType(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.recordType = "63"
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda18FieldInclusionTypeCode(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.TypeCode = ""
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda18FieldInclusion(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.EntryDetailSequenceNumber = 0
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "EntryDetailSequenceNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda18FieldInclusionSequenceNumber(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.SequenceNumber = 0
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "SequenceNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda18FieldInclusionRecordType(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.recordType = ""
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda18FieldInclusionFCBankName(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.ForeignCorrespondentBankName = ""
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignCorrespondentBankName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda18FieldInclusionFCBankIDNumberQualifier(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.ForeignCorrespondentBankIDNumberQualifier = ""
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignCorrespondentBankIDNumberQualifier" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda18FieldInclusionFCBankIDNumber(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.ForeignCorrespondentBankIDNumber = ""
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignCorrespondentBankIDNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
 func TestAddenda18FieldInclusionFCBankBranchCountryCode(t *testing.T) {
 	addenda18 := mockAddenda18()
 	addenda18.ForeignCorrespondentBankBranchCountryCode = ""
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignCorrespondentBankBranchCountryCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -279,12 +255,9 @@ func TestAddenda18FieldInclusionFCBankBranchCountryCode(t *testing.T) {
 func testAddenda18ForeignCorrespondentBankNameAlphaNumeric(t testing.TB) {
 	addenda18 := mockAddenda18()
 	addenda18.ForeignCorrespondentBankName = "®©"
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignCorrespondentBankName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -306,12 +279,9 @@ func BenchmarkAddenda18ForeignCorrespondentBankNameAlphaNumeric(b *testing.B) {
 func testAddenda18ForeignCorrespondentBankIDQualifierAlphaNumeric(t testing.TB) {
 	addenda18 := mockAddenda18()
 	addenda18.ForeignCorrespondentBankIDNumberQualifier = "®©"
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignCorrespondentBankIDNumberQualifier" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -332,12 +302,9 @@ func BenchmarkAddenda18ForeignCorrespondentBankIDQualifierAlphaNumeric(b *testin
 func testAddenda18ForeignCorrespondentBankBranchCountryCodeAlphaNumeric(t testing.TB) {
 	addenda18 := mockAddenda18()
 	addenda18.ForeignCorrespondentBankBranchCountryCode = "®©"
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignCorrespondentBankBranchCountryCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -358,12 +325,9 @@ func BenchmarkAddenda18ForeignCorrespondentBankBranchCountryCodeAlphaNumeric(b *
 func testAddenda18ForeignCorrespondentBankIDNumberAlphaNumeric(t testing.TB) {
 	addenda18 := mockAddenda18()
 	addenda18.ForeignCorrespondentBankIDNumber = "®©"
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignCorrespondentBankIDNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -384,14 +348,9 @@ func BenchmarkAddendaForeignCorrespondentBankIDNumberAlphaNumeric(b *testing.B) 
 func testAddenda18ValidTypeCode(t testing.TB) {
 	addenda18 := mockAddenda18()
 	addenda18.TypeCode = "65"
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -412,14 +371,9 @@ func BenchmarkAddenda18ValidTypeCode(b *testing.B) {
 func testAddenda18TypeCode18(t testing.TB) {
 	addenda18 := mockAddenda18()
 	addenda18.TypeCode = "05"
-	if err := addenda18.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda18.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda98_test.go
+++ b/addenda98_test.go
@@ -6,6 +6,8 @@ package ach
 
 import (
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 func mockAddenda98() *Addenda98 {
@@ -82,14 +84,10 @@ func BenchmarkAddenda98String(b *testing.B) {
 func testAddenda98ValidRecordType(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.recordType = "63"
-	if err := addenda98.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda98.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 func TestAddenda98ValidRecordType(t *testing.T) {
@@ -106,14 +104,9 @@ func BenchmarkAddenda98ValidRecordType(b *testing.B) {
 func testAddenda98ValidTypeCode(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.TypeCode = "05"
-	if err := addenda98.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda98.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -131,14 +124,9 @@ func BenchmarkAddenda98ValidTypeCode(b *testing.B) {
 func testAddenda98ValidCorrectedData(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.CorrectedData = ""
-	if err := addenda98.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CorrectedData" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda98.Validate()
+	if !base.Match(err, ErrAddenda98CorrectedData) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -156,14 +144,10 @@ func BenchmarkAddenda98ValidCorrectedData(b *testing.B) {
 func testAddenda98ValidateTrue(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.ChangeCode = "C11"
-	if err := addenda98.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ChangeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda98.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -181,14 +165,9 @@ func BenchmarkAddenda98ValidateTrue(b *testing.B) {
 func testAddenda98ValidateChangeCodeFalse(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.ChangeCode = "C63"
-	if err := addenda98.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ChangeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda98.Validate()
+	if !base.Match(err, ErrAddenda98ChangeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -283,14 +262,9 @@ func BenchmarkAddenda98TraceNumberField(b *testing.B) {
 func testAddenda98TypeCodeNil(t testing.TB) {
 	addenda98 := mockAddenda98()
 	addenda98.TypeCode = ""
-	if err := addenda98.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda98.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/addenda99_test.go
+++ b/addenda99_test.go
@@ -6,6 +6,8 @@ package ach
 
 import (
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 func mockAddenda99() *Addenda99 {
@@ -110,14 +112,10 @@ func BenchmarkAddenda99MakeReturnCodeDict(b *testing.B) {
 func testAddenda99ValidateTrue(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.ReturnCode = "R13"
-	if err := addenda99.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReturnCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda99.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -135,14 +133,9 @@ func BenchmarkAddenda99ValidateTrue(b *testing.B) {
 func testAddenda99ValidateReturnCodeFalse(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.ReturnCode = ""
-	if err := addenda99.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReturnCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda99.Validate()
+	if !base.Match(err, ErrAddenda99ReturnCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -260,14 +253,10 @@ func BenchmarkAddenda99TraceNumberField(b *testing.B) {
 func testAddenda99ValidRecordType(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.recordType = "63"
-	if err := addenda99.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda99.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 func TestAddenda99ValidRecordType(t *testing.T) {
@@ -285,14 +274,9 @@ func BenchmarkAddenda99ValidRecordType(b *testing.B) {
 func testAddenda99TypeCode99(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.TypeCode = "05"
-	if err := addenda99.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda99.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -313,14 +297,9 @@ func BenchmarkAddenda99TypeCode99(b *testing.B) {
 func testAddenda99TypeCodeNil(t testing.TB) {
 	addenda99 := mockAddenda99()
 	addenda99.TypeCode = ""
-	if err := addenda99.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := addenda99.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/advBatchControl_test.go
+++ b/advBatchControl_test.go
@@ -149,12 +149,10 @@ func BenchmarkADVBCString(b *testing.B) {
 func testValidateADVBCRecordType(t testing.TB) {
 	bc := mockADVBatchControl()
 	bc.recordType = "2"
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -175,12 +173,9 @@ func BenchmarkValidateADVBCRecordType(b *testing.B) {
 func testADVBCisServiceClassErr(t testing.TB) {
 	bc := mockADVBatchControl()
 	bc.ServiceClassCode = 123
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	if !base.Match(err, ErrServiceClass) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -200,12 +195,10 @@ func BenchmarkADVBCisServiceClassErr(b *testing.B) {
 func testADVBCBatchNumber(t testing.TB) {
 	bc := mockADVBatchControl()
 	bc.BatchNumber = 0
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "BatchNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -226,12 +219,9 @@ func BenchmarkADVBCBatchNumber(b *testing.B) {
 func testADVBCACHOperatorDataAlphaNumeric(t testing.TB) {
 	bc := mockADVBatchControl()
 	bc.ACHOperatorData = "®"
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ACHOperatorData" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/advEntryDetail_test.go
+++ b/advEntryDetail_test.go
@@ -5,9 +5,10 @@
 package ach
 
 import (
-	"github.com/moov-io/base"
 	"strings"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockADVEntryDetail creates a ADV entry detail
@@ -127,12 +128,10 @@ func BenchmarkADVEDString(b *testing.B) {
 func TestValidateADVEDRecordType(t *testing.T) {
 	ed := mockADVEntryDetail()
 	ed.recordType = "2"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -140,12 +139,9 @@ func TestValidateADVEDRecordType(t *testing.T) {
 func TestValidateADVEDTransactionCode(t *testing.T) {
 	ed := mockADVEntryDetail()
 	ed.TransactionCode = 63
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrTransactionCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -153,12 +149,9 @@ func TestValidateADVEDTransactionCode(t *testing.T) {
 func TestADVEDDFIAccountNumberAlphaNumeric(t *testing.T) {
 	ed := mockADVEntryDetail()
 	ed.DFIAccountNumber = "®"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "DFIAccountNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -166,12 +159,9 @@ func TestADVEDDFIAccountNumberAlphaNumeric(t *testing.T) {
 func TestADVEDAdviceRoutingNumberAlphaNumeric(t *testing.T) {
 	ed := mockADVEntryDetail()
 	ed.AdviceRoutingNumber = "®"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "AdviceRoutingNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -179,12 +169,9 @@ func TestADVEDAdviceRoutingNumberAlphaNumeric(t *testing.T) {
 func TestADVEDIndividualNameAlphaNumeric(t *testing.T) {
 	ed := mockADVEntryDetail()
 	ed.IndividualName = "®"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "IndividualName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -192,12 +179,9 @@ func TestADVEDIndividualNameAlphaNumeric(t *testing.T) {
 func TestADVEDDiscretionaryDataAlphaNumeric(t *testing.T) {
 	ed := mockADVEntryDetail()
 	ed.DiscretionaryData = "®"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "DiscretionaryData" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -205,12 +189,9 @@ func TestADVEDDiscretionaryDataAlphaNumeric(t *testing.T) {
 func TestADVEDACHOperatorRoutingNumberAlphaNumeric(t *testing.T) {
 	ed := mockADVEntryDetail()
 	ed.ACHOperatorRoutingNumber = "®"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ACHOperatorRoutingNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -218,12 +199,9 @@ func TestADVEDACHOperatorRoutingNumberAlphaNumeric(t *testing.T) {
 func TestADVEDisCheckDigit(t *testing.T) {
 	ed := mockADVEntryDetail()
 	ed.CheckDigit = "1"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "RDFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, NewErrValidCheckDigit(7)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -321,12 +299,10 @@ func TestADVEDFieldInclusionSequenceNumber(t *testing.T) {
 func TestBadTransactionCode(t *testing.T) {
 	entry := mockADVEntryDetail()
 	entry.TransactionCode = CheckingDebit
-	if err := entry.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := entry.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -342,13 +318,8 @@ func TestInvalidADVEDParse(t *testing.T) {
 		ODFIIdentification:     "121042882"}
 	r.addCurrentBatch(NewBatchADV(&bh))
 
-	if err := r.parseEntryDetail(); err != nil {
-		if p, ok := err.(*base.ParseError); ok {
-			if p.Record != "EntryDetail" {
-				t.Errorf("%T: %s", p, p)
-			}
-		} else {
-			t.Errorf("%T: %s", p.Err, p.Err)
-		}
+	err := r.parseEntryDetail()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/advFileControl_test.go
+++ b/advFileControl_test.go
@@ -143,12 +143,10 @@ func testValidateADVFCRecordType(t testing.TB) {
 	fc := mockADVFileControl()
 	fc.recordType = "2"
 
-	if err := fc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fc.Validate()
+	// TODO: are we not expecting any errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -290,13 +288,8 @@ func TestInvalidADVFCParse(t *testing.T) {
 	batchADV := mockBatchADV()
 	r.File.AddBatch(batchADV)
 
-	if err := r.parseFileControl(); err != nil {
-		if p, ok := err.(*base.ParseError); ok {
-			if p.Record != "FileControl" {
-				t.Errorf("%T: %s", p, p)
-			}
-		} else {
-			t.Errorf("%T: %s", p.Err, p.Err)
-		}
+	err := r.parseFileControl()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batch.go
+++ b/batch.go
@@ -203,8 +203,6 @@ func (batch *Batch) Validate() error {
 
 // verify checks basic valid NACHA batch rules. Assumes properly parsed records. This does not mean it is a valid batch as validity is tied to each batch type
 func (batch *Batch) verify() error {
-	batchNumber := batch.Header.BatchNumber
-
 	// No entries in batch
 	if len(batch.Entries) <= 0 && len(batch.ADVEntries) <= 0 {
 		return batch.Error("entries", ErrBatchNoEntries)
@@ -212,10 +210,7 @@ func (batch *Batch) verify() error {
 	// verify field inclusion in all the records of the batch.
 	if err := batch.isFieldInclusion(); err != nil {
 		// convert the field error in to a batch error for a consistent api
-		if e, ok := err.(*FieldError); ok {
-			return &BatchError{BatchNumber: batchNumber, FieldName: e.FieldName, Err: e}
-		}
-		return &BatchError{BatchNumber: batchNumber, FieldName: "FieldError", Err: err}
+		return batch.Error("FieldError", err)
 	}
 
 	if !batch.IsADV() {

--- a/batchACK_test.go
+++ b/batchACK_test.go
@@ -103,14 +103,9 @@ func TestBatchACKAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -122,14 +117,9 @@ func TestBatchACKAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -138,14 +128,9 @@ func testBatchACKReceivingCompanyName(t testing.TB) {
 	mockBatch := mockBatchACK()
 	// modify the Individual name / receiving company to nothing
 	mockBatch.GetEntries()[0].SetReceivingCompany("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IndividualName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -166,14 +151,9 @@ func BenchmarkBatchACKReceivingCompanyName(b *testing.B) {
 func testBatchACKAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchACK()
 	mockBatch.GetEntries()[0].Addenda05[0].TypeCode = "07"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -242,14 +222,9 @@ func testBatchACKServiceClassCode(t testing.TB) {
 	mockBatch := mockBatchACK()
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetHeader().ServiceClassCode = 0
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchADV_test.go
+++ b/batchADV_test.go
@@ -65,14 +65,9 @@ func TestBatchADVAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetADVEntries()[0].Category = CategoryReturn
 	mockBatch.GetADVEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -104,14 +99,9 @@ func testBatchADVServiceClassCode(t testing.TB) {
 	mockBatch := mockBatchADV()
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetHeader().ServiceClassCode = 220
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchServiceClassCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchARC_test.go
+++ b/batchARC_test.go
@@ -265,14 +265,9 @@ func testBatchARCCheckSerialNumber(t testing.TB) {
 	mockBatch := mockBatchARC()
 	// modify CheckSerialNumber / IdentificationNumber to nothing
 	mockBatch.GetEntries()[0].SetCheckSerialNumber("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "CheckSerialNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrBatchCheckSerialNumber) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -341,14 +336,10 @@ func BenchmarkBatchARCAddendaCount(b *testing.B) {
 func testBatchARCInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchARC()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -373,14 +364,9 @@ func TestBatchARCAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -391,14 +377,9 @@ func TestBatchARCAddendum99(t *testing.T) {
 	mockAddenda99 := mockAddenda99()
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchATX.go
+++ b/batchATX.go
@@ -5,7 +5,6 @@
 package ach
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -17,10 +16,6 @@ import (
 type BatchATX struct {
 	Batch
 }
-
-var (
-	msgBatchATXAddendaCount = "%v entry detail addenda records not equal to addendum %v"
-)
 
 // NewBatchATX returns a *BatchATX
 func NewBatchATX(bh *BatchHeader) *BatchATX {
@@ -66,8 +61,7 @@ func (batch *BatchATX) Validate() error {
 		// use 0 value if there is no Addenda records
 		addendaRecords, _ := strconv.Atoi(entry.CATXAddendaRecordsField())
 		if len(entry.Addenda05) != addendaRecords {
-			msg := fmt.Sprintf(msgBatchATXAddendaCount, addendaRecords, len(entry.Addenda05))
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "AddendaCount", Msg: msg}
+			return batch.Error("AddendaCount", NewErrBatchExpectedAddendaCount(len(entry.Addenda05), addendaRecords))
 		}
 		// Verify the TransactionCode is valid for a ServiceClassCode
 		if err := batch.ValidTranCodeForServiceClassCode(entry); err != nil {

--- a/batchATX_test.go
+++ b/batchATX_test.go
@@ -145,14 +145,9 @@ func testBatchATXAddendaCount(t testing.TB) {
 	mockBatch := mockBatchATX()
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "AddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(2, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -174,14 +169,10 @@ func testBatchATXAddendaCountZero(t testing.TB) {
 	mockBatch := NewBatchATX(mockBatchATXHeader())
 	mockBatch.AddEntry(mockATXEntryDetail())
 	//mockBatch.GetEntries()[0].Addenda05[0].
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -218,8 +209,7 @@ func testBatchATXInvalidAddenda(t testing.TB) {
 	addenda05.recordType = "63"
 	mockBatch.GetEntries()[0].AddAddenda05(addenda05)
 	err := mockBatch.Create()
-	// TODO: are we expecting to see an error here?
-	if !base.Match(err, nil) {
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -241,14 +231,10 @@ func BenchmarkBatchATXInvalidAddenda(b *testing.B) {
 func testBatchATXInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchATX()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -346,14 +332,10 @@ func testBatchATXAddendaRecords(t testing.TB) {
 		mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	}
 
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -442,14 +424,10 @@ func testBatchATXZeroAddendaRecords(t testing.TB) {
 	mockBatch := NewBatchATX(bh)
 	mockBatch.AddEntry(entry)
 
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -555,14 +533,9 @@ func TestBatchATXAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -574,14 +547,9 @@ func TestBatchATXAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchBOC_test.go
+++ b/batchBOC_test.go
@@ -266,14 +266,9 @@ func testBatchBOCCheckSerialNumber(t testing.TB) {
 	mockBatch := mockBatchBOC()
 	// modify CheckSerialNumber / IdentificationNumber to empty string
 	mockBatch.GetEntries()[0].SetCheckSerialNumber("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "CheckSerialNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrBatchCheckSerialNumber) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -341,14 +336,10 @@ func BenchmarkBatchBOCAddenda05(b *testing.B) {
 func testBatchBOCInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchBOC()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -373,14 +364,9 @@ func TestBatchBOCAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -392,13 +378,8 @@ func TestBatchBOCAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchCCD_test.go
+++ b/batchCCD_test.go
@@ -197,7 +197,7 @@ func testBatchCCDAddendaCount(t testing.TB) {
 	mockBatch := mockBatchCCD()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !base.Match(err, NewErrBatchAddendaCount(0,1)) {
+	if !base.Match(err, NewErrBatchAddendaCount(0, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchCCD_test.go
+++ b/batchCCD_test.go
@@ -102,14 +102,9 @@ func TestBatchCCDAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -121,14 +116,9 @@ func TestBatchCCDAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -137,14 +127,9 @@ func testBatchCCDReceivingCompanyName(t testing.TB) {
 	mockBatch := mockBatchCCD()
 	// modify the Individual name / receiving company to nothing
 	mockBatch.GetEntries()[0].SetReceivingCompany("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IndividualName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -165,14 +150,9 @@ func BenchmarkBatchCCDReceivingCompanyName(b *testing.B) {
 func testBatchCCDAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchCCD()
 	mockBatch.GetEntries()[0].Addenda05[0].TypeCode = "07"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -216,14 +196,9 @@ func BenchmarkBatchCCDSEC(b *testing.B) {
 func testBatchCCDAddendaCount(t testing.TB) {
 	mockBatch := mockBatchCCD()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "AddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchAddendaCount(0,1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -245,14 +220,9 @@ func testBatchCCDCreate(t testing.TB) {
 	mockBatch := mockBatchCCD()
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetHeader().ServiceClassCode = 0
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchCIE_test.go
+++ b/batchCIE_test.go
@@ -309,14 +309,10 @@ func testBatchCIEInvalidAddenda(t testing.TB) {
 	addenda05.recordType = "63"
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -337,14 +333,10 @@ func BenchmarkBatchCIEInvalidAddenda(b *testing.B) {
 func testBatchCIEInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -365,14 +357,10 @@ func BenchmarkBatchCIEInvalidBuild(b *testing.B) {
 func testBatchCIECardTransactionType(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.GetEntries()[0].DiscretionaryData = "555"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "CardTransactionType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -397,14 +385,9 @@ func TestBatchCIEAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -416,14 +399,9 @@ func TestBatchCIEAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -432,14 +410,9 @@ func TestBatchCIEAddenda(t *testing.T) {
 	mockBatch := mockBatchCIE()
 	// mock batch already has one addenda. Creating two addenda should error
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "AddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchRequiredAddendaCount(2, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchCOR.go
+++ b/batchCOR.go
@@ -4,18 +4,12 @@
 
 package ach
 
-import (
-	"fmt"
-)
-
 // BatchCOR COR - Automated Notification of Change (NOC) or Refused Notification of Change
 // This Standard Entry Class Code is used by an RDFI or ODFI when originating a Notification of Change or Refused Notification of Change in automated format.
 // A Notification of Change may be created by an RDFI to notify the ODFI that a posted Entry or Prenotification Entry contains invalid or erroneous information and should be changed.
 type BatchCOR struct {
 	Batch
 }
-
-var msgBatchCORAmount = "debit:%v credit:%v entry detail amount fields must be zero for SEC type COR"
 
 // NewBatchCOR returns a *BatchCOR
 func NewBatchCOR(bh *BatchHeader) *BatchCOR {
@@ -43,9 +37,11 @@ func (batch *BatchCOR) Validate() error {
 	}
 	// The Amount field must be zero
 	// batch.verify calls batch.isBatchAmount which ensures the batch.Control values are accurate.
-	if batch.Control.TotalCreditEntryDollarAmount != 0 || batch.Control.TotalDebitEntryDollarAmount != 0 {
-		msg := fmt.Sprintf(msgBatchCORAmount, batch.Control.TotalCreditEntryDollarAmount, batch.Control.TotalDebitEntryDollarAmount)
-		return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "Amount", Msg: msg}
+	if batch.Control.TotalCreditEntryDollarAmount != 0 {
+		return batch.Error("TotalCreditEntryDollarAmount", ErrBatchAmountNonZero, batch.Control.TotalCreditEntryDollarAmount)
+	}
+	if batch.Control.TotalDebitEntryDollarAmount != 0 {
+		return batch.Error("TotalDebitEntryDollarAmount", ErrBatchAmountNonZero, batch.Control.TotalDebitEntryDollarAmount)
 	}
 
 	for _, entry := range batch.Entries {

--- a/batchCOR_test.go
+++ b/batchCOR_test.go
@@ -195,8 +195,16 @@ func BenchmarkBatchCORAddendaTypeCode(b *testing.B) {
 // testBatchCORAmount validates BatchCOR Amount
 func testBatchCORAmount(t testing.TB) {
 	mockBatch := mockBatchCOR()
+	// test a nonzero credit amount
 	mockBatch.GetEntries()[0].Amount = 9999
 	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchAmountNonZero) {
+		t.Errorf("%T: %s", err, err)
+	}
+
+	// test a nonzero debit amount
+	mockBatch.GetEntries()[0].TransactionCode = CheckingReturnNOCDebit
+	err = mockBatch.Create()
 	if !base.Match(err, ErrBatchAmountNonZero) {
 		t.Errorf("%T: %s", err, err)
 	}

--- a/batchCOR_test.go
+++ b/batchCOR_test.go
@@ -101,14 +101,10 @@ func testBatchCORAddendumCountTwo(t testing.TB) {
 	mockBatch := mockBatchCOR()
 	// Adding a second addenda to the mock entry
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98()
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -129,14 +125,9 @@ func BenchmarkBatchCORAddendumCountTwo(b *testing.B) {
 func testBatchCORAddendaCountZero(t testing.TB) {
 	mockBatch := NewBatchCOR(mockBatchCORHeader())
 	mockBatch.AddEntry(mockCOREntryDetail())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda98" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchCORAddenda) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -159,14 +150,9 @@ func testBatchCORAddendaType(t testing.TB) {
 	mockBatch.AddEntry(mockCOREntryDetail())
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda98" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchCORAddenda) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -187,14 +173,9 @@ func BenchmarkBatchCORAddendaType(b *testing.B) {
 func testBatchCORAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchCOR()
 	mockBatch.GetEntries()[0].Addenda98.TypeCode = "07"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -215,14 +196,9 @@ func BenchmarkBatchCORAddendaTypeCode(b *testing.B) {
 func testBatchCORAmount(t testing.TB) {
 	mockBatch := mockBatchCOR()
 	mockBatch.GetEntries()[0].Amount = 9999
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Amount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchAmountNonZero) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -291,14 +267,9 @@ func testBatchCORCreate(t testing.TB) {
 	mockBatch := mockBatchCOR()
 	// Must have valid batch header to create a Batch
 	mockBatch.GetHeader().ServiceClassCode = 63
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrServiceClass) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -346,14 +317,9 @@ func TestBatchCORCategoryNOCAddenda05(t *testing.T) {
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda05" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchAddendaCategory) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -378,14 +344,10 @@ func TestBatchCORCategoryNOCAddenda98(t *testing.T) {
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda98" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -409,14 +371,10 @@ func TestBatchCORTestBatchCORInvalidAddenda98(t *testing.T) {
 	mockBatch.GetEntries()[0].Addenda98 = addenda98
 
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -424,13 +382,8 @@ func TestBatchCORTestBatchCORInvalidAddenda98(t *testing.T) {
 func TestBatchCORAutomatedAccountingAdvices(t *testing.T) {
 	mockBatch := mockBatchCOR()
 	mockBatch.GetEntries()[0].TransactionCode = 65
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TransactionCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrTransactionCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchCTX.go
+++ b/batchCTX.go
@@ -5,7 +5,6 @@
 package ach
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -18,10 +17,6 @@ import (
 type BatchCTX struct {
 	Batch
 }
-
-var (
-	msgBatchCTXAddendaCount = "%v entry detail addenda records not equal to addendum %v"
-)
 
 // NewBatchCTX returns a *BatchCTX
 func NewBatchCTX(bh *BatchHeader) *BatchCTX {
@@ -57,8 +52,7 @@ func (batch *BatchCTX) Validate() error {
 		// use 0 value if there is no Addenda records
 		addendaRecords, _ := strconv.Atoi(entry.CATXAddendaRecordsField())
 		if len(entry.Addenda05) != addendaRecords {
-			msg := fmt.Sprintf(msgBatchCTXAddendaCount, addendaRecords, len(entry.Addenda05))
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "Addendum", Msg: msg}
+			return batch.Error("AddendaCount", NewErrBatchExpectedAddendaCount(len(entry.Addenda05), addendaRecords))
 		}
 
 		switch entry.TransactionCode {

--- a/batchCTX_test.go
+++ b/batchCTX_test.go
@@ -144,14 +144,9 @@ func BenchmarkBatchCTXServiceClassCodeEquality(b *testing.B) {
 func testBatchCTXAddendaCount(t testing.TB) {
 	mockBatch := mockBatchCTX()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(0, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -172,14 +167,9 @@ func BenchmarkBatchCTXAddendaCount(b *testing.B) {
 func testBatchCTXAddendaCountZero(t testing.TB) {
 	mockBatch := NewBatchCTX(mockBatchCTXHeader())
 	mockBatch.AddEntry(mockCTXEntryDetail())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(0, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -204,14 +194,10 @@ func testBatchCTXInvalidAddenda(t testing.TB) {
 	addenda05.recordType = "63"
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -232,14 +218,10 @@ func BenchmarkBatchCTXInvalidAddenda(b *testing.B) {
 func testBatchCTXInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchCTX()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -334,14 +316,9 @@ func testBatchCTXAddendaRecords(t testing.TB) {
 		mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	}
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(0, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -428,14 +405,9 @@ func testBatchCTXZeroAddendaRecords(t testing.TB) {
 	mockBatch := NewBatchCTX(bh)
 	mockBatch.AddEntry(entry)
 
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(0, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -479,14 +451,9 @@ func testBatchCTXPrenoteAddendaRecords(t testing.TB) {
 	mockBatch.AddEntry(entry)
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchTransactionCodeAddenda) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -511,14 +478,9 @@ func TestBatchCTXAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -530,14 +492,9 @@ func TestBatchCTXAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchControl_test.go
+++ b/batchControl_test.go
@@ -153,12 +153,10 @@ func BenchmarkBCString(b *testing.B) {
 func testValidateBCRecordType(t testing.TB) {
 	bc := mockBatchControl()
 	bc.recordType = "2"
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -179,12 +177,9 @@ func BenchmarkValidateBCRecordType(b *testing.B) {
 func testBCisServiceClassErr(t testing.TB) {
 	bc := mockBatchControl()
 	bc.ServiceClassCode = 123
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	if !base.Match(err, ErrServiceClass) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -204,12 +199,10 @@ func BenchmarkBCisServiceClassErr(b *testing.B) {
 func testBCBatchNumber(t testing.TB) {
 	bc := mockBatchControl()
 	bc.BatchNumber = 0
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "BatchNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -230,12 +223,9 @@ func BenchmarkBCBatchNumber(b *testing.B) {
 func testBCCompanyIdentificationAlphaNumeric(t testing.TB) {
 	bc := mockBatchControl()
 	bc.CompanyIdentification = "®"
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -256,12 +246,9 @@ func BenchmarkBCCompanyIdentificationAlphaNumeric(b *testing.B) {
 func testBCMessageAuthenticationCodeAlphaNumeric(t testing.TB) {
 	bc := mockBatchControl()
 	bc.MessageAuthenticationCode = "®"
-	if err := bc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "MessageAuthenticationCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bc.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchDNE_test.go
+++ b/batchDNE_test.go
@@ -188,7 +188,7 @@ func testBatchDNEAddendaCount(t testing.TB) {
 	mockBatch := mockBatchDNE()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !base.Match(err, NewErrBatchAddendaCount(0,1)) {
+	if !base.Match(err, NewErrBatchAddendaCount(0, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchDNE_test.go
+++ b/batchDNE_test.go
@@ -105,14 +105,10 @@ func BenchmarkBatchDNEAddendumCount(b *testing.B) {
 func TestBatchDNEAddendum98(t *testing.T) {
 	mockBatch := NewBatchDNE(mockBatchDNEHeader())
 	mockBatch.AddEntry(mockDNEEntryDetail())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -121,14 +117,9 @@ func testBatchDNEReceivingCompanyName(t testing.TB) {
 	mockBatch := mockBatchDNE()
 	// modify the Individual name / receiving company to nothing
 	mockBatch.GetEntries()[0].SetReceivingCompany("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IndividualName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -149,14 +140,10 @@ func BenchmarkBatchDNEReceivingCompanyName(b *testing.B) {
 func testBatchDNEAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchDNE()
 	mockBatch.GetEntries()[0].Addenda05[0].TypeCode = "05"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -200,14 +187,9 @@ func BenchmarkBatchDNESEC(b *testing.B) {
 func testBatchDNEAddendaCount(t testing.TB) {
 	mockBatch := mockBatchDNE()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "AddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchAddendaCount(0,1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -229,14 +211,9 @@ func testBatchDNEServiceClassCode(t testing.TB) {
 	mockBatch := mockBatchDNE()
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetHeader().ServiceClassCode = 0
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchENR_test.go
+++ b/batchENR_test.go
@@ -104,14 +104,10 @@ func BenchmarkBatchENRAddendumCount(b *testing.B) {
 func TestBatchENRAddendum98(t *testing.T) {
 	mockBatch := NewBatchENR(mockBatchENRHeader())
 	mockBatch.AddEntry(mockENREntryDetail())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -142,14 +138,9 @@ func BenchmarkBatchENRCompanyEntryDescription(b *testing.B) {
 func testBatchENRAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchENR()
 	mockBatch.GetEntries()[0].Addenda05[0].TypeCode = "98"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -193,14 +184,10 @@ func BenchmarkBatchENRSEC(b *testing.B) {
 func testBatchENRAddendaCount(t testing.TB) {
 	mockBatch := mockBatchENR()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "AddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -221,14 +208,9 @@ func BenchmarkBatchENRAddendaCount(b *testing.B) {
 func testBatchENRServiceClassCode(t testing.TB) {
 	mockBatch := mockBatchENR()
 	mockBatch.GetHeader().ServiceClassCode = 0
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchErrors.go
+++ b/batchErrors.go
@@ -50,7 +50,6 @@ type BatchError struct {
 	BatchType   string
 	FieldName   string
 	FieldValue  interface{}
-	Msg         string // deprecated
 	Err         error
 }
 
@@ -268,6 +267,27 @@ func (e ErrBatchRequiredAddendaCount) Error() string {
 	return e.Message
 }
 
+// ErrBatchExpectedAddendaCount is the error given when the batch type has entries with a field
+// for the number of addenda, and a different number of addenda are foound
+type ErrBatchExpectedAddendaCount struct {
+	Message       string
+	FoundCount    int
+	ExpectedCount int
+}
+
+// NewErrBatchExpectedAddendaCount creates a new error of the ErrBatchExpectedAddendaCount type
+func NewErrBatchExpectedAddendaCount(found, expected int) ErrBatchExpectedAddendaCount {
+	return ErrBatchExpectedAddendaCount{
+		Message:       fmt.Sprintf("%v addendum found where %v are Expected for this batch type", found, expected),
+		FoundCount:    found,
+		ExpectedCount: expected,
+	}
+}
+
+func (e ErrBatchExpectedAddendaCount) Error() string {
+	return e.Message
+}
+
 // ErrBatchServiceClassTranCode is the error given when the transaction code is not valid for the batch's service class
 type ErrBatchServiceClassTranCode struct {
 	Message          string
@@ -306,5 +326,26 @@ func NewErrBatchAmount(amount, limit int) ErrBatchAmount {
 }
 
 func (e ErrBatchAmount) Error() string {
+	return e.Message
+}
+
+// ErrBatchIATNOC is the error given when an IAT batch has an NOC, and there are invalid values
+type ErrBatchIATNOC struct {
+	Message  string
+	Found    interface{}
+	Expected interface{}
+}
+
+// NewErrBatchIATNOC creates a new error of the ErrBatchIATNOC type
+func NewErrBatchIATNOC(found, expected interface{}) ErrBatchIATNOC {
+	// TODO: pretty format the amounts to make it more readable
+	return ErrBatchIATNOC{
+		Message:  fmt.Sprintf("%v invalid for IAT NOC, should be %v", found, expected),
+		Found:    found,
+		Expected: expected,
+	}
+}
+
+func (e ErrBatchIATNOC) Error() string {
 	return e.Message
 }

--- a/batchHeader_test.go
+++ b/batchHeader_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"strings"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockBatchHeader creates a batch header
@@ -156,12 +158,10 @@ func BenchmarkBHString(b *testing.B) {
 func testValidateBHRecordType(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.recordType = "2"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -182,12 +182,9 @@ func BenchmarkValidateBHRecordType(b *testing.B) {
 func testInvalidServiceCode(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.ServiceClassCode = 123
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrServiceClass) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -208,12 +205,9 @@ func BenchmarkInvalidServiceCode(b *testing.B) {
 func testInvalidSECCode(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.StandardEntryClassCode = "123"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "StandardEntryClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrSECCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -234,12 +228,9 @@ func BenchmarkInvalidSECCode(b *testing.B) {
 func testInvalidOrigStatusCode(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.OriginatorStatusCode = 3
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorStatusCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrOrigStatusCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -260,12 +251,10 @@ func BenchmarkInvalidOrigStatusCode(b *testing.B) {
 func testBatchHeaderFieldInclusion(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.BatchNumber = 0
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "BatchNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -286,12 +275,9 @@ func BenchmarkBatchHeaderFieldInclusion(b *testing.B) {
 func testBatchHeaderCompanyNameAlphaNumeric(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.CompanyName = "AT&T®"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -312,12 +298,9 @@ func BenchmarkBatchHeaderCompanyNameAlphaNumeric(b *testing.B) {
 func testBatchCompanyDiscretionaryDataAlphaNumeric(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.CompanyDiscretionaryData = "®"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyDiscretionaryData" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -338,12 +321,9 @@ func BenchmarkBatchCompanyDiscretionaryDataAlphaNumeric(b *testing.B) {
 func testBatchCompanyIdentificationAlphaNumeric(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.CompanyIdentification = "®"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -364,12 +344,9 @@ func BenchmarkBatchCompanyIdentificationAlphaNumeric(b *testing.B) {
 func testBatchCompanyEntryDescriptionAlphaNumeric(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.CompanyEntryDescription = "P®YROLL"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyEntryDescription" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -390,12 +367,9 @@ func BenchmarkBatchCompanyEntryDescriptionAlphaNumeric(b *testing.B) {
 func testBHFieldInclusionRecordType(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.recordType = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -416,12 +390,9 @@ func BenchmarkBHFieldInclusionRecordType(b *testing.B) {
 func testBHFieldInclusionCompanyName(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.CompanyName = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -442,12 +413,9 @@ func BenchmarkBHFieldInclusionCompanyName(b *testing.B) {
 func testBHFieldInclusionCompanyIdentification(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.CompanyIdentification = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -468,12 +436,9 @@ func BenchmarkBHFieldInclusionCompanyIdentification(b *testing.B) {
 func testBHFieldInclusionStandardEntryClassCode(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.StandardEntryClassCode = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "StandardEntryClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -494,12 +459,9 @@ func BenchmarkBHFieldInclusionStandardEntryClassCode(b *testing.B) {
 func testBHFieldInclusionCompanyEntryDescription(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.CompanyEntryDescription = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyEntryDescription" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -520,12 +482,10 @@ func BenchmarkBHFieldInclusionCompanyEntryDescription(b *testing.B) {
 func testBHFieldInclusionOriginatorStatusCode(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.OriginatorStatusCode = 0
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorStatusCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -546,12 +506,9 @@ func BenchmarkBHFieldInclusionOriginatorStatusCode(b *testing.B) {
 func testBHFieldInclusionODFIIdentification(t testing.TB) {
 	bh := mockBatchHeader()
 	bh.ODFIIdentification = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ODFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchMTE.go
+++ b/batchMTE.go
@@ -5,8 +5,6 @@
 package ach
 
 import (
-	"fmt"
-
 	"github.com/moov-io/ach/internal/usabbrev"
 )
 
@@ -54,8 +52,7 @@ func (batch *BatchMTE) Validate() error {
 		}
 		if entry.Category == CategoryForward {
 			if !usabbrev.Valid(entry.Addenda02.TerminalState) {
-				msg := fmt.Sprintf("%q is not a valid US state or territory", entry.Addenda02.TerminalState)
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TerminalState", Msg: msg}
+				return batch.Error("TerminalState", ErrValidState, entry.Addenda02.TerminalState)
 			}
 		}
 	}

--- a/batchMTE_test.go
+++ b/batchMTE_test.go
@@ -89,14 +89,10 @@ func BenchmarkBatchMTEHeader(b *testing.B) {
 func TestBatchMTEAddendum02(t *testing.T) {
 	mockBatch := NewBatchMTE(mockBatchMTEHeader())
 	mockBatch.AddEntry(mockMTEEntryDetail())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -105,14 +101,9 @@ func testBatchMTEReceivingCompanyName(t testing.TB) {
 	mockBatch := mockBatchMTE()
 	// modify the Individual name / receiving company to nothing
 	mockBatch.GetEntries()[0].SetReceivingCompany("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IndividualName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -133,14 +124,9 @@ func BenchmarkBatchMTEReceivingCompanyName(b *testing.B) {
 func testBatchMTEAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchMTE()
 	mockBatch.GetEntries()[0].Addenda02.TypeCode = "05"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -185,14 +171,9 @@ func testBatchMTEServiceClassCode(t testing.TB) {
 	mockBatch := mockBatchMTE()
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetHeader().ServiceClassCode = 0
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -222,14 +203,9 @@ func TestBatchMTEAmount(t *testing.T) {
 func TestBatchMTETerminalState(t *testing.T) {
 	mockBatch := mockBatchMTE()
 	mockBatch.GetEntries()[0].Addenda02.TerminalState = "XX"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TerminalState" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrValidState) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -237,14 +213,9 @@ func TestBatchMTETerminalState(t *testing.T) {
 func TestBatchMTEIndividualName(t *testing.T) {
 	mockBatch := mockBatchMTE()
 	mockBatch.GetEntries()[0].IndividualName = ""
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IndividualName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -254,25 +225,17 @@ func TestBatchMTEIdentificationNumber(t *testing.T) {
 
 	// NACHA rules state MTE records can't be all spaces or all zeros
 	mockBatch.GetEntries()[0].IdentificationNumber = "   "
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IdentificationNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 	mockBatch.GetEntries()[0].IdentificationNumber = "000000"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IdentificationNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err = mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchPOP_test.go
+++ b/batchPOP_test.go
@@ -269,14 +269,9 @@ func testBatchPOPCheckSerialNumber(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	// modify CheckSerialNumber / IdentificationNumber to nothing
 	mockBatch.GetEntries()[0].SetCheckSerialNumber("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "CheckSerialNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrBatchCheckSerialNumber) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -397,14 +392,9 @@ func testBatchPOPAddendaCount(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda05" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchAddendaCategory) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -425,14 +415,10 @@ func BenchmarkBatchPOPAddendaCount(b *testing.B) {
 func testBatchPOPInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchPOP()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -457,14 +443,9 @@ func TestBatchPOPAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -476,13 +457,8 @@ func TestBatchPOPAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -5,8 +5,6 @@
 package ach
 
 import (
-	"fmt"
-
 	"github.com/moov-io/ach/internal/usabbrev"
 )
 
@@ -76,8 +74,7 @@ func (batch *BatchPOS) Validate() error {
 		}
 		if entry.Category == CategoryForward {
 			if !usabbrev.Valid(entry.Addenda02.TerminalState) {
-				msg := fmt.Sprintf("%q is not a valid US state or territory", entry.Addenda02.TerminalState)
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TerminalState", Msg: msg}
+				return batch.Error("TerminalState", ErrValidState, entry.Addenda02.TerminalState)
 			}
 		}
 	}

--- a/batchPOS_test.go
+++ b/batchPOS_test.go
@@ -234,14 +234,10 @@ func BenchmarkBatchPOSTransactionCode(b *testing.B) {
 func testBatchPOSAddendaCount(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -265,14 +261,10 @@ func testBatchPOSAddendaCountZero(t testing.TB) {
 	mockAddenda02 := mockAddenda02()
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "AddendaCount" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -323,14 +315,9 @@ func TestBatchPOSAddendum98(t *testing.T) {
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda98" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -342,14 +329,9 @@ func TestBatchPOSAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -361,14 +343,10 @@ func testBatchPOSInvalidAddenda(t testing.TB) {
 	addenda02.recordType = "63"
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -389,14 +367,10 @@ func BenchmarkBatchPOSInvalidAddenda(b *testing.B) {
 func testBatchPOSInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchPOS()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -458,14 +432,9 @@ func TestBatchPOSCategoryReturn(t *testing.T) {
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda02" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchAddendaCategory) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -475,14 +444,9 @@ func TestBatchPOSCategoryReturnAddenda99(t *testing.T) {
 	mockBatch.AddEntry(mockPOSEntryDetail())
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda99" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchPOS_test.go
+++ b/batchPOS_test.go
@@ -458,8 +458,8 @@ func TestBatchPOSTerminalState(t *testing.T) {
 	mockAddenda02.TerminalState = "YY"
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	err := mockBatch.Validate()
-	if !base.Match(err, NewErrBatchHeaderControlEquality("225", "200")) {
+	err := mockBatch.Create()
+	if !base.Match(err, ErrValidState) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchPPD_test.go
+++ b/batchPPD_test.go
@@ -137,14 +137,9 @@ func testBatchPPDCreate(t testing.TB) {
 	mockBatch := mockBatchPPD()
 	// can not have default values in Batch Header to build batch
 	mockBatch.GetHeader().ServiceClassCode = 0
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -168,14 +163,9 @@ func testBatchPPDTypeCode(t testing.TB) {
 	a := mockAddenda05()
 	a.TypeCode = "63"
 	mockBatch.GetEntries()[0].AddAddenda05(a)
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -297,14 +287,9 @@ func TestBatchPPDAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -316,14 +301,9 @@ func TestBatchPPDAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchRCK_test.go
+++ b/batchRCK_test.go
@@ -241,14 +241,9 @@ func BenchmarkBatchRCKAutomatedAccountingAdvices(b *testing.B) {
 func testBatchRCKCompanyEntryDescription(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.Header.CompanyEntryDescription = "XYZ975"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "CompanyEntryDescription" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchCompanyEntryDescriptionREDEPCHECK) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -293,14 +288,9 @@ func testBatchRCKCheckSerialNumber(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	// modify CheckSerialNumber / IdentificationNumber to empty string
 	mockBatch.GetEntries()[0].SetCheckSerialNumber("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "CheckSerialNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrBatchCheckSerialNumber) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -346,14 +336,9 @@ func testBatchRCKAddendaCount(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda05" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchAddendaCategory) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -400,14 +385,10 @@ func BenchmarkBatchRCKParseCheckSerialNumber(b *testing.B) {
 func testBatchRCKInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchRCK()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -432,14 +413,9 @@ func TestBatchRCKAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -451,13 +427,8 @@ func TestBatchRCKAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -5,8 +5,6 @@
 package ach
 
 import (
-	"fmt"
-
 	"github.com/moov-io/ach/internal/usabbrev"
 )
 
@@ -80,8 +78,7 @@ func (batch *BatchSHR) Validate() error {
 		}
 		if entry.Category == CategoryForward {
 			if !usabbrev.Valid(entry.Addenda02.TerminalState) {
-				msg := fmt.Sprintf("%q is not a valid US state or territory", entry.Addenda02.TerminalState)
-				return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "TerminalState", Msg: msg}
+				return batch.Error("TerminalState", ErrValidState, entry.Addenda02.TerminalState)
 			}
 		}
 	}

--- a/batchSHR_test.go
+++ b/batchSHR_test.go
@@ -235,14 +235,10 @@ func BenchmarkBatchSHRTransactionCode(b *testing.B) {
 func testBatchSHRAddendaCount(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -293,14 +289,9 @@ func TestBatchSHRAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -312,14 +303,9 @@ func TestBatchSHRAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -357,14 +343,10 @@ func testBatchSHRInvalidAddenda(t testing.TB) {
 	addenda02.recordType = "63"
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -385,14 +367,10 @@ func BenchmarkBatchSHRInvalidAddenda(b *testing.B) {
 func testBatchSHRInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -511,14 +489,9 @@ func BenchmarkBatchSHRDocumentReferenceNumberField(b *testing.B) {
 func testSHRCardExpirationDateMonth(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.GetEntries()[0].SetSHRCardExpirationDate("1306")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CardExpirationDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrValidMonth) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -539,14 +512,9 @@ func BenchmarkSHRCardExpirationDateMonth(b *testing.B) {
 func testSHRCardExpirationDateYear(t testing.TB) {
 	mockBatch := mockBatchSHR()
 	mockBatch.GetEntries()[0].SetSHRCardExpirationDate("0612")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CardExpirationDate" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrValidYear) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchSHR_test.go
+++ b/batchSHR_test.go
@@ -553,8 +553,8 @@ func TestBatchSHRTerminalState(t *testing.T) {
 	mockAddenda02.TerminalState = "YY"
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	err := mockBatch.Validate()
-	if !base.Match(err, NewErrBatchHeaderControlEquality("225", "200")) {
+	err := mockBatch.Create()
+	if !base.Match(err, ErrValidState) {
 		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/batchTEL_test.go
+++ b/batchTEL_test.go
@@ -73,14 +73,9 @@ func testBatchTELCreate(t testing.TB) {
 	mockBatch := mockBatchTEL()
 	// Batch Header information is required to Create a batch.
 	mockBatch.GetHeader().ServiceClassCode = 0
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -173,15 +168,10 @@ func BenchmarkBatchTELDebit(b *testing.B) {
 func testBatchTELPaymentType(t testing.TB) {
 	mockBatch := mockBatchTEL()
 	mockBatch.GetEntries()[0].DiscretionaryData = "AA"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			println(e.Error())
-			if e.FieldName != "PaymentType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -208,14 +198,9 @@ func TestBatchTELAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -227,14 +212,9 @@ func TestBatchTELAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchTRC_test.go
+++ b/batchTRC_test.go
@@ -245,14 +245,10 @@ func testBatchTRCCheckSerialNumber(t testing.TB) {
 	mockBatch := mockBatchTRC()
 	// modify CheckSerialNumber / IdentificationNumber to nothing
 	mockBatch.GetEntries()[0].SetCheckSerialNumber("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "CheckSerialNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -321,14 +317,10 @@ func BenchmarkBatchTRCAddendaCount(b *testing.B) {
 func testBatchTRCInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchTRC()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -353,14 +345,9 @@ func TestBatchTRCAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -371,14 +358,9 @@ func TestBatchTRCAddendum99(t *testing.T) {
 	mockAddenda99 := mockAddenda99()
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -401,14 +383,9 @@ func TestBatchTRCProcessControlField(t *testing.T) {
 	mockBatch := NewBatchTRC(mockBatchTRCHeader())
 	mockBatch.AddEntry(mockTRCEntryDetail())
 	mockBatch.GetEntries()[0].SetProcessControlField("")
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ProcessControlField" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrFieldRequired) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -419,14 +396,9 @@ func TestBatchTRCItemResearchNumber(t *testing.T) {
 	mockBatch.GetEntries()[0].IndividualName = ""
 	mockBatch.GetEntries()[0].SetProcessControlField("CHECK1")
 	mockBatch.GetEntries()[0].SetItemResearchNumber("")
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ItemResearchNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrFieldRequired) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchTRX.go
+++ b/batchTRX.go
@@ -5,7 +5,6 @@
 package ach
 
 import (
-	"fmt"
 	"strconv"
 )
 
@@ -15,10 +14,6 @@ import (
 type BatchTRX struct {
 	Batch
 }
-
-var (
-	msgBatchTRXAddendaCount = "%v entry detail addenda records not equal to addendum %v"
-)
 
 // NewBatchTRX returns a *BatchTRX
 func NewBatchTRX(bh *BatchHeader) *BatchTRX {
@@ -62,8 +57,7 @@ func (batch *BatchTRX) Validate() error {
 		// use 0 value if there is no Addenda records
 		addendaRecords, _ := strconv.Atoi(entry.CATXAddendaRecordsField())
 		if len(entry.Addenda05) != addendaRecords {
-			msg := fmt.Sprintf(msgBatchTRXAddendaCount, addendaRecords, len(entry.Addenda05))
-			return &BatchError{BatchNumber: batch.Header.BatchNumber, FieldName: "Addendum", Msg: msg}
+			return batch.Error("AddendaCount", NewErrBatchExpectedAddendaCount(len(entry.Addenda05), addendaRecords))
 		}
 		// Verify the TransactionCode is valid for a ServiceClassCode
 		if err := batch.ValidTranCodeForServiceClassCode(entry); err != nil {

--- a/batchTRX_test.go
+++ b/batchTRX_test.go
@@ -178,14 +178,9 @@ func BenchmarkBatchTRXServiceClassCodeEquality(b *testing.B) {
 func testBatchTRXAddendaCount(t testing.TB) {
 	mockBatch := mockBatchTRX()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(2, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -206,14 +201,9 @@ func BenchmarkBatchTRXAddendaCount(b *testing.B) {
 func testBatchTRXAddendaCountZero(t testing.TB) {
 	mockBatch := NewBatchTRX(mockBatchTRXHeader())
 	mockBatch.AddEntry(mockTRXEntryDetail())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(0, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -236,14 +226,9 @@ func testBatchTRXInvalidAddendum(t testing.TB) {
 	mockBatch.AddEntry(mockTRXEntryDetail())
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(0, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -268,14 +253,10 @@ func testBatchTRXInvalidAddenda(t testing.TB) {
 	addenda05.recordType = "63"
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -296,14 +277,10 @@ func BenchmarkBatchTRXInvalidAddenda(b *testing.B) {
 func testBatchTRXInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchTRX()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -398,14 +375,9 @@ func testBatchTRXAddendaRecords(t testing.TB) {
 		mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	}
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(565, 500)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -492,14 +464,9 @@ func testBatchTRXZeroAddendaRecords(t testing.TB) {
 	mockBatch := NewBatchTRX(bh)
 	mockBatch.AddEntry(entry)
 
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, NewErrBatchExpectedAddendaCount(0, 1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -546,14 +513,9 @@ func TestBatchTRXAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -565,14 +527,9 @@ func TestBatchTRXAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batchWEB_test.go
+++ b/batchWEB_test.go
@@ -79,14 +79,9 @@ func testBatchWebIndividualNameRequired(t testing.TB) {
 	mockBatch := mockBatchWEB()
 	// mock batch already has one addenda. Creating two addenda should error
 	mockBatch.GetEntries()[0].IndividualName = ""
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IndividualName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -111,14 +106,9 @@ func TestBatchWEBAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -130,14 +120,9 @@ func TestBatchWEBAddendum99(t *testing.T) {
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryReturn
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -146,14 +131,9 @@ func testBatchWEBAddendaTypeCode(t testing.TB) {
 	mockBatch := mockBatchWEB()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	mockBatch.GetEntries()[0].Addenda05[0].TypeCode = "02"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -198,14 +178,10 @@ func BenchmarkBatchWebSEC(b *testing.B) {
 func testBatchWebPaymentType(t testing.TB) {
 	mockBatch := mockBatchWEB()
 	mockBatch.GetEntries()[0].DiscretionaryData = "AA"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "PaymentType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -229,14 +205,9 @@ func testBatchWebCreate(t testing.TB) {
 	mockBatch := mockBatchWEB()
 	// Must have valid batch header to create a batch
 	mockBatch.GetHeader().ServiceClassCode = 63
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrServiceClass) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -258,14 +229,10 @@ func BenchmarkBatchWebCreate(b *testing.B) {
 func testBatchWebPaymentTypeR(t testing.TB) {
 	mockBatch := mockBatchWEB()
 	mockBatch.GetEntries()[0].DiscretionaryData = "R"
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "PaymentType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 	if mockBatch.GetEntries()[0].PaymentTypeField() != "R" {
 		t.Errorf("PaymentTypeField %v was expecting R", mockBatch.GetEntries()[0].PaymentTypeField())

--- a/batchXCK_test.go
+++ b/batchXCK_test.go
@@ -245,14 +245,10 @@ func testBatchXCKCheckSerialNumber(t testing.TB) {
 	mockBatch := mockBatchXCK()
 	// modify CheckSerialNumber / IdentificationNumber to nothing
 	mockBatch.GetEntries()[0].SetCheckSerialNumber("")
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "CheckSerialNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -298,14 +294,9 @@ func testBatchXCKAddendaCount(t testing.TB) {
 	mockBatch := mockBatchXCK()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda05" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrBatchAddendaCategory) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -326,14 +317,10 @@ func BenchmarkBatchXCKAddendaCount(b *testing.B) {
 func testBatchXCKInvalidBuild(t testing.TB) {
 	mockBatch := mockBatchXCK()
 	mockBatch.GetHeader().recordType = "3"
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -358,14 +345,9 @@ func TestBatchXCKAddendum98(t *testing.T) {
 	mockAddenda98.TypeCode = "05"
 	mockBatch.GetEntries()[0].Category = CategoryNOC
 	mockBatch.GetEntries()[0].Addenda98 = mockAddenda98
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -376,14 +358,9 @@ func TestBatchXCKAddendum99(t *testing.T) {
 	mockAddenda99 := mockAddenda99()
 	mockAddenda99.TypeCode = "05"
 	mockBatch.GetEntries()[0].Addenda99 = mockAddenda99
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -406,14 +383,9 @@ func TestBatchXCKProcessControlField(t *testing.T) {
 	mockBatch := NewBatchXCK(mockBatchXCKHeader())
 	mockBatch.AddEntry(mockXCKEntryDetail())
 	mockBatch.GetEntries()[0].SetProcessControlField("")
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ProcessControlField" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrFieldRequired) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -424,14 +396,9 @@ func TestBatchXCKItemResearchNumber(t *testing.T) {
 	mockBatch.GetEntries()[0].IndividualName = ""
 	mockBatch.GetEntries()[0].SetProcessControlField("CHECK1")
 	mockBatch.GetEntries()[0].SetItemResearchNumber("")
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ItemResearchNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	if !base.Match(err, ErrFieldRequired) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -513,14 +513,9 @@ func BenchmarkBatchTraceNumberExists(b *testing.B) {
 func testBatchFieldInclusion(t testing.TB) {
 	mockBatch := mockBatch()
 	mockBatch.Header.ODFIIdentification = ""
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ODFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -5,6 +5,7 @@
 package ach
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -159,12 +160,10 @@ func BenchmarkEDString(b *testing.B) {
 func testValidateEDRecordType(t testing.TB) {
 	ed := mockEntryDetail()
 	ed.recordType = "2"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -185,12 +184,9 @@ func BenchmarkValidateEDRecordType(b *testing.B) {
 func testValidateEDTransactionCode(t testing.TB) {
 	ed := mockEntryDetail()
 	ed.TransactionCode = 63
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrTransactionCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -234,12 +230,9 @@ func BenchmarkEDFieldInclusion(b *testing.B) {
 func testEDdfiAccountNumberAlphaNumeric(t testing.TB) {
 	ed := mockEntryDetail()
 	ed.DFIAccountNumber = "®"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "DFIAccountNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -260,12 +253,9 @@ func BenchmarkEDdfiAccountNumberAlphaNumeric(b *testing.B) {
 func testEDIdentificationNumberAlphaNumeric(t testing.TB) {
 	ed := mockEntryDetail()
 	ed.IdentificationNumber = "®"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "IdentificationNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -286,12 +276,9 @@ func BenchmarkEDIdentificationNumberAlphaNumeric(b *testing.B) {
 func testEDIndividualNameAlphaNumeric(t testing.TB) {
 	ed := mockEntryDetail()
 	ed.IndividualName = "W®DE"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "IndividualName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -312,12 +299,9 @@ func BenchmarkEDIndividualNameAlphaNumeric(b *testing.B) {
 func testEDDiscretionaryDataAlphaNumeric(t testing.TB) {
 	ed := mockEntryDetail()
 	ed.DiscretionaryData = "®!"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "DiscretionaryData" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -338,12 +322,9 @@ func BenchmarkEDDiscretionaryDataAlphaNumeric(b *testing.B) {
 func testEDisCheckDigit(t testing.TB) {
 	ed := mockEntryDetail()
 	ed.CheckDigit = "1"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "RDFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, NewErrValidCheckDigit(7)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -625,12 +606,9 @@ func BenchmarkEDCreditOrDebit(b *testing.B) {
 func testValidateEDCheckDigit(t testing.TB) {
 	ed := mockEntryDetail()
 	ed.CheckDigit = "XYZ"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CheckDigit" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, &strconv.NumError{}) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/fieldErrors.go
+++ b/fieldErrors.go
@@ -40,6 +40,12 @@ var (
 	ErrValidDay = errors.New("is an invalid day")
 	//ErrValidYear is given when there's an invalid year
 	ErrValidYear = errors.New("is an invalid year")
+	// ErrValidState is the error given when a field has an invalid US state or territory
+	ErrValidState = errors.New("is an invalid US state or territory")
+	// ErrValidISO3166 is the error given when a field has an invalid ISO 3166-1-alpha-2 code
+	ErrValidISO3166 = errors.New("is an invalid ISO 3166-1-alpha-2 code")
+	// ErrValidISO4217 is the error given when a field has an invalid ISO 4217 code
+	ErrValidISO4217 = errors.New("is an invalid ISO 4217 code")
 
 	// Addenda errors
 
@@ -50,7 +56,7 @@ var (
 	// ErrAddenda99ReturnCode is given when there's an invalid return code
 	ErrAddenda99ReturnCode = errors.New("found is not a valid return code")
 	// ErrBatchCORAddenda is given when an entry in a COR batch does not have an addenda98
-	ErrBatchCORAddenda = errors.New("found and one Addenda98 record is required for each entry in SEC Type COR")
+	ErrBatchCORAddenda = errors.New("one Addenda98 record is required for each entry in SEC Type COR")
 
 	// FileHeader errors
 
@@ -113,8 +119,6 @@ func fieldError(field string, err error, values ...interface{}) error {
 	}
 	return &fe
 }
-
-// ErrValidFieldLength    = "is not length %d"
 
 // ErrValidCheckDigit is the error given when the observed check digit does not match the calculated one
 type ErrValidCheckDigit struct {

--- a/file.go
+++ b/file.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 )
 
 // First position of all Record Types. These codes are uniquely assigned to
@@ -215,7 +214,7 @@ func (f *File) Create() error {
 
 	// Requires at least one Batch in the new file.
 	if len(f.Batches) <= 0 && len(f.IATBatches) <= 0 {
-		return &FileError{FieldName: "Batches", Value: strconv.Itoa(len(f.Batches)), Msg: "must have []*Batches or []*IATBatches to be built"}
+		return ErrFileNoBatches
 	}
 
 	if !f.IsADV() {

--- a/fileControl_test.go
+++ b/fileControl_test.go
@@ -137,12 +137,10 @@ func testValidateFCRecordType(t testing.TB) {
 	fc := mockFileControl()
 	fc.recordType = "2"
 
-	if err := fc.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fc.Validate()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/fileErrors.go
+++ b/fileErrors.go
@@ -28,6 +28,8 @@ var (
 	ErrFileADVOnly = errors.New("file can only have ADV Batches")
 	// ErrFileIATSEC is the error given if an IAT batch uses the normal NewBatch
 	ErrFileIATSEC = errors.New("IAT Standard Entry Class Code should use iatBatch")
+	// ErrFileNoBatches is the error given if a file has no batches
+	ErrFileNoBatches = errors.New("must have []*Batches or []*IATBatches to be built")
 )
 
 // RecordWrongLengthErr is the error given when a record is the wrong length

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -151,12 +151,10 @@ func BenchmarkFHString(b *testing.B) {
 func testValidateFHRecordType(t testing.TB) {
 	fh := mockFileHeader()
 	fh.recordType = "2"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -177,12 +175,9 @@ func BenchmarkValidateFHRecordType(b *testing.B) {
 func testValidateIDModifier(t testing.TB) {
 	fh := mockFileHeader()
 	fh.FileIDModifier = "®"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "FileIDModifier" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	if !base.Match(err, ErrUpperAlpha) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -203,12 +198,9 @@ func BenchmarkValidateIDModifier(b *testing.B) {
 func testValidateRecordSize(t testing.TB) {
 	fh := mockFileHeader()
 	fh.recordSize = "666"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordSize" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	if !base.Match(err, ErrRecordSize) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -229,12 +221,9 @@ func BenchmarkValidateRecordSize(b *testing.B) {
 func testBlockingFactor(t testing.TB) {
 	fh := mockFileHeader()
 	fh.blockingFactor = "99"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "blockingFactor" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	if !base.Match(err, ErrBlockingFactor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -255,12 +244,9 @@ func BenchmarkBlockingFactor(b *testing.B) {
 func testFormatCode(t testing.TB) {
 	fh := mockFileHeader()
 	fh.formatCode = "2"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "formatCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	if !base.Match(err, ErrFormatCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -304,21 +290,15 @@ func BenchmarkFHFieldInclusion(b *testing.B) {
 func testUpperLengthFileID(t testing.TB) {
 	fh := mockFileHeader()
 	fh.FileIDModifier = "a"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "FileIDModifier" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	if !base.Match(err, ErrUpperAlpha) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 	fh.FileIDModifier = "AA"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "FileIDModifier" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err = fh.Validate()
+	if !base.Match(err, NewErrValidFieldLength(1)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -340,12 +320,9 @@ func testImmediateDestinationNameAlphaNumeric(t testing.TB) {
 	fh := mockFileHeader()
 	fh.ImmediateDestinationName = "Super Big Bank"
 	fh.ImmediateDestinationName = "Big ®$$ Bank"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ImmediateDestinationName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -369,12 +346,9 @@ func testImmediateOriginNameAlphaNumeric(t testing.TB) {
 	fh := mockFileHeader()
 	fh.ImmediateOriginName = "Super Big Bank"
 	fh.ImmediateOriginName = "Bigger ®$$ Bank"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ImmediateOriginName" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -397,12 +371,9 @@ func testImmediateReferenceCodeAlphaNumeric(t testing.TB) {
 	fh := mockFileHeader()
 	fh.ReferenceCode = " "
 	fh.ReferenceCode = "®"
-	if err := fh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ReferenceCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := fh.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -309,14 +309,9 @@ func BenchmarkFileBuildBadFileHeader(b *testing.B) {
 // testFileBuildNoBatch validates a file with no batches
 func testFileBuildNoBatch(t testing.TB) {
 	file := NewFile().SetHeader(mockFileHeader())
-	if err := file.Create(); err != nil {
-		if e, ok := err.(*FileError); ok {
-			if e.FieldName != "Batches" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Create()
+	if !base.Match(err, ErrFileNoBatches) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -692,14 +687,10 @@ func TestFileADVControlValidate(t *testing.T) {
 	file := mockFileADV()
 
 	file.ADVControl.recordType = "22"
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -708,14 +699,10 @@ func TestFileControlValidate(t *testing.T) {
 	file := mockFilePPD()
 
 	file.Control.recordType = "22"
-	if err := file.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := file.Validate()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -893,13 +880,7 @@ func TestFile__readInvalidFilesJson(t *testing.T) {
 
 	_, err = FileFromJSON(bs)
 
-	if err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "FileIDModifier" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	if !base.Match(err, ErrUpperAlpha) {
+		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/iatBatchHeader.go
+++ b/iatBatchHeader.go
@@ -277,8 +277,7 @@ func (iatBh *IATBatchHeader) Validate() error {
 		return fieldError("ForeignExchangeReferenceIndicator", err, strconv.Itoa(iatBh.ForeignExchangeReferenceIndicator))
 	}
 	if !iso3166.Valid(iatBh.ISODestinationCountryCode) {
-		return &FieldError{FieldName: "ISODestinationCountryCode",
-			Value: iatBh.ISODestinationCountryCode, Msg: "invalid ISO 3166-1-alpha-2 code"}
+		return fieldError("ISODestinationCountryCode", ErrValidISO3166, iatBh.ISODestinationCountryCode)
 	}
 	if err := iatBh.isSECCode(iatBh.StandardEntryClassCode); err != nil {
 		return fieldError("StandardEntryClassCode", err, iatBh.StandardEntryClassCode)
@@ -287,12 +286,10 @@ func (iatBh *IATBatchHeader) Validate() error {
 		return fieldError("CompanyEntryDescription", err, iatBh.CompanyEntryDescription)
 	}
 	if !iso4217.Valid(iatBh.ISOOriginatingCurrencyCode) {
-		return &FieldError{FieldName: "ISOOriginatingCurrencyCode",
-			Value: iatBh.ISOOriginatingCurrencyCode, Msg: "invalid ISO 4217 code"}
+		return fieldError("ISOOriginatingCurrencyCode", ErrValidISO4217, iatBh.ISOOriginatingCurrencyCode)
 	}
 	if !iso4217.Valid(iatBh.ISODestinationCurrencyCode) {
-		return &FieldError{FieldName: "ISODestinationCurrencyCode",
-			Value: iatBh.ISODestinationCurrencyCode, Msg: "invalid ISO 4217 code"}
+		return fieldError("ISODestinationCurrencyCode", ErrValidISO4217, iatBh.ISODestinationCurrencyCode)
 	}
 	if err := iatBh.isOriginatorStatusCode(iatBh.OriginatorStatusCode); err != nil {
 		return fieldError("OriginatorStatusCode", err, strconv.Itoa(iatBh.OriginatorStatusCode))

--- a/iatBatchHeader_test.go
+++ b/iatBatchHeader_test.go
@@ -7,6 +7,8 @@ package ach
 import (
 	"strings"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockIATBatchHeaderFF creates a IAT BatchHeader that is Fixed-Fixed
@@ -243,12 +245,10 @@ func BenchmarkIATBHFVString(b *testing.B) {
 func testValidateIATBHRecordType(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.recordType = "2"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	// TODO: are we expecting there to be an error here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -270,12 +270,9 @@ func BenchmarkValidateIATBHRecordType(b *testing.B) {
 func testValidateIATBHServiceClassCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ServiceClassCode = 999
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrServiceClass) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -299,12 +296,9 @@ func BenchmarkValidateIATBHServiceClassCode(b *testing.B) {
 func testValidateIATBHForeignExchangeIndicator(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ForeignExchangeIndicator = "XY"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignExchangeIndicator" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrForeignExchangeIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -328,12 +322,9 @@ func BenchmarkValidateIATBHForeignExchangeIndicator(b *testing.B) {
 func testValidateIATBHForeignExchangeReferenceIndicator(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ForeignExchangeReferenceIndicator = 5
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignExchangeReferenceIndicator" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrForeignExchangeReferenceIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -357,12 +348,9 @@ func BenchmarkValidateIATBHForeignExchangeReferenceIndicator(b *testing.B) {
 func testValidateIATBHISODestinationCountryCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ISODestinationCountryCode = "®"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ISODestinationCountryCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrValidISO3166) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -386,12 +374,10 @@ func BenchmarkValidateIATBHISODestinationCountryCode(b *testing.B) {
 func testValidateIATBHOriginatorIdentification(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.OriginatorIdentification = "®"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -415,12 +401,9 @@ func BenchmarkValidateIATBHOriginatorIdentification(b *testing.B) {
 func testValidateIATBHStandardEntryClassCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.StandardEntryClassCode = "ABC"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "StandardEntryClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrSECCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -444,12 +427,9 @@ func BenchmarkValidateIATBHStandardEntryClassCode(b *testing.B) {
 func testValidateIATBHCompanyEntryDescription(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.CompanyEntryDescription = "®"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyEntryDescription" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -473,12 +453,9 @@ func BenchmarkValidateIATBHCompanyEntryDescription(b *testing.B) {
 func testValidateIATBHISOOriginatingCurrencyCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ISOOriginatingCurrencyCode = "®"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ISOOriginatingCurrencyCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrValidISO4217) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -502,12 +479,9 @@ func BenchmarkValidateIATBHISOOriginatingCurrencyCode(b *testing.B) {
 func testValidateIATBHISODestinationCurrencyCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ISODestinationCurrencyCode = "®"
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ISODestinationCurrencyCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrValidISO4217) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -531,12 +505,9 @@ func BenchmarkValidateIATBHISODestinationCurrencyCode(b *testing.B) {
 func testValidateIATBHOriginatorStatusCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.OriginatorStatusCode = 7
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorStatusCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrOrigStatusCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -561,12 +532,9 @@ func BenchmarkValidateIATBHOriginatorStatusCode(b *testing.B) {
 func testIATBHRecordType(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.recordType = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -587,12 +555,9 @@ func BenchmarkIATBHRecordType(b *testing.B) {
 func testIATBHServiceClassCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ServiceClassCode = 0
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ServiceClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -613,12 +578,9 @@ func BenchmarkIATBHServiceClassCode(b *testing.B) {
 func testIATBHForeignExchangeIndicator(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ForeignExchangeIndicator = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignExchangeIndicator" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -639,12 +601,9 @@ func BenchmarkIATBHForeignExchangeIndicator(b *testing.B) {
 func testIATBHForeignExchangeReferenceIndicator(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ForeignExchangeReferenceIndicator = 0
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ForeignExchangeReferenceIndicator" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldRequired) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -665,12 +624,9 @@ func BenchmarkIATBHForeignExchangeReferenceIndicator(b *testing.B) {
 func testIATBHISODestinationCountryCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ISODestinationCountryCode = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ISODestinationCountryCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -691,12 +647,9 @@ func BenchmarkIATBHISODestinationCountryCode(b *testing.B) {
 func testIATBHOriginatorIdentification(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.OriginatorIdentification = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "OriginatorIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -717,12 +670,9 @@ func BenchmarkIATBHOriginatorIdentification(b *testing.B) {
 func testIATBHStandardEntryClassCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.StandardEntryClassCode = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "StandardEntryClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -743,12 +693,9 @@ func BenchmarkIATBHStandardEntryClassCode(b *testing.B) {
 func testIATBHCompanyEntryDescription(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.CompanyEntryDescription = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CompanyEntryDescription" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -769,12 +716,9 @@ func BenchmarkIATBHCompanyEntryDescription(b *testing.B) {
 func testIATBHISOOriginatingCurrencyCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ISOOriginatingCurrencyCode = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ISOOriginatingCurrencyCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -795,12 +739,9 @@ func BenchmarkIATBHISOOriginatingCurrencyCode(b *testing.B) {
 func testIATBHISODestinationCurrencyCode(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ISODestinationCurrencyCode = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ISODestinationCurrencyCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -821,12 +762,9 @@ func BenchmarkIATBHISODestinationCurrencyCode(b *testing.B) {
 func testIATBHODFIIdentification(t testing.TB) {
 	bh := mockIATBatchHeaderFF()
 	bh.ODFIIdentification = ""
-	if err := bh.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "ODFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := bh.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/iatBatch_test.go
+++ b/iatBatch_test.go
@@ -169,14 +169,9 @@ func TestIATBatch__UnmarshalJSON(t *testing.T) {
 func testIATBatchAddenda10Error(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda10 = nil
-	if err := iatBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda10" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.verify()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -199,14 +194,9 @@ func BenchmarkIATBatchAddenda10Error(b *testing.B) {
 func testIATBatchAddenda11Error(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda11 = nil
-	if err := iatBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda11" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.verify()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -229,14 +219,9 @@ func BenchmarkIATBatchAddenda11Error(b *testing.B) {
 func testIATBatchAddenda12Error(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda12 = nil
-	if err := iatBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda12" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.verify()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -259,14 +244,9 @@ func BenchmarkIATBatchAddenda12Error(b *testing.B) {
 func testIATBatchAddenda13Error(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda13 = nil
-	if err := iatBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda13" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.verify()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -289,14 +269,9 @@ func BenchmarkIATBatchAddenda13Error(b *testing.B) {
 func testIATBatchAddenda14Error(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda14 = nil
-	if err := iatBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda14" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.verify()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -319,14 +294,9 @@ func BenchmarkIATBatchAddenda14Error(b *testing.B) {
 func testIATBatchAddenda15Error(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda15 = nil
-	if err := iatBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda15" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.verify()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -349,14 +319,9 @@ func BenchmarkIATBatchAddenda15Error(b *testing.B) {
 func testIATBatchAddenda16Error(t testing.TB) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.GetEntries()[0].Addenda16 = nil
-	if err := iatBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda16" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.verify()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -694,32 +659,20 @@ func testIATBatchFieldInclusion(t testing.TB) {
 	mockBatch2 := mockIATBatch(t)
 	mockBatch2.Header.recordType = "4"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
-	if err := mockBatch2.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err = mockBatch2.verify()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
-	if err := mockBatch2.build(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err = mockBatch2.build()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -742,14 +695,9 @@ func testIATBatchBuild(t testing.TB) {
 	mockBatch := IATBatch{}
 	mockBatch.SetHeader(mockIATBatchHeaderFF())
 
-	if err := mockBatch.build(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "entries" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.build()
+	if !base.Match(err, ErrBatchNoEntries) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -794,14 +742,9 @@ func BenchmarkIATODFIIdentificationMismatch(b *testing.B) {
 func testIATBatchAddendaRecordIndicator(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.GetEntries()[0].AddendaRecordIndicator = 2
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "AddendaRecordIndicator" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrIATBatchAddendaIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -952,14 +895,9 @@ func testIATBatchIsCategory(t testing.TB) {
 	mockBatch := mockIATBatchManyEntries(t)
 	mockBatch.GetEntries()[1].Category = CategoryReturn
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda99" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1007,14 +945,10 @@ func testIATBatchValidateEntry(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.GetEntries()[0].recordType = "5"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1036,14 +970,9 @@ func testIATBatchValidateAddenda10(t testing.TB) {
 	mockBatch := mockIATBatchManyEntries(t)
 	mockBatch.GetEntries()[1].Addenda10.TypeCode = "02"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1065,14 +994,9 @@ func testIATBatchValidateAddenda11(t testing.TB) {
 	mockBatch := mockIATBatchManyEntries(t)
 	mockBatch.GetEntries()[1].Addenda11.TypeCode = "02"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1094,14 +1018,9 @@ func testIATBatchValidateAddenda12(t testing.TB) {
 	mockBatch := mockIATBatchManyEntries(t)
 	mockBatch.GetEntries()[1].Addenda12.TypeCode = "02"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1123,14 +1042,9 @@ func testIATBatchValidateAddenda13(t testing.TB) {
 	mockBatch := mockIATBatchManyEntries(t)
 	mockBatch.GetEntries()[1].Addenda13.TypeCode = "02"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1152,14 +1066,9 @@ func testIATBatchValidateAddenda14(t testing.TB) {
 	mockBatch := mockIATBatchManyEntries(t)
 	mockBatch.GetEntries()[1].Addenda14.TypeCode = "02"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1181,14 +1090,9 @@ func testIATBatchValidateAddenda15(t testing.TB) {
 	mockBatch := mockIATBatchManyEntries(t)
 	mockBatch.GetEntries()[1].Addenda15.TypeCode = "02"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1210,14 +1114,9 @@ func testIATBatchValidateAddenda16(t testing.TB) {
 	mockBatch := mockIATBatchManyEntries(t)
 	mockBatch.GetEntries()[1].Addenda16.TypeCode = "02"
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1238,14 +1137,9 @@ func BenchmarkIATBatchValidateAddenda16(b *testing.B) {
 func testIATBatchValidateAddenda17(t testing.TB) {
 	mockBatch := mockInvalidIATBatch(t)
 
-	if err := mockBatch.verify(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TypeCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.verify()
+	if !base.Match(err, ErrAddendaTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1268,14 +1162,10 @@ func testIATBatchCreate(t testing.TB) {
 	mockBatch := mockIATBatch(t)
 	mockBatch.GetHeader().recordType = "7"
 
-	if err := mockBatch.Create(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Create()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 	file.AddIATBatch(mockBatch)
@@ -1340,14 +1230,9 @@ func testIATBatchEntryAddendum(t testing.TB) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda18" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, NewErrBatchAddendaCount(6, 5)) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 	file.AddIATBatch(mockBatch)
@@ -1620,14 +1505,10 @@ func testIATBatchAddendumTypeCode(t testing.TB) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// no error expected
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1677,14 +1558,9 @@ func testIATBatchAddenda17Count(t testing.TB) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda17" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, NewErrBatchAddendaCount(3, 2)) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 }
@@ -1735,14 +1611,9 @@ func testIATBatchAddenda18Count(t testing.TB) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda18" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, NewErrBatchAddendaCount(6, 5)) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 }
@@ -1766,14 +1637,9 @@ func testIATBatchBuildAddendaError(t testing.TB) {
 	mockBatch.SetHeader(mockIATBatchHeaderFF())
 	mockBatch.AddEntry(mockIATEntryDetail())
 
-	if err := mockBatch.build(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "Addenda10" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.build()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1837,14 +1703,10 @@ func testIATBatchAddenda99Count(t testing.TB) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 }
@@ -1877,14 +1739,10 @@ func TestIATBatchAddenda98TotalCount(t *testing.T) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addendum" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1901,14 +1759,9 @@ func TestIATBatchAddenda98Nil(t *testing.T) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "Addenda98" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1928,14 +1781,10 @@ func TestIATBatchAddenda98RecordType(t *testing.T) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1953,14 +1802,10 @@ func TestIATBatchAddenda99RecordType(t *testing.T) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1976,14 +1821,10 @@ func TestIATBatchAddenda18RecordType(t *testing.T) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	//TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -2001,14 +1842,10 @@ func TestIATBatchAddenda98TransactionCode(t *testing.T) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "TransactionCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -2027,14 +1864,9 @@ func TestIATBatchAddenda98IATIndicator(t *testing.T) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "IATIndicator" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, NewErrBatchIATNOC("B", "IATCOR")) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -2052,14 +1884,9 @@ func TestIATBatchAddenda98SECCode(t *testing.T) {
 		t.Errorf("%T: %s", err, err)
 	}
 
-	if err := mockBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "StandardEntryClassCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := mockBatch.Validate()
+	if !base.Match(err, NewErrBatchIATNOC("IAT", "COR")) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -2067,14 +1894,9 @@ func TestIATBatchAddenda98SECCode(t *testing.T) {
 func TestMockISODestinationCountryCode(t *testing.T) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.Header.ISODestinationCountryCode = "®©"
-	if err := iatBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ISODestinationCountryCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.Validate()
+	if !base.Match(err, ErrValidISO3166) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 }
@@ -2083,14 +1905,9 @@ func TestMockISODestinationCountryCode(t *testing.T) {
 func TestMockISOOriginatingCurrencyCode(t *testing.T) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.Header.ISOOriginatingCurrencyCode = "®©"
-	if err := iatBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ISOOriginatingCurrencyCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.Validate()
+	if !base.Match(err, ErrValidISO4217) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 }
@@ -2099,16 +1916,10 @@ func TestMockISOOriginatingCurrencyCode(t *testing.T) {
 func TestMockISODestinationCurrencyCode(t *testing.T) {
 	iatBatch := mockIATBatch(t)
 	iatBatch.Header.ISODestinationCurrencyCode = "®©"
-	if err := iatBatch.Validate(); err != nil {
-		if e, ok := err.(*BatchError); ok {
-			if e.FieldName != "ISODestinationCurrencyCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := iatBatch.Validate()
+	if !base.Match(err, ErrValidISO4217) {
+		t.Errorf("%T: %s", err, err)
 	}
-
 }
 
 // TestParseRuneCountIATBatchHeader tests parsing an invalid RuneCount in IATBatchHeader
@@ -2116,13 +1927,8 @@ func TestParseRuneCountIATBatchHeader(t *testing.T) {
 	line := "5220                FF3               US123456789 IATTRADEPAYMTCADUSD010101"
 	r := NewReader(strings.NewReader(line))
 	r.line = line
-	if err := r.parseIATBatchHeader(); err != nil {
-		if e, ok := err.(*base.ParseError); ok {
-			if e.Record != "BatchHeader" {
-				t.Errorf("%T: %s", err, err)
-			}
-		} else {
-			t.Errorf("%T: %s", err, err)
-		}
+	err := r.parseIATBatchHeader()
+	if !base.Match(err, ErrFieldInclusion) {
+		t.Errorf("%T: %s", err, err)
 	}
 }

--- a/iatEntryDetail_test.go
+++ b/iatEntryDetail_test.go
@@ -5,8 +5,11 @@
 package ach
 
 import (
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/moov-io/base"
 )
 
 // mockIATEntryDetail creates an IAT EntryDetail
@@ -166,12 +169,10 @@ func BenchmarkIATEDString(b *testing.B) {
 func testIATEDInvalidRecordType(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.recordType = "2"
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -192,12 +193,9 @@ func BenchmarkIATEDInvalidRecordType(b *testing.B) {
 func testIATEDInvalidTransactionCode(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.TransactionCode = 77
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	if !base.Match(err, ErrTransactionCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -218,12 +216,9 @@ func BenchmarkIATEDInvalidTransactionCode(b *testing.B) {
 func testEDIATDFIAccountNumberAlphaNumeric(t testing.TB) {
 	ed := mockIATEntryDetail()
 	ed.DFIAccountNumber = "®"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "DFIAccountNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -244,12 +239,9 @@ func BenchmarkEDIATDFIAccountNumberAlphaNumeric(b *testing.B) {
 func testEDIATisCheckDigit(t testing.TB) {
 	ed := mockIATEntryDetail()
 	ed.CheckDigit = "1"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "RDFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, NewErrValidCheckDigit(7)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -295,12 +287,9 @@ func BenchmarkEDIATSetRDFI(b *testing.B) {
 func testValidateEDIATCheckDigit(t testing.TB) {
 	ed := mockIATEntryDetail()
 	ed.CheckDigit = "XYZ"
-	if err := ed.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "CheckDigit" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := ed.Validate()
+	if !base.Match(err, &strconv.NumError{}) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -317,18 +306,13 @@ func BenchmarkValidateEDIATCheckDigit(b *testing.B) {
 	}
 }
 
-//FieldInclusion
-
 // testIATEDRecordType validates IATEntryDetail recordType fieldInclusion
 func testIATEDRecordType(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.recordType = ""
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "recordType" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -349,12 +333,9 @@ func BenchmarkIATEDRecordType(b *testing.B) {
 func testIATEDTransactionCode(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.TransactionCode = 0
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TransactionCode" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -375,12 +356,9 @@ func BenchmarkIATEDTransactionCode(b *testing.B) {
 func testIATEDRDFIIdentification(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.RDFIIdentification = ""
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "RDFIIdentification" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -401,12 +379,9 @@ func BenchmarkIATEDRDFIIdentification(b *testing.B) {
 func testIATEDAddendaRecords(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.AddendaRecords = 0
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "AddendaRecords" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -427,12 +402,9 @@ func BenchmarkIATEDAddendaRecords(b *testing.B) {
 func testIATEDDFIAccountNumber(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.DFIAccountNumber = ""
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "DFIAccountNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -453,12 +425,10 @@ func BenchmarkIATEDDFIAccountNumber(b *testing.B) {
 func testIATEDTraceNumber(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.TraceNumber = "0"
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "TraceNumber" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	// TODO: are we expecting there to be no errors here?
+	if !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -479,12 +449,9 @@ func BenchmarkIATEDTraceNumber(b *testing.B) {
 func testIATEDAddendaRecordIndicator(t testing.TB) {
 	iatEd := mockIATEntryDetail()
 	iatEd.AddendaRecordIndicator = 0
-	if err := iatEd.Validate(); err != nil {
-		if e, ok := err.(*FieldError); ok {
-			if e.FieldName != "AddendaRecordIndicator" {
-				t.Errorf("%T: %s", err, err)
-			}
-		}
+	err := iatEd.Validate()
+	if !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -519,18 +519,8 @@ func testFileAddenda02invalid(t testing.TB) {
 	line := bh.String() + "\n" + ed.String() + "\n" + ed.Addenda02.String()
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "TransactionDate" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrBatchAddendaIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -556,18 +546,8 @@ func testFileAddenda02(t testing.TB) {
 	line := bh.String() + "\n" + ed.String() + "\n" + ed.Addenda02.String()
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "TransactionDate" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrBatchAddendaIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -597,18 +577,8 @@ func testFileAddenda98invalid(t testing.TB) {
 	line := bh.String() + "\n" + ed.String() + "\n" + ed.Addenda98.String()
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ChangeCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrBatchAddendaIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -668,18 +638,8 @@ func testFileAddenda99invalid(t testing.TB) {
 	line := bh.String() + "\n" + ed.String() + "\n" + ed.Addenda99.String()
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ReturnCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrBatchAddendaIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -762,16 +722,8 @@ func testFileAddendaNoIndicator(t testing.TB) {
 	line := bh.String() + "\n" + ed.String() + "\n" + addenda.String()
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if el, ok := err.(base.ErrorList); ok {
-		if p, ok := el.Err().(*base.ParseError); ok {
-			if e, ok := p.Err.(*FileError); ok {
-				if e.FieldName != "AddendaRecordIndicator" {
-					t.Errorf("%T: %s", e, e)
-				}
-			}
-		} else {
-			t.Errorf("%T: %s", el, el)
-		}
+	if !base.Has(err, ErrBatchAddendaIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -818,16 +770,8 @@ func testFileBatchHeaderSEC(t testing.TB) {
 	bh.StandardEntryClassCode = "ABC"
 	r := NewReader(strings.NewReader(bh.String()))
 	_, err := r.Read()
-	if el, ok := err.(base.ErrorList); ok {
-		if p, ok := el.Err().(*base.ParseError); ok {
-			if e, ok := p.Err.(*FileError); ok {
-				if e.FieldName != "StandardEntryClassCode" {
-					t.Errorf("%T: %s", e, e)
-				}
-			}
-		} else {
-			t.Errorf("%T: %s", el, el)
-		}
+	if !base.Has(err, ErrSECCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -876,16 +820,8 @@ func testFileBatchControlValidate(t testing.TB) {
 	line := bh.String() + "\n" + ed.String() + "\n" + bc.String()
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if el, ok := err.(base.ErrorList); ok {
-		if p, ok := el.Err().(*base.ParseError); ok {
-			if e, ok := p.Err.(*FieldError); ok {
-				if e.FieldName != "CompanyIdentification" {
-					t.Errorf("%T: %s", e, e)
-				}
-			}
-		} else {
-			t.Errorf("%T: %s", el, el)
-		}
+	if !base.Has(err, NewErrBatchHeaderControlEquality(220, 200)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -910,16 +846,8 @@ func testFileAddBatchValidation(t testing.TB) {
 	line := bh.String() + "\n" + ed.String() + "\n" + bc.String()
 	r := NewReader(strings.NewReader(line))
 	_, err := r.Read()
-	if el, ok := err.(base.ErrorList); ok {
-		if p, ok := el.Err().(*base.ParseError); ok {
-			if e, ok := p.Err.(*BatchError); ok {
-				if e.FieldName != "EntryAddendaCount" {
-					t.Errorf("%T: %s", e, e)
-				}
-			}
-		} else {
-			t.Errorf("%T: %s", el, el)
-		}
+	if !base.Has(err, NewErrBatchCalculatedControlEquality(1, 0)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1022,31 +950,13 @@ func testACHFileRead(t testing.TB) {
 	_, err = r.Read()
 
 	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*BatchError); ok {
-					if e.FieldName != "entries" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+		t.Errorf("%T: %s", err, err)
 	}
 
 	err2 := r.File.Validate()
-
-	if err2 != nil {
-		if el, ok := err2.(base.ErrorList); ok {
-			if e, ok := el.Err().(*FileError); ok {
-				if e.FieldName != "BatchCount" {
-					t.Errorf("%T: %s", e, e)
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	// TODO: is this supposed to have an error here?
+	if !base.Match(err2, NewErrFileCalculatedControlEquality("BatchCount", 2, 5)) {
+		t.Errorf("%T: %s", err2, err2)
 	}
 }
 
@@ -1074,31 +984,13 @@ func testACHFileRead2(t testing.TB) {
 	_, err = r.Read()
 
 	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*BatchError); ok {
-					if e.FieldName != "entries" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+		t.Errorf("%T: %s", err, err)
 	}
 
 	err2 := r.File.Validate()
-
-	if err2 != nil {
-		if el, ok := err2.(base.ErrorList); ok {
-			if e, ok := el.Err().(*FileError); ok {
-				if e.FieldName != "BatchCount" {
-					t.Errorf("%T: %s", e, e)
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	// TODO: is this supposed to have an error here?
+	if !base.Match(err2, NewErrFileCalculatedControlEquality("BatchCount", 2, 5)) {
+		t.Errorf("%T: %s", err2, err2)
 	}
 }
 
@@ -1125,41 +1017,15 @@ func testACHFileRead3(t testing.TB) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*BatchError); ok {
-					if e.FieldName != "entries" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			}
-		}
+	// TODO: is this supposed to return an error?
+	if !base.Has(err, NewRecordWrongLengthErr(94)) {
+		t.Errorf("%T: %s", err, err)
 	}
 
 	err2 := r.File.Validate()
-
-	if err2 != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			// Check first error
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FileError); ok {
-					if e.FieldName != "RecordLength" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			}
-			// Check second error
-			if p, ok := el[1].(*base.ParseError); ok {
-				if e, ok := p.Err.(*FileError); ok {
-					if e.Msg != "none or more than one file control exists" {
-						t.Errorf("%T: %s", e, e)
-					}
-				} else {
-					t.Errorf("%T: %s", el, el)
-				}
-			}
-		}
+	// TODO: shouldn't this not be giving an error since 0 == 0?
+	if !base.Match(err2, NewErrFileCalculatedControlEquality("BatchCount", 0, 0)) {
+		t.Errorf("%T: %s", err2, err2)
 	}
 }
 
@@ -1187,31 +1053,12 @@ func testACHIATAddenda17(t testing.TB) {
 	_, err = r.Read()
 
 	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*BatchError); ok {
-					if e.FieldName != "entries" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+		t.Errorf("%T: %s", err, err)
 	}
 
 	err2 := r.File.Validate()
-
 	if err2 != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if e, ok := el.Err().(*FileError); ok {
-				if e.FieldName != "BatchCount" {
-					t.Errorf("%T: %s", e, e)
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+		t.Errorf("%T: %s", err2, err2)
 	}
 }
 
@@ -1239,31 +1086,12 @@ func testACHIATAddenda1718(t testing.TB) {
 	_, err = r.Read()
 
 	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*BatchError); ok {
-					if e.FieldName != "entries" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+		t.Errorf("%T: %s", err, err)
 	}
 
 	err2 := r.File.Validate()
-
 	if err2 != nil {
-		if el, ok := err2.(base.ErrorList); ok {
-			if e, ok := el.Err().(*FileError); ok {
-				if e.FieldName != "BatchCount" {
-					t.Errorf("%T: %s", e, e)
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+		t.Errorf("%T: %s", err2, err2)
 	}
 }
 
@@ -1290,18 +1118,8 @@ func testACHFileIATBatchHeader(t testing.TB) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ServiceClassCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrServiceClass) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1328,18 +1146,8 @@ func testACHFileIATEntryDetail(t testing.TB) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "TransactionCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrTransactionCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1366,18 +1174,8 @@ func TestIATAddendaRecordIndicator(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FileError); ok {
-					if e.FieldName != "AddendaRecordIndicator" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrIATBatchAddendaIndicator) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1391,18 +1189,8 @@ func TestACHFileIATAddenda10(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "TransactionTypeCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrTransactionTypeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1416,18 +1204,8 @@ func TestACHFileIATAddenda11(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "OriginatorName" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1441,18 +1219,8 @@ func TestACHFileIATAddenda12(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "OriginatorCityStateProvince" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1466,18 +1234,8 @@ func TestACHFileIATAddenda13(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ODFIName" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1491,18 +1249,8 @@ func TestACHFileIATAddenda14(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "RDFIName" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1516,18 +1264,8 @@ func TestACHFileIATAddenda15(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ReceiverStreetAddress" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1541,18 +1279,8 @@ func TestACHFileIATAddenda16(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ReceiverCityStateProvince" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1566,18 +1294,8 @@ func TestACHFileIATAddenda17(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "PaymentRelatedInformation" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1591,18 +1309,8 @@ func TestACHFileIATAddenda18(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ForeignCorrespondentBankName" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1616,18 +1324,8 @@ func TestACHFileIATAddenda98(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ChangeCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrAddenda98ChangeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1641,18 +1339,8 @@ func TestACHFileIATAddenda99(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ReturnCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrAddenda99ReturnCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1666,18 +1354,8 @@ func TestPOSInvalidReturnFile(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ReturnCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrAddenda99ReturnCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1691,18 +1369,8 @@ func TestWEBInvalidNOCFile(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "ChangeCode" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrAddenda98ChangeCode) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1716,18 +1384,8 @@ func TestPOSInvalidEntryDetail(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*FieldError); ok {
-					if e.FieldName != "IndividualName" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrNonAlphanumeric) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1771,18 +1429,8 @@ func testACHFileIATBC(t testing.TB) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if e, ok := p.Err.(*BatchError); ok {
-					if e.FieldName != "ODFIIdentification" {
-						t.Errorf("%T: %s", e, e)
-					}
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, NewErrBatchHeaderControlEquality(23138010, 23100000)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1876,18 +1524,8 @@ func TestADVReturnError(t *testing.T) {
 
 	r := NewReader(strings.NewReader(b.String()))
 	_, err := r.Read()
-	if err != nil {
-		if err != nil {
-			if el, ok := err.(base.ErrorList); ok {
-				if p, ok := el.Err().(*base.ParseError); ok {
-					if p.Record != "Addenda" {
-						t.Errorf("%T: %s", p, p)
-					}
-				} else {
-					t.Errorf("%T: %s", el, el)
-				}
-			}
-		}
+	if !base.Has(err, NewErrBatchCalculatedControlEquality(1, 2)) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 
@@ -1901,16 +1539,8 @@ func TestADVFileControl(t *testing.T) {
 	r := NewReader(f)
 	_, err = r.Read()
 
-	if err != nil {
-		if el, ok := err.(base.ErrorList); ok {
-			if p, ok := el.Err().(*base.ParseError); ok {
-				if p.Record != "FileControl" {
-					t.Errorf("%T: %s", p, p)
-				}
-			} else {
-				t.Errorf("%T: %s", el, el)
-			}
-		}
+	if !base.Has(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 


### PR DESCRIPTION
This updates all the tests to switch to using the `base.Has` and `base.Match` error systems where appropriate. 

There were some cases where tests looked like they were not hitting an expected error (similar to https://github.com/moov-io/ach/issues/458), which I've marked with a `TODO` comment, indicating that these need to be reexamined to ensure that they are working as expected.