### PR TITLE
fuzz: build fuzz binary in Docker build steps

### DIFF
--- a/Dockerfile-fuzz
+++ b/Dockerfile-fuzz
@@ -4,4 +4,5 @@ WORKDIR /go/src/github.com/moov-io/ach
 COPY . .
 WORKDIR /go/src/github.com/moov-io/ach/test/fuzz-reader
 RUN make install
-ENTRYPOINT ["make"]
+RUN make fuzz-build
+ENTRYPOINT make fuzz-run

--- a/test/fuzz-reader/makefile
+++ b/test/fuzz-reader/makefile
@@ -1,7 +1,11 @@
 .PHONY: fuzz
 
-fuzz:
+fuzz: fuzz-build fuzz-run
+
+fuzz-build:
 	CGO_ENABLED=1 GO111MODULE=off go-fuzz-build github.com/moov-io/ach/test/fuzz-reader
+
+fuzz-run:
 	CGO_ENABLED=1 GO111MODULE=off go-fuzz -bin=./fuzzreader-fuzz.zip -workdir=$(shell pwd)
 
 install:


### PR DESCRIPTION
Running go-fuzz-build when the container launched requied +400MB and
was being OOMKilled on the node. Let's just bundle it with the image ourselves.

The image is a bit larger, but it was already big to begin with.

```
moov/achfuzz                v1.0.0              f570869bd778        31 minutes ago      918MB
moov/achfuzz                v0.6.0              a066990d34e5        2 hours ago         872MB
```