### PR TITLE
server: only wrap validateFile error when non-nil

### DIFF
--- a/server/files.go
+++ b/server/files.go
@@ -308,14 +308,13 @@ func validateFileEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 		}
 
 		err := s.ValidateFile(req.ID)
-
 		if req.requestId != "" && logger != nil {
 			logger.Log("files", "validateFile", "requestId", req.requestId, "error", err)
 		}
-
-		return validateFileResponse{
-			fmt.Errorf("%v: %v", errInvalidFile, err),
-		}, nil
+		if err != nil { // wrap err with context
+			err = fmt.Errorf("%v: %v", errInvalidFile, err)
+		}
+		return validateFileResponse{err}, nil
 	}
 }
 


### PR DESCRIPTION
Technically a regression from https://github.com/moov-io/ach/pull/488 where the error was wrapped always. It should only be wrapped when `err != nil`. 