### PR TITLE
server: validate file endpoint should return 400, not 500

### DIFF
--- a/server/files.go
+++ b/server/files.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -313,7 +314,7 @@ func validateFileEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 		}
 
 		return validateFileResponse{
-			Err: err,
+			fmt.Errorf("%v: %v", errInvalidFile, err),
 		}, nil
 	}
 }

--- a/server/routing_test.go
+++ b/server/routing_test.go
@@ -7,6 +7,8 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"github.com/moov-io/ach"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +17,24 @@ import (
 
 	httptransport "github.com/go-kit/kit/transport/http"
 )
+
+func TestRouting_codeFrom(t *testing.T) {
+	if v := codeFrom(nil); v != http.StatusOK {
+		t.Errorf("HTTP status: %d", v)
+	}
+	if v := codeFrom(fmt.Errorf("%v: other", errInvalidFile)); v != http.StatusBadRequest {
+		t.Errorf("HTTP status: %d", v)
+	}
+	if v := codeFrom(ErrNotFound); v != http.StatusNotFound {
+		t.Errorf("HTTP status: %d", v)
+	}
+	if v := codeFrom(ErrAlreadyExists); v != http.StatusBadRequest {
+		t.Errorf("HTTP status: %d", v)
+	}
+	if v := codeFrom(errors.New("other")); v != http.StatusInternalServerError {
+		t.Errorf("HTTP status: %d", v)
+	}
+}
 
 func TestEncodeResponse(t *testing.T) {
 	ctx := context.TODO()


### PR DESCRIPTION
500's represent internal errors (bugs), but 400 is more fitting
here. It also looks like other endpoints here return 5xx errors that
might confuse people later on, so this is showing how we could fixup those.

See: https://github.com/moov-io/api/pull/71 