### PR TITLE
server: log even if we have an empty x-request-id

### DIFF
--- a/server/batches.go
+++ b/server/batches.go
@@ -44,7 +44,7 @@ func createBatchEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 
 		id, err := s.CreateBatch(req.FileID, req.Batch)
 
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("batches", "createBatch", "file", req.FileID, "requestId", req.requestId, "error", err)
 		}
 
@@ -114,7 +114,7 @@ func getBatchesEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 			}, err
 		}
 
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("batches", "getBatches", "file", req.fileID, "requestId", req.requestId)
 		}
 		return getBatchesResponse{
@@ -169,7 +169,7 @@ func getBatchEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 
 		batch, err := s.GetBatch(req.fileID, req.batchID)
 
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("batches", "getBatche", "file", req.fileID, "requestId", req.requestId, "error", err)
 		}
 
@@ -224,7 +224,7 @@ func deleteBatchEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 
 		err := s.DeleteBatch(req.fileID, req.batchID)
 
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("batches", "deleteBatch", "file", req.fileID, "requestId", req.requestId, "error", err)
 		}
 

--- a/server/batches_test.go
+++ b/server/batches_test.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/moov-io/ach"
+
 	"github.com/go-kit/kit/log"
 )
 
 func TestFiles__createBatchEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory(testTTLDuration, nil)
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -26,10 +28,29 @@ func TestFiles__createBatchEndpoint(t *testing.T) {
 	if err == nil || r.Err == nil {
 		t.Errorf("expected error: err=%v resp.Err=%v", err, r.Err)
 	}
+
+	f := ach.NewFile()
+	f.ID = "create-batch"
+	if err := repo.StoreFile(f); err != nil {
+		t.Fatal(err)
+	}
+
+	// successful batch
+	resp, err = createBatchEndpoint(svc, log.NewNopLogger())(context.TODO(), createBatchRequest{
+		FileID: f.ID,
+		Batch:  &mockBatchWEB().Batch,
+	})
+	if r, ok := resp.(createBatchResponse); ok {
+		if r.ID != "54321" || err != nil {
+			t.Errorf("id=%s error=%v", r.ID, r.Err)
+		}
+	} else {
+		t.Errorf("%T %#v", resp, resp)
+	}
 }
 
 func TestFiles__getBatchesEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory(testTTLDuration, nil)
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -42,10 +63,31 @@ func TestFiles__getBatchesEndpoint(t *testing.T) {
 	if err == nil || r.Err == nil {
 		t.Errorf("expected error: err=%v resp.Err=%v", err, r.Err)
 	}
+
+	// successful batch
+	f := ach.NewFile()
+	f.ID = "get-batches"
+	f.AddBatch(mockBatchWEB())
+	if err := repo.StoreFile(f); err != nil {
+		t.Fatal(err)
+	}
+	resp, err = getBatchesEndpoint(svc, log.NewNopLogger())(context.TODO(), getBatchesRequest{
+		fileID: f.ID,
+	})
+	if r, ok := resp.(getBatchesResponse); ok {
+		if len(r.Batches) != 1 {
+			t.Errorf("got %d Batches=%#v", len(r.Batches), r.Batches)
+		}
+		if err != nil {
+			t.Error(r.Err)
+		}
+	} else {
+		t.Errorf("%T %#v", resp, resp)
+	}
 }
 
 func TestFiles__getBatchEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory(testTTLDuration, nil)
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -58,10 +100,33 @@ func TestFiles__getBatchEndpoint(t *testing.T) {
 	if err == nil || r.Err == nil {
 		t.Errorf("expected error: err=%v resp.Err=%v", err, r.Err)
 	}
+
+	// successful batch
+	f := ach.NewFile()
+	f.ID = "get-batch"
+	b := mockBatchWEB()
+	f.AddBatch(b)
+	if err := repo.StoreFile(f); err != nil {
+		t.Fatal(err)
+	}
+	resp, err = getBatchEndpoint(svc, log.NewNopLogger())(context.TODO(), getBatchRequest{
+		fileID:  f.ID,
+		batchID: b.ID(),
+	})
+	if r, ok := resp.(getBatchResponse); ok {
+		if r.Batch == nil {
+			t.Error("nil ach.Batcher")
+		}
+		if err != nil {
+			t.Error(r.Err)
+		}
+	} else {
+		t.Errorf("%T %#v", resp, resp)
+	}
 }
 
 func TestFiles__deleteBatchEndpoint(t *testing.T) {
-	repo := NewRepositoryInMemory(testTTLDuration, nil)
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
 	svc := NewService(repo)
 
 	body := strings.NewReader(`{"random":"json"}`)
@@ -73,5 +138,25 @@ func TestFiles__deleteBatchEndpoint(t *testing.T) {
 	}
 	if err == nil || r.Err == nil {
 		t.Errorf("expected error: err=%v resp.Err=%v", err, r.Err)
+	}
+
+	// successful batch
+	f := ach.NewFile()
+	f.ID = "delete-batch"
+	b := mockBatchWEB()
+	f.AddBatch(b)
+	if err := repo.StoreFile(f); err != nil {
+		t.Fatal(err)
+	}
+	resp, err = deleteBatchEndpoint(svc, log.NewNopLogger())(context.TODO(), deleteBatchRequest{
+		fileID:  f.ID,
+		batchID: b.ID(),
+	})
+	if r, ok := resp.(deleteBatchResponse); ok {
+		if err != nil {
+			t.Error(r.Err)
+		}
+	} else {
+		t.Errorf("%T %#v", resp, resp)
 	}
 }

--- a/server/batches_test.go
+++ b/server/batches_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/go-kit/kit/log"
 )
 
 func TestFiles__createBatchEndpoint(t *testing.T) {
@@ -16,7 +18,7 @@ func TestFiles__createBatchEndpoint(t *testing.T) {
 
 	body := strings.NewReader(`{"random":"json"}`)
 
-	resp, err := createBatchEndpoint(svc, nil)(context.TODO(), body)
+	resp, err := createBatchEndpoint(svc, log.NewNopLogger())(context.TODO(), body)
 	r, ok := resp.(createBatchResponse)
 	if !ok {
 		t.Errorf("got %#v", resp)
@@ -32,7 +34,7 @@ func TestFiles__getBatchesEndpoint(t *testing.T) {
 
 	body := strings.NewReader(`{"random":"json"}`)
 
-	resp, err := getBatchesEndpoint(svc, nil)(context.TODO(), body)
+	resp, err := getBatchesEndpoint(svc, log.NewNopLogger())(context.TODO(), body)
 	r, ok := resp.(getBatchesResponse)
 	if !ok {
 		t.Errorf("got %#v", resp)
@@ -48,7 +50,7 @@ func TestFiles__getBatchEndpoint(t *testing.T) {
 
 	body := strings.NewReader(`{"random":"json"}`)
 
-	resp, err := getBatchEndpoint(svc, nil)(context.TODO(), body)
+	resp, err := getBatchEndpoint(svc, log.NewNopLogger())(context.TODO(), body)
 	r, ok := resp.(getBatchResponse)
 	if !ok {
 		t.Errorf("got %#v", resp)
@@ -64,7 +66,7 @@ func TestFiles__deleteBatchEndpoint(t *testing.T) {
 
 	body := strings.NewReader(`{"random":"json"}`)
 
-	resp, err := deleteBatchEndpoint(svc, nil)(context.TODO(), body)
+	resp, err := deleteBatchEndpoint(svc, log.NewNopLogger())(context.TODO(), body)
 	r, ok := resp.(deleteBatchResponse)
 	if !ok {
 		t.Errorf("got %#v", resp)

--- a/server/files.go
+++ b/server/files.go
@@ -71,7 +71,7 @@ func createFileEndpoint(s Service, r Repository, logger log.Logger) endpoint.End
 		}
 
 		err := r.StoreFile(req.File)
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("files", "createFile", "requestId", req.requestId, "error", err)
 		}
 
@@ -168,7 +168,7 @@ func getFileEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 
 		f, err := s.GetFile(req.ID)
 
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("files", "getFile", "requestId", req.requestId, "error", err)
 		}
 
@@ -217,7 +217,7 @@ func deleteFileEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 
 		err := s.DeleteFile(req.ID)
 
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("files", "deleteFile", "requestId", req.requestId, "error", err)
 		}
 
@@ -263,7 +263,7 @@ func getFileContentsEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 
 		r, err := s.GetFileContents(req.ID)
 
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("files", "getFileContents", "requestId", req.requestId, "error", err)
 		}
 		if err != nil {
@@ -309,7 +309,7 @@ func validateFileEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 		}
 
 		err := s.ValidateFile(req.ID)
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("files", "validateFile", "requestId", req.requestId, "error", err)
 		}
 		if err != nil { // wrap err with context
@@ -355,7 +355,7 @@ func segmentFileEndpoint(s Service, r Repository, logger log.Logger) endpoint.En
 
 		creditFile, debitFile, err := s.SegmentFile(req.fileID)
 
-		if req.requestId != "" && logger != nil {
+		if logger != nil {
 			logger.Log("files", "segmentFile", "requestId", req.requestId, "error", err)
 		}
 		if err != nil {
@@ -364,14 +364,14 @@ func segmentFileEndpoint(s Service, r Repository, logger log.Logger) endpoint.En
 
 		if creditFile.ID != "" {
 			err = r.StoreFile(creditFile)
-			if req.requestId != "" && logger != nil {
+			if logger != nil {
 				logger.Log("files", "storeCreditFile", "requestId", req.requestId, "error", err)
 			}
 		}
 
 		if debitFile.ID != "" {
 			err = r.StoreFile(debitFile)
-			if req.requestId != "" && logger != nil {
+			if logger != nil {
 				logger.Log("files", "storeDebitFile", "requestId", req.requestId, "error", err)
 			}
 		}

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -7,8 +7,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/go-kit/kit/log"
-	"github.com/moov-io/base"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -18,7 +16,9 @@ import (
 	"testing"
 
 	"github.com/moov-io/ach"
+	"github.com/moov-io/base"
 
+	"github.com/go-kit/kit/log"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
 )


### PR DESCRIPTION
We miss out on logs by forgetting to set this header and that makes debugging harder.