### PR TITLE
add environment variables to override command line flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ $ go doc github.com/moov-io/ach BatchHeader
 | Environmental Variable | Description | Default |
 |-----|-----|-----|
 | `ACH_FILE_TTL` | Time to live (TTL) for `*ach.File` objects stored in the in-memory repository. | 0 = No TTL / Never delete files (Example: `240m`) |
+| `LOG_FORMAT` | Format for logging lines to be written as. | Options: `json`, `plain` - Default: `plain` |
+| `HTTP_BIND_ADDRESS` | Address for paygate to bind its HTTP server on. This overrides the command-line flag `-http.addr`. | Default: `:8080` |
+| `HTTP_ADMIN_BIND_ADDRESS` | Address for paygate to bind its admin HTTP server on. This overrides the command-line flag `-admin.addr`. | Default: `:9090` |
+
 
 Note: By design ACH **does not persist** (save) any data about the files, batches or entry details created. The only storage occurs in memory of the process and upon restart ACH will have no files, batches, or data saved. Also, no in memory encryption of the data is performed.
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -39,6 +39,9 @@ func main() {
 	flag.Parse()
 
 	// Setup logging, default to stdout
+	if v := os.Getenv("LOG_FORMAT"); v != "" {
+		*flagLogFormat = v
+	}
 	if *flagLogFormat == "json" {
 		logger = log.NewJSONLogger(os.Stdout)
 	} else {
@@ -75,6 +78,11 @@ func main() {
 	writTimeout, _ := time.ParseDuration("30s")
 	idleTimeout, _ := time.ParseDuration("60s")
 
+	// Check to see if our -http.addr flag has been overridden
+	if v := os.Getenv("HTTP_BIND_ADDRESS"); v != "" {
+		*httpAddr = v
+	}
+
 	serve := &http.Server{
 		Addr:    *httpAddr,
 		Handler: handler,
@@ -91,6 +99,11 @@ func main() {
 		if err := serve.Shutdown(context.TODO()); err != nil {
 			logger.Log("shutdown", err)
 		}
+	}
+
+	// Check to see if our -admin.addr flag has been overridden
+	if v := os.Getenv("HTTP_ADMIN_BIND_ADDRESS"); v != "" {
+		*adminAddr = v
 	}
 
 	// Admin server (metrics and debugging)


### PR DESCRIPTION
added support for the following environment variables:
LOG_FORMAT HTTP_BIND_ADDRESS HTTP_ADMIN_BIND_ADDRESS