### PR TITLE
fileHeader: allow immediate origin to be a 10 digit value

### DIFF
--- a/fileHeader.go
+++ b/fileHeader.go
@@ -30,10 +30,9 @@ type FileHeader struct {
 
 	// ImmediateOrigin contains the Routing Number of the ACH Operator or sending
 	// point that is sending the file. The ach file format specifies a 10 character field
-	// which begins with a blank space in the first position, followed by the four digit
+	// which can begin with a blank space or '1' in the first position, followed by the four digit
 	// Federal Reserve Routing Symbol, the four digit ABA Institution Identifier, and the Check
-	// Digit (bTTTTAAAAC).  ImmediateOriginField() will append the blank space to the routing
-	// number.
+	// Digit (bTTTTAAAAC).  ImmediateOriginField() will append the blank space to the routing number.
 	ImmediateOrigin string `json:"immediateOrigin"`
 
 	// FileCreationDate is the date on which the file is prepared by an ODFI (ACH input files)
@@ -182,7 +181,7 @@ func (fh *FileHeader) Validate() error {
 	if err := fh.isAlphanumeric(fh.ImmediateDestinationName); err != nil {
 		return fieldError("ImmediateDestinationName", err, fh.ImmediateDestinationName)
 	}
-	if fh.ImmediateOrigin == "000000000" {
+	if fh.ImmediateOrigin == "0000000000" {
 		return fieldError("ImmediateOrigin", ErrConstructor, fh.ImmediateOrigin)
 	}
 	if fh.ImmediateDestination == "000000000" {
@@ -241,7 +240,7 @@ func (fh *FileHeader) ImmediateDestinationField() string {
 
 // ImmediateOriginField gets the immediate origin number with 0 padding
 func (fh *FileHeader) ImmediateOriginField() string {
-	return " " + fh.stringField(fh.ImmediateOrigin, 9)
+	return fh.stringField(fh.ImmediateOrigin, 10)
 }
 
 // FileCreationDateField gets the file creation date in YYMMDD format

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -56,6 +56,28 @@ func BenchmarkMockFileHeader(b *testing.B) {
 	}
 }
 
+func TestFileHeader__ImmediateOrigin(t *testing.T) {
+	// From https://github.com/moov-io/ach/issues/510
+	// We should allow a blank space or '1' followed by a 9 digit routing number and 9 digits
+	header := NewFileHeader()
+	header.ImmediateOrigin = " 123456789" // ' ' + routing number
+	if v := header.ImmediateOriginField(); v != " 123456789" {
+		t.Errorf("got %q", v)
+	}
+	header.ImmediateOrigin = "123456789" // 9 digit routing number
+	if v := header.ImmediateOriginField(); v != "0123456789" {
+		t.Errorf("got %q", v)
+	}
+	header.ImmediateOrigin = "0123456789" // 0 + routing number
+	if v := header.ImmediateOriginField(); v != "0123456789" {
+		t.Errorf("got %q", v)
+	}
+	header.ImmediateOrigin = "1123456789" // 1 + routing number
+	if v := header.ImmediateOriginField(); v != "1123456789" {
+		t.Errorf("got %q", v)
+	}
+}
+
 // parseFileHeader validates parsing a file header
 func parseFileHeader(t testing.TB) {
 	var line = "101 076401251 0764012511807291511A094101achdestname            companyname                    "
@@ -75,8 +97,8 @@ func parseFileHeader(t testing.TB) {
 	if record.ImmediateDestinationField() != " 076401251" {
 		t.Errorf("ImmediateDestination Expected ' 076401251' got: %v", record.ImmediateDestinationField())
 	}
-	if record.ImmediateOriginField() != " 076401251" {
-		t.Errorf("ImmediateOrigin Expected '   076401251' got: %v", record.ImmediateOriginField())
+	if record.ImmediateOriginField() != "0076401251" {
+		t.Errorf("ImmediateOrigin Expected '  0076401251' got: %v", record.ImmediateOriginField())
 	}
 
 	if record.FileCreationDateField() != "180729" {


### PR DESCRIPTION
This allows clients to specify a 10 digit Immediate origin value (which is the field size) rather than hardcoding a leading space. 

Related: https://github.com/moov-io/ach/pull/512
Fixes: https://github.com/moov-io/ach/issues/510 