### PR TITLE
 batch: inspect EntryDetail records for Category 

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -491,7 +491,17 @@ func (batch *Batch) GetADVEntries() []*ADVEntryDetail {
 
 // Category returns batch category
 func (batch *Batch) Category() string {
-	return batch.category
+	if len(batch.Entries) == 0 && batch.category != "" {
+		return batch.category
+	}
+	// If an Entry has NOC or Return that's the Batch's category
+	for i := range batch.Entries {
+		switch batch.Entries[i].Category {
+		case CategoryReturn, CategoryNOC:
+			return batch.Entries[i].Category
+		}
+	}
+	return CategoryForward
 }
 
 // ID returns the id of the batch

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -670,10 +670,14 @@ func TestEntryDetail__CategoryJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if n := len(file.ReturnEntries); n != 2 {
+		t.Errorf("got %d ReturnEntries", n)
+	}
 	if err := json.NewEncoder(&buf).Encode(file); err != nil {
 		t.Fatal(err)
 	}
-	if n := strings.Count(buf.String(), `"category":"Return"`); n != 2 {
+	// There are two ReturnEntries and two Batches
+	if n := strings.Count(buf.String(), `"category":"Return"`); n != 4 {
 		// return-WEB.ach has two EntryDetail records
 		t.Errorf("got %d category:Return\n%s", n, buf.String())
 	}
@@ -688,7 +692,9 @@ func TestEntryDetail__ParseReturn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
+	if n := len(file.ReturnEntries); n != 2 {
+		t.Errorf("got %d ReturnEntries", n)
+	}
 	if n := len(file.Batches); n != 2 {
 		t.Errorf("got %d batches: %#v", n, file.Batches)
 	}


### PR DESCRIPTION
Returning the `.category` struct member is too naive after parsing ACH returns. Also, Batches can't have mixes of Forward and Return (or NOC), so `Category()` needs to respond with whichever non-Forward value is within the EntryDetails. 