### PR TITLE
files: properly format FileCreation dates or times from multiple input formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       - "/Users/travis/Library/Caches/go-build"
 env:
   matrix:
-  - GO111MODULE=auto
+    - GO111MODULE=on
 before_install:
   - go get -u github.com/client9/misspell/cmd/misspell
   - go get -u golang.org/x/lint/golint

--- a/converters.go
+++ b/converters.go
@@ -30,7 +30,7 @@ func (c *converters) formatSimpleDate(s string) string {
 	return s
 }
 
-// formatSimpleTime takes a HHMM time and formats it for the fixed-width ACH file format
+// formatSimpleTime takes a HHmm (H=hour, m=minute) time and formats it for the fixed-width ACH file format
 func (c *converters) formatSimpleTime(s string) string {
 	if s == "" {
 		return c.stringField(s, 4)

--- a/fileHeader.go
+++ b/fileHeader.go
@@ -261,6 +261,8 @@ func (fh *FileHeader) ImmediateOriginField() string {
 }
 
 // FileCreationDateField gets the file creation date in YYMMDD (year, month, day) format
+// A blank string is returned when an error occurred while parsing the timestamp. ISO 8601
+// is the only other format supported.
 func (fh *FileHeader) FileCreationDateField() string {
 	switch utf8.RuneCountInString(fh.FileCreationDate) {
 	case 0:
@@ -276,6 +278,8 @@ func (fh *FileHeader) FileCreationDateField() string {
 }
 
 // FileCreationTimeField gets the file creation time in HHmm (hour, minute) format
+// A blank string is returned when an error occurred while parsing the timestamp. ISO 8601
+// is the only other format supported.
 func (fh *FileHeader) FileCreationTimeField() string {
 	switch utf8.RuneCountInString(fh.FileCreationTime) {
 	case 0:

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -562,33 +562,6 @@ func BenchmarkFHFieldInclusionFormatCode(b *testing.B) {
 	}
 }
 
-// testFHFieldInclusionCreationDate validates creation date field inclusion
-func testFHFieldInclusionCreationDate(t testing.TB) {
-	fh := mockFileHeader()
-	fh.FileCreationDate = time.Now().AddDate(0, 0, 1).Format("060102") // YYMMDD
-	if err := fh.Validate(); !base.Match(err, nil) {
-		t.Errorf("%T: %s", err, err)
-	}
-
-	fh.FileCreationDate = time.Now().Format(base.ISO8601Format)
-	if err := fh.Validate(); !base.Match(err, nil) {
-		t.Errorf("%T: %s", err, err)
-	}
-}
-
-// TestFHFieldInclusionCreationDate tests validating creation date field inclusion
-func TestFHFieldInclusionCreationDate(t *testing.T) {
-	testFHFieldInclusionCreationDate(t)
-}
-
-// BenchmarkFHFieldInclusionCreationDate benchmarks validating creation date field inclusion
-func BenchmarkFHFieldInclusionCreationDate(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		testFHFieldInclusionCreationDate(b)
-	}
-}
-
 func TestFHImmediateDestinationInvalidLength(t *testing.T) {
 	fh := mockFileHeader()
 	fh.ImmediateDestination = "198387"
@@ -625,8 +598,64 @@ func TestFHImmediateOriginInvalidCheckSum(t *testing.T) {
 	}
 }
 
-// testFHFieldInclusionCreationTime validates creation date field inclusion
-func testFHFieldInclusionCreationTime(t testing.TB) {
+func TestFHFieldInclusionFileCreationDate(t *testing.T) {
+	fh := mockFileHeader()
+	fh.FileCreationDate = ""
+	if err := fh.Validate(); !base.Match(err, ErrConstructor) {
+		t.Errorf("%T: %s", err, err)
+	}
+}
+
+// testFileHeaderCreationDate validates creation date field inclusion
+func testFileHeaderCreationDate(t testing.TB) {
+	fh := mockFileHeader()
+	fh.FileCreationDate = time.Now().AddDate(0, 0, 1).Format("060102") // YYMMDD
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+
+	fh.FileCreationDate = time.Now().Format(base.ISO8601Format)
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+	if v := fh.FileCreationDateField(); len(v) != 6 {
+		t.Errorf("got %q", v)
+	}
+
+	fh.FileCreationDate = "      "
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+
+	fh.FileCreationDate = ""
+	if v := fh.FileCreationDateField(); len(v) != 6 {
+		t.Errorf("got %q", v)
+	}
+
+	fh.FileCreationDate = "05/01/2019" // non ISO 8601 date
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+	if v := fh.FileCreationDateField(); v != "" {
+		t.Errorf("got %q", v)
+	}
+}
+
+// TestFileHeaderCreationDate tests validating creation date field inclusion
+func TestFileHeaderCreationDate(t *testing.T) {
+	testFileHeaderCreationDate(t)
+}
+
+// BenchmarkFileHeaderCreationDate benchmarks validating creation date field inclusion
+func BenchmarkFileHeaderCreationDate(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testFileHeaderCreationDate(b)
+	}
+}
+
+// testFileHeaderCreationTime validates creation date field inclusion
+func testFileHeaderCreationTime(t testing.TB) {
 	fh := mockFileHeader()
 	fh.FileCreationTime = time.Now().AddDate(0, 0, 1).Format("1504") // HHmm
 	if err := fh.Validate(); !base.Match(err, nil) {
@@ -637,17 +666,38 @@ func testFHFieldInclusionCreationTime(t testing.TB) {
 	if err := fh.Validate(); !base.Match(err, nil) {
 		t.Errorf("%T: %s", err, err)
 	}
+	if v := fh.FileCreationTimeField(); len(v) != 4 {
+		t.Errorf("got %q", v)
+	}
+
+	fh.FileCreationTime = "    "
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+
+	fh.FileCreationTime = ""
+	if v := fh.FileCreationTimeField(); len(v) != 4 {
+		t.Errorf("got %q", v)
+	}
+
+	fh.FileCreationTime = "05/01/2019" // non ISO 8601 date
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+	if v := fh.FileCreationTimeField(); v != "" {
+		t.Errorf("got %q", v)
+	}
 }
 
-// TestFHFieldInclusionCreationTime tests validating creation date field inclusion
-func TestFHFieldInclusionCreationTime(t *testing.T) {
-	testFHFieldInclusionCreationTime(t)
+// TestFileHeaderCreationTime tests validating creation date field inclusion
+func TestFileHeaderCreationTime(t *testing.T) {
+	testFileHeaderCreationTime(t)
 }
 
-// BenchmarkFHFieldInclusionCreationTime benchmarks validating creation date field inclusion
-func BenchmarkFHFieldInclusionCreationTime(b *testing.B) {
+// BenchmarkFileHeaderCreationTime benchmarks validating creation date field inclusion
+func BenchmarkFileHeaderCreationTime(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		testFHFieldInclusionCreationTime(b)
+		testFileHeaderCreationTime(b)
 	}
 }

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -566,9 +566,12 @@ func BenchmarkFHFieldInclusionFormatCode(b *testing.B) {
 func testFHFieldInclusionCreationDate(t testing.TB) {
 	fh := mockFileHeader()
 	fh.FileCreationDate = time.Now().AddDate(0, 0, 1).Format("060102") // YYMMDD
-	err := fh.Validate()
-	// TODO: are we expecting to see an error here?
-	if !base.Match(err, nil) {
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+
+	fh.FileCreationDate = time.Now().Format(base.ISO8601Format)
+	if err := fh.Validate(); !base.Match(err, nil) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -619,5 +622,32 @@ func TestFHImmediateOriginInvalidCheckSum(t *testing.T) {
 	err := fh.Validate()
 	if !strings.Contains(err.Error(), "routing number checksum mismatch") {
 		t.Errorf("%T: %s", err, err)
+	}
+}
+
+// testFHFieldInclusionCreationTime validates creation date field inclusion
+func testFHFieldInclusionCreationTime(t testing.TB) {
+	fh := mockFileHeader()
+	fh.FileCreationTime = time.Now().AddDate(0, 0, 1).Format("1504") // HHmm
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+
+	fh.FileCreationTime = time.Now().Format(base.ISO8601Format)
+	if err := fh.Validate(); !base.Match(err, nil) {
+		t.Errorf("%T: %s", err, err)
+	}
+}
+
+// TestFHFieldInclusionCreationTime tests validating creation date field inclusion
+func TestFHFieldInclusionCreationTime(t *testing.T) {
+	testFHFieldInclusionCreationTime(t)
+}
+
+// BenchmarkFHFieldInclusionCreationTime benchmarks validating creation date field inclusion
+func BenchmarkFHFieldInclusionCreationTime(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		testFHFieldInclusionCreationTime(b)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/go-kit/kit v0.8.0
 	github.com/gorilla/mux v1.7.2
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/moov-io/base v0.9.0
+	github.com/moov-io/base v0.10.0-rc1.0.20190624220657-442e0f291a97
 	github.com/prometheus/client_golang v1.0.0
 	github.com/rickar/cal v1.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -12,6 +13,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-logfmt/logfmt v0.3.0 h1:8HUsc87TaSWLKwrnumgC8/YconD2fJQsRJAsWaPg2ic=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -24,6 +26,7 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/mux v1.7.1 h1:Dw4jY2nghMMRsh1ol8dv1axHkDwMQK2DHerMNJsIpJU=
 github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -38,6 +41,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/moov-io/base v0.9.0 h1:7bp5Jpola4EunGmOVVaw3WkWOqcSnyVZJEoOmYLKdhw=
 github.com/moov-io/base v0.9.0/go.mod h1:pPu/TAc9PkaaegbREVEeDHsGqyAlvji9vqTuARuAnd0=
+github.com/moov-io/base v0.10.0-rc1.0.20190624220657-442e0f291a97 h1:E1H55Hr2IJthV71u3ZAnV3LvFhAWznBTnTxMmRi9kLE=
+github.com/moov-io/base v0.10.0-rc1.0.20190624220657-442e0f291a97/go.mod h1:pPu/TAc9PkaaegbREVEeDHsGqyAlvji9vqTuARuAnd0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -46,6 +51,7 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
+github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -57,6 +63,7 @@ github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7q
 github.com/prometheus/common v0.3.0 h1:taZ4h8Tkxv2kNyoSctBvfXEHmBmxrwmIidZTIaHons4=
 github.com/prometheus/common v0.3.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nLJdBg+pBmGgkJlSaKC2KaQmTCk1XDtE=
@@ -65,6 +72,7 @@ github.com/prometheus/procfs v0.0.0-20190412120340-e22ddced7142 h1:JO6VBMEDSBX/L
 github.com/prometheus/procfs v0.0.0-20190412120340-e22ddced7142/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.0-20190520144149-9935e8e0588d/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rickar/cal v1.0.1 h1:Tyjkk4sBvVC3gcXCgLowEM53R2eVfFcoi1gtQuocrmk=

--- a/merge.go
+++ b/merge.go
@@ -84,7 +84,7 @@ next:
 	out := NewFile()
 	out.Header = f.Header
 	out.Header.FileCreationDate = now.Format("060102") // YYMMDD
-	out.Header.FileCreationTime = now.Format("1504")   // HHMM
+	out.Header.FileCreationTime = now.Format("1504")   // HHmm
 	out.Create()
 	fs.outfiles = append(fs.outfiles, out) // add the new outfile
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -489,7 +489,7 @@ components:
           maxLength: 23
           example: Federal Reserve Bank
         fileCreationTime:
-          description: 'The File Creation Date is the date when the file was prepared by an ODFI. (Format HHMM - H=Hour, M=Minute)'
+          description: 'The File Creation Date is the date when the file was prepared by an ODFI. (Format HHmm - H=Hour, m=Minute)'
           type: string
           example: 1504
         fileCreationDate:

--- a/validators.go
+++ b/validators.go
@@ -137,7 +137,7 @@ func (v *validator) validateSimpleDate(s string) string {
 
 var (
 	// hhmmRegex defines a regex for all valid 24-hour clock timestamps.
-	// Format: HHMM (first H can only be 0, 1, or 2)
+	// Format: HHmm (H=hour, m=minute) - (first H can only be 0, 1, or 2)
 	hhmmRegex = regexp.MustCompile(`^([0-2]{1}[\d]{1}[0-5]{1}\d{1})$`)
 )
 


### PR DESCRIPTION
When `FileCreationTime` and `FileCreationDate` values are empty we are going to render them as tomorrow's appropriate value. This decision came from Wade, fyi. 

When the format is an ISO 8601 timestamp (common for Javascript and other languages) we need to handle that and convert to the format required by NACHA for ACH files. 

Also, clarify `m` vs `M` in time/date formats. `m` should refer to minutes and `M` to months. 

Issue: https://github.com/moov-io/ach/issues/556 