### PR TITLE
adv: fix typo in omitempty annotation

### DIFF
--- a/advEntryDetail.go
+++ b/advEntryDetail.go
@@ -64,7 +64,7 @@ type ADVEntryDetail struct {
 	// JulianDay
 	JulianDay int `json:"julianDay"`
 	// SequenceNumber
-	SequenceNumber int `json:"sequenceNumber,omitEmpty"`
+	SequenceNumber int `json:"sequenceNumber,omitempty"`
 	// Addenda99 for use with Returns
 	Addenda99 *Addenda99 `json:"addenda99,omitempty"`
 	// Category defines if the entry is a Forward, Return, or NOC


### PR DESCRIPTION
```
$ staticcheck ./...
advEntryDetail.go:67:21: unknown JSON option "omitEmpty" (SA5008)
The command "staticcheck ./..." exited with 1.
```

Source: https://travis-ci.com/moov-io/ach/jobs/192243937