### PR TITLE
 files: support arbitrary merging of ACH files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Examples: [Go](examples/http/main.go) | [Ruby](https://github.com/moov-io/ruby-a
 
 - [Running ACH Server](https://docs.moov.io/en/latest/tutorials/ach-server/)
 - [ACH Server metrics](documentation/metrics.md)
+- [Merging ACH files](https://docs.moov.io/en/latest/ach/merging-files/)
 
 ### From Source
 

--- a/file.go
+++ b/file.go
@@ -379,24 +379,25 @@ func (f *File) AddBatch(batch Batcher) []Batcher {
 // RemoveBatch will delete a given Batcher from an ach.File
 func (f *File) RemoveBatch(batch Batcher) {
 	if batch.Category() == CategoryNOC {
-		for i := range f.NotificationOfChange {
+		for i := 0; i < len(f.NotificationOfChange); i++ {
 			if f.NotificationOfChange[i].Equal(batch) {
 				f.NotificationOfChange = append(f.NotificationOfChange[:i], f.NotificationOfChange[i+1:]...)
-				return
+				i--
 			}
 		}
 	}
 	if batch.Category() == CategoryReturn {
-		for i := range f.ReturnEntries {
+		for i := 0; i < len(f.ReturnEntries); i++ {
 			if f.ReturnEntries[i].Equal(batch) {
 				f.ReturnEntries = append(f.ReturnEntries[:i], f.ReturnEntries[i+1:]...)
-				return
+				i--
 			}
 		}
 	}
-	for i := range f.Batches {
+	for i := 0; i < len(f.Batches); i++ {
 		if f.Batches[i].Equal(batch) {
 			f.Batches = append(f.Batches[:i], f.Batches[i+1:]...)
+			i--
 		}
 	}
 }

--- a/file.go
+++ b/file.go
@@ -376,6 +376,31 @@ func (f *File) AddBatch(batch Batcher) []Batcher {
 	return f.Batches
 }
 
+// RemoveBatch will delete a given Batcher from an ach.File
+func (f *File) RemoveBatch(batch Batcher) {
+	if batch.Category() == CategoryNOC {
+		for i := range f.NotificationOfChange {
+			if f.NotificationOfChange[i].Equal(batch) {
+				f.NotificationOfChange = append(f.NotificationOfChange[:i], f.NotificationOfChange[i+1:]...)
+				return
+			}
+		}
+	}
+	if batch.Category() == CategoryReturn {
+		for i := range f.ReturnEntries {
+			if f.ReturnEntries[i].Equal(batch) {
+				f.ReturnEntries = append(f.ReturnEntries[:i], f.ReturnEntries[i+1:]...)
+				return
+			}
+		}
+	}
+	for i := range f.Batches {
+		if f.Batches[i].Equal(batch) {
+			f.Batches = append(f.Batches[:i], f.Batches[i+1:]...)
+		}
+	}
+}
+
 // AddIATBatch appends a IATBatch to the ach.File
 func (f *File) AddIATBatch(iatBatch IATBatch) []IATBatch {
 	f.IATBatches = append(f.IATBatches, iatBatch)

--- a/merge.go
+++ b/merge.go
@@ -1,0 +1,129 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package ach
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"time"
+)
+
+// MergeFiles is a helper function for consolidating an array of ACH Files into as few files
+// as possible. This is useful for optimizing cost and network efficiency.
+//
+// Per NACHA rules files must remain under 10,000 lines (when rendered in their ASCII encoding)
+//
+// File Batches can only be merged if they are unique and routed to and from the same ABA routing numbers.
+func MergeFiles(files []*File) ([]*File, error) {
+	fs := &mergableFiles{infiles: files}
+	for i := range fs.infiles {
+		outf := fs.lookupByHeader(fs.infiles[i])
+		for j := range fs.infiles[i].Batches {
+			batchExistsInMerged := false
+			for k := range outf.Batches {
+				if fs.infiles[i].Batches[j].Equal(outf.Batches[k]) {
+					batchExistsInMerged = true
+				}
+			}
+			if !batchExistsInMerged {
+				outf.AddBatch(fs.infiles[i].Batches[j])
+				if err := outf.Create(); err != nil {
+					return nil, err
+				}
+				n, err := lineCount(outf)
+				if n == 0 || err != nil {
+					return nil, fmt.Errorf("problem getting line count of File (header: %#v): %v", outf.Header, err)
+				}
+				if n > 10000 {
+					outf.RemoveBatch(fs.infiles[i].Batches[j])
+					if err := outf.Create(); err != nil { // rebalance ACH file after removing the Batch
+						return nil, err
+					}
+					f := *outf
+					fs.locMaxed = append(fs.locMaxed, &f)
+
+					outf = fs.create(outf) // replace output file with the one we just created
+
+					outf.AddBatch(fs.infiles[i].Batches[j])
+					if err := outf.Create(); err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+	}
+
+	// TODO(adam): We should also look at consolidating EntryDetail records inside Batches
+
+	return append(fs.locMaxed, fs.outfiles...), nil // return LOC-maxed files and merged files
+}
+
+type mergableFiles struct {
+	infiles  []*File
+	outfiles []*File
+	locMaxed []*File
+}
+
+// create returns the index of a newly created file in fs.outfiles given the details from f.Header
+func (fs *mergableFiles) create(f *File) *File { // returns the outfiles index of the created file
+	now := time.Now()
+
+	// remove the current file from outfiles
+	for i := range fs.outfiles {
+		if fs.outfiles[i].Header.ImmediateDestination == f.Header.ImmediateDestination &&
+			fs.outfiles[i].Header.ImmediateOrigin == f.Header.ImmediateOrigin {
+			// found a matching file, so remove it from fs.outfiles
+			fs.outfiles = append(fs.outfiles[:i], fs.outfiles[i+1:]...)
+			goto next
+		}
+	}
+next:
+	out := NewFile()
+	out.Header = f.Header
+	out.Header.FileCreationDate = now.Format("060102") // YYMMDD
+	out.Header.FileCreationTime = now.Format("1504")   // HHMM
+	out.Create()
+	fs.outfiles = append(fs.outfiles, out) // add the new outfile
+
+	return out
+}
+
+// lookupByHeader optionally returns a File from fs.files if the FileHeaders match.
+// This is done because we append batches into files to minimize the count of output files.
+//
+// lookupByHeader will return the existing file (stored in outfiles) if no matching file exists.
+func (fs *mergableFiles) lookupByHeader(f *File) *File {
+	for i := range fs.outfiles {
+		if fs.outfiles[i].Header.ImmediateDestination == f.Header.ImmediateDestination &&
+			fs.outfiles[i].Header.ImmediateOrigin == f.Header.ImmediateOrigin {
+			// found a matching file, so return it
+			return fs.outfiles[i]
+		}
+	}
+	fs.outfiles = append(fs.outfiles, f)
+	return f
+}
+
+func lineCount(f *File) (int, error) {
+	if len(f.Batches) < 100 {
+		// Ignore Files with low batch counts by returning a valid count.
+		// Calling Writer.Write() is costly and so we're going to ignore it in easy cases.
+		return 1, nil
+	}
+
+	var buf bytes.Buffer
+	if err := NewWriter(&buf).Write(f); err != nil {
+		return 0, err
+	}
+	lines := 0
+	s := bufio.NewScanner(&buf)
+	for s.Scan() {
+		if v := s.Text(); v != "" {
+			lines++
+		}
+	}
+	return lines, nil
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,0 +1,219 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package ach
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func filesAreEqual(f1, f2 *File) error {
+	// File Header
+	if f1.Header.ImmediateOrigin != f2.Header.ImmediateOrigin {
+		return fmt.Errorf("f1.Header.ImmediateOrigin=%s vs f2.Header.ImmediateOrigin=%s", f1.Header.ImmediateOrigin, f2.Header.ImmediateOrigin)
+	}
+	if f1.Header.ImmediateDestination != f2.Header.ImmediateDestination {
+		return fmt.Errorf("f1.Header.ImmediateDestination=%s vs f2.Header.ImmediateDestination=%s", f1.Header.ImmediateDestination, f2.Header.ImmediateDestination)
+	}
+
+	// Batches
+	if len(f1.Batches) != len(f2.Batches) {
+		return fmt.Errorf("len(f1.Batches)=%d vs len(f2.Batches)=%d", len(f1.Batches), len(f2.Batches))
+	}
+	for i := range f1.Batches {
+		for j := range f2.Batches {
+			if f1.Batches[i].Equal(f2.Batches[j]) {
+				goto next
+			}
+		}
+		return fmt.Errorf("unable to find batch in f2: %v", f1.Batches[i])
+	next:
+		// check the next batch
+	}
+
+	// IATBatches
+	if len(f1.IATBatches) != len(f2.IATBatches) {
+		return fmt.Errorf("len(f1.IATBatches)=%d vs len(f2.IATBatches)=%d", len(f1.IATBatches), len(f2.IATBatches))
+	}
+
+	// File Control
+	if f1.Control.EntryAddendaCount != f2.Control.EntryAddendaCount {
+		return fmt.Errorf("f1.Control.EntryAddendaCount=%d vs f2.Control.EntryAddendaCount=%d", f1.Control.EntryAddendaCount, f2.Control.EntryAddendaCount)
+	}
+	if f1.Control.TotalDebitEntryDollarAmountInFile != f2.Control.TotalDebitEntryDollarAmountInFile {
+		return fmt.Errorf("f1.Control.TotalDebitEntryDollarAmountInFile=%d vs f2.Control.TotalDebitEntryDollarAmountInFile=%d", f1.Control.TotalDebitEntryDollarAmountInFile, f2.Control.TotalDebitEntryDollarAmountInFile)
+	}
+	if f1.Control.TotalCreditEntryDollarAmountInFile != f2.Control.TotalCreditEntryDollarAmountInFile {
+		return fmt.Errorf("f1.Control.TotalCreditEntryDollarAmountInFile=%d vs f2.Control.TotalCreditEntryDollarAmountInFile=%d", f1.Control.TotalCreditEntryDollarAmountInFile, f2.Control.TotalCreditEntryDollarAmountInFile)
+	}
+
+	return nil
+}
+
+func TestMergeFiles__filesAreEqual(t *testing.T) {
+	file, err := readACHFilepath(filepath.Join("test", "testdata", "ppd-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// compare a file against itself
+	if err := filesAreEqual(file, file); err != nil {
+		t.Fatalf("same file: %v", err)
+	}
+
+	// break the equality
+	f2 := *file
+	f2.Header.ImmediateOrigin = "12"
+	if err := filesAreEqual(file, &f2); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestMergeFiles__identity(t *testing.T) {
+	file, err := readACHFilepath(filepath.Join("test", "testdata", "ppd-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := MergeFiles([]*File{file})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 {
+		t.Errorf("got %d merged ACH files", len(out))
+	}
+	if err := filesAreEqual(file, out[0]); err != nil {
+		t.Errorf("unequal files:%v", err)
+	}
+}
+
+func TestMergeFiles__together(t *testing.T) {
+	f1, err := readACHFilepath(filepath.Join("test", "testdata", "ppd-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := readACHFilepath(filepath.Join("test", "testdata", "web-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2.Header = f1.Header // replace Header so they're merged into one file
+
+	if len(f1.Batches) != 1 || len(f2.Batches) != 3 {
+		t.Errorf("did batch counts change? f1:%d f2:%d", len(f1.Batches), len(f2.Batches))
+	}
+
+	out, err := MergeFiles([]*File{f1, f2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 {
+		t.Errorf("got %d merged ACH files", len(out))
+	}
+	if len(out[0].Batches) != 4 {
+		t.Errorf("got %d batches", len(out[0].Batches))
+	}
+}
+
+func TestMergeFiles__apart(t *testing.T) {
+	f1, err := readACHFilepath(filepath.Join("test", "testdata", "ppd-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := readACHFilepath(filepath.Join("test", "testdata", "web-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := MergeFiles([]*File{f1, f2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 {
+		t.Errorf("got %d merged ACH files", len(out))
+	}
+	if len(out[0].Batches) != 1 {
+		t.Errorf("got %d batches", len(out[0].Batches))
+	}
+	if len(out[1].Batches) != 3 {
+		t.Errorf("got %d batches", len(out[1].Batches))
+	}
+}
+
+func TestMergeFiles__lineCount(t *testing.T) {
+	file, err := readACHFilepath(filepath.Join("test", "testdata", "ppd-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	if n, err := lineCount(file); n != 1 || err != nil {
+		// We've optimized small file line counts to bypass writing out the file
+		// into plain text as it's costly.
+		t.Errorf("did we change optimizations? n=%d error=%v", n, err)
+	}
+
+	// Add 100 batches to file and get a real line count
+	for i := 0; i < 100; i++ {
+		file.AddBatch(file.Batches[0])
+	}
+	if err := file.Create(); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := lineCount(file); n != 310 || err != nil {
+		t.Errorf("unexpected line count of %d: %v", n, err)
+	}
+}
+
+// TestMergeFiles__splitFiles generates a file over the 10k line limit and attempts to merge
+// another file into it only to come away with two files after merging.
+func TestMergeFiles__splitFiles(t *testing.T) {
+	file, err := readACHFilepath(filepath.Join("test", "testdata", "ppd-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Control = NewFileControl()
+	if err := file.Create(); err != nil {
+		t.Fatal(err)
+	}
+	if len(file.Batches) != 1 {
+		t.Fatalf("unexpected batch count of %d", len(file.Batches))
+	}
+
+	// Add a bunch of batches so it's over the line limit
+	// somewhere between 3-4k Batches exceed the 10k line limit
+	for i := 0; i < 4000; i++ {
+		file.AddBatch(file.Batches[0])
+	}
+	if err := file.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read another file to merge
+	f2, err := readACHFilepath(filepath.Join("test", "testdata", "web-debit.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2.Header = file.Header // replace Header so they're merged into one file
+	if err := f2.Create(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Merge our big file into another file and verify we get two back
+	// TODO(adam): We should probably recurse back on `file` to ensure we don't exceed the
+	// 10k line limit. That shouldn't happen as MergeFiles processes one batch at a time, but
+	// an incoming file might be invalid in that way.
+	out, err := MergeFiles([]*File{file, f2})
+	if err != nil || len(out) != 2 {
+		t.Fatalf("got %d files, error=%v", len(out), err)
+	}
+	if len(out[0].Batches) != 4001 || len(out[1].Batches) != 3 {
+		// These batch counts will change when we recurse back through out[0]
+		// so it doesn't exceed the 10k line limit.
+		t.Errorf("out[0].Batches:%d out[1].Batches:%d", len(out[0].Batches), len(out[1].Batches))
+	}
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -203,15 +203,25 @@ func TestMergeFiles__splitFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// read a third file
+	f3, err := readACHFilepath(filepath.Join("test", "testdata", "20110729A.ach"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f3.Header = file.Header // replace Header so they're merged into one file
+	if err := f3.Create(); err != nil {
+		t.Fatal(err)
+	}
+
 	// Merge our big file into another file and verify we get two back
 	// TODO(adam): We should probably recurse back on `file` to ensure we don't exceed the
 	// 10k line limit. That shouldn't happen as MergeFiles processes one batch at a time, but
 	// an incoming file might be invalid in that way.
-	out, err := MergeFiles([]*File{file, f2})
+	out, err := MergeFiles([]*File{file, f2, f3})
 	if err != nil || len(out) != 2 {
 		t.Fatalf("got %d files, error=%v", len(out), err)
 	}
-	if len(out[0].Batches) != 4001 || len(out[1].Batches) != 3 {
+	if len(out[0].Batches) != 4001 || len(out[1].Batches) != 5 {
 		// These batch counts will change when we recurse back through out[0]
 		// so it doesn't exceed the 10k line limit.
 		t.Errorf("out[0].Batches:%d out[1].Batches:%d", len(out[0].Batches), len(out[1].Batches))

--- a/reader_test.go
+++ b/reader_test.go
@@ -17,6 +17,20 @@ import (
 	"github.com/moov-io/base"
 )
 
+func readACHFilepath(path string) (*File, error) {
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	file, err := NewReader(fd).Read()
+	if err != nil {
+		return nil, err
+	}
+	return &file, nil
+}
+
 func TestReader__crashers(t *testing.T) {
 	dir := filepath.Join("test", "testdata", "crashes")
 	fds, err := ioutil.ReadDir(dir)


### PR DESCRIPTION
This pull request implements merging of arbitrary ACH files based on their `FileHeader` structs. The code optimizes for the fewest files by ABA routing information, but does not consolidate Batches with the same SEC codes. 

Files provided are assumed to be valid and under NACHA's 10k line limit and this function will always return valid files when provided with valid files. An error will be returned on invalid input files. 

Issue: https://github.com/moov-io/ach/issues/529