### PR TITLE
fileHeader: file creation date and time are always today

### DIFF
--- a/fileHeader.go
+++ b/fileHeader.go
@@ -266,7 +266,7 @@ func (fh *FileHeader) ImmediateOriginField() string {
 func (fh *FileHeader) FileCreationDateField() string {
 	switch utf8.RuneCountInString(fh.FileCreationDate) {
 	case 0:
-		return base.Now().AddBankingDay(1).Format("060102")
+		return time.Now().Format("060102")
 	case 6:
 		return fh.formatSimpleDate(fh.FileCreationDate) // YYMMDD
 	}
@@ -283,7 +283,7 @@ func (fh *FileHeader) FileCreationDateField() string {
 func (fh *FileHeader) FileCreationTimeField() string {
 	switch utf8.RuneCountInString(fh.FileCreationTime) {
 	case 0:
-		return base.Now().AddBankingDay(1).Format("1504")
+		return time.Now().Format("1504")
 	case 4:
 		return fh.formatSimpleTime(fh.FileCreationTime) // HHmm
 	}

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -618,7 +618,8 @@ func testFileHeaderCreationDate(t testing.TB) {
 	if err := fh.Validate(); !base.Match(err, nil) {
 		t.Errorf("%T: %s", err, err)
 	}
-	if v := fh.FileCreationDateField(); len(v) != 6 {
+	yymmdd := time.Now().Format("060102")
+	if v := fh.FileCreationDateField(); v != yymmdd {
 		t.Errorf("got %q", v)
 	}
 


### PR DESCRIPTION
We got a bit mixed up on when to increment certain Date/Time values. 

See: https://github.com/moov-io/ach/issues/556 and https://github.com/moov-io/ach/pull/558#issuecomment-505648969 