### PR TITLE
addenda{12,16}: fixup examples for city/state and country/postal code

### DIFF
--- a/addenda12.go
+++ b/addenda12.go
@@ -25,11 +25,11 @@ type Addenda12 struct {
 	// Originator City & State / Province
 	// Data elements City and State / Province  should be separated with an asterisk (*) as a delimiter
 	// and the field should end with a backslash (\).
-	// For example: San FranciscoCA.
+	// For example: San Francisco*CA\
 	OriginatorCityStateProvince string `json:"originatorCityStateProvince"`
 	// Originator Country & Postal Code
 	// Data elements must be separated by an asterisk (*) and must end with a backslash (\)
-	// For example: US10036\
+	// For example: US*10036\
 	OriginatorCountryPostalCode string `json:"originatorCountryPostalCode"`
 	// reserved - Leave blank
 	reserved string

--- a/addenda16.go
+++ b/addenda16.go
@@ -24,11 +24,11 @@ type Addenda16 struct {
 	// Receiver City & State / Province
 	// Data elements City and State / Province  should be separated with an asterisk (*) as a delimiter
 	// and the field should end with a backslash (\).
-	// For example: San FranciscoCA.
+	// For example: San Francisco*CA\
 	ReceiverCityStateProvince string `json:"receiverCityStateProvince"`
 	// Receiver Country & Postal Code
 	// Data elements must be separated by an asterisk (*) and must end with a backslash (\)
-	// For example: US10036\
+	// For example: US*10036\
 	ReceiverCountryPostalCode string `json:"receiverCountryPostalCode"`
 	// reserved - Leave blank
 	reserved string


### PR DESCRIPTION
I noticed the examples didn't match the description.