### PR TITLE
batch: only check DNE specifics if the SEC code is DNE

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -704,7 +704,7 @@ func (batch *Batch) calculateEntryHash() int {
 // allowed for DNEs. Tranaction codes 21 and 31 are just for returns or NOCs of the 23 and 33 codes.
 // So we check that the Originator Status Code is not equal to “2” for DNE if the Transaction Code is 23 or 33
 func (batch *Batch) isOriginatorDNE() error {
-	if batch.Header.OriginatorStatusCode != 2 {
+	if batch.Header.OriginatorStatusCode != 2 && batch.Header.StandardEntryClassCode == DNE {
 		for _, entry := range batch.Entries {
 			if entry.TransactionCode == CheckingPrenoteCredit || entry.TransactionCode == SavingsPrenoteCredit {
 				return batch.Error("OriginatorStatusCode", ErrBatchOriginatorDNE, batch.Header.OriginatorStatusCode)

--- a/batch_test.go
+++ b/batch_test.go
@@ -230,8 +230,10 @@ func BenchmarkBatchIsEntryHash(b *testing.B) {
 }
 
 func testBatchDNEMismatch(t testing.TB) {
+	bh := mockBatchHeader()
+	bh.StandardEntryClassCode = DNE
 	mockBatch := mockBatch()
-	mockBatch.SetHeader(mockBatchHeader())
+	mockBatch.SetHeader(bh)
 	ed := mockBatch.GetEntries()[0]
 	ed.AddAddenda05(mockAddenda05())
 	ed.AddAddenda05(mockAddenda05())
@@ -253,6 +255,19 @@ func BenchmarkBatchDNEMismatch(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		testBatchDNEMismatch(b)
+	}
+}
+
+func TestBatch__DNEOriginatorCheck(t *testing.T) {
+	bh := mockBatchHeader()
+	bh.OriginatorStatusCode = 1
+	bh.StandardEntryClassCode = PPD
+
+	batch := mockBatch()
+	batch.SetHeader(bh)
+
+	if err := batch.isOriginatorDNE(); err != nil {
+		t.Errorf("%T: %s", err, err)
 	}
 }
 


### PR DESCRIPTION
This came up when a PPD prenote was created, but this check was too
broad and returned an error incorrectly.