### PR TITLE
build: add makefile steps to generate and render coverage profiles

### DIFF
--- a/makefile
+++ b/makefile
@@ -41,6 +41,12 @@ release-push:
 	docker push moov/ach:latest
 	docker push moov/achfuzz:$(VERSION)
 
+.PHONY: cover-test cover-web
+cover-test:
+	go test -coverprofile=cover.out ./...
+cover-web:
+	go tool cover -html=cover.out
+
 # From https://github.com/genuinetools/img
 .PHONY: AUTHORS
 AUTHORS:


### PR DESCRIPTION
The other projects have these quick tasks and I'm not sure why they
aren't already in ACH.