### PR TITLE
server: initial setup for an endpoint to balance ACH files

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1119,7 +1119,9 @@ func createOffsetEntryDetail(off *Offset, batch *Batch) *EntryDetail {
 	ed.IdentificationNumber = "" // left empty
 	ed.IndividualName = "OFFSET"
 	ed.DiscretionaryData = batch.offset.Description
-	ed.Category = CategoryForward
+	if len(batch.Entries) > 0 {
+		ed.Category = batch.Entries[0].Category
+	}
 	return ed
 }
 

--- a/batch.go
+++ b/batch.go
@@ -1104,6 +1104,8 @@ func (b *Batch) upsertOffsets() error {
 		b.Control.TotalCreditEntryDollarAmount += creditED.Amount
 	}
 	b.Header.ServiceClassCode = MixedDebitsAndCredits
+
+	b.Control.ServiceClassCode = MixedDebitsAndCredits
 	b.Control.EntryHash = b.calculateEntryHash()
 
 	return nil

--- a/batcher.go
+++ b/batcher.go
@@ -49,15 +49,15 @@ type Batcher interface {
 
 // Offset contains the associated information to append an 'Offset Record' on an ACH batch during Create.
 type Offset struct {
-	RoutingNumber string
-	AccountNumber string
-	AccountType   OffsetAccountType
-	Description   string
+	RoutingNumber string            `json:"routingNumber"`
+	AccountNumber string            `json:"accountNumber"`
+	AccountType   OffsetAccountType `json:"accountType"`
+	Description   string            `json:"description"`
 }
 
-type OffsetAccountType int
+type OffsetAccountType string
 
 const (
-	OffsetChecking OffsetAccountType = 1
-	OffsetSavings  OffsetAccountType = 2
+	OffsetChecking OffsetAccountType = "checking"
+	OffsetSavings  OffsetAccountType = "savings"
 )

--- a/server/files.go
+++ b/server/files.go
@@ -391,6 +391,9 @@ func decodeBalanceFileRequest(_ context.Context, r *http.Request) (interface{}, 
 	if err := json.NewDecoder(r.Body).Decode(&off); err != nil {
 		return nil, err
 	}
+	if off.RoutingNumber == "" || off.AccountNumber == "" || string(off.AccountType) == "" {
+		return nil, errors.New("missing some offset json fields")
+	}
 	return balanceFileRequest{
 		fileID:    fileID,
 		offset:    &off,

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -306,6 +306,37 @@ func TestFiles__balanceFileEndpoint(t *testing.T) {
 	}
 }
 
+func TestFilesErr__balanceFileEndpointJSON(t *testing.T) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(testTTLDuration, logger)
+	svc := NewService(repo)
+	router := MakeHTTPHandler(svc, repo, logger)
+
+	// write an ACH file into the repository
+	fd, err := os.Open(filepath.Join("..", "test", "testdata", "ppd-mixedDebitCredit-valid.json"))
+	if err != nil {
+		t.Fatalf("empty ACH file: %v", err)
+	}
+	defer fd.Close()
+
+	bs, _ := ioutil.ReadAll(fd)
+	file, _ := ach.FileFromJSON(bs)
+	repo.StoreFile(file)
+
+	w := httptest.NewRecorder()
+
+	body := strings.NewReader(`{"routingNumber": "987654320"}`) // partial JSON, but we left off fields
+	req := httptest.NewRequest("POST", fmt.Sprintf("/files/%s/balance", file.ID), body)
+	req.Header.Set("X-Request-ID", base.ID())
+
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("bogus HTTP status: %d", w.Code)
+	}
+}
+
 // TestFilesError__segmentFileEndpoint test an error returned from segmentFileEndpoint
 func TestFilesError__segmentFileEndpoint(t *testing.T) {
 	repo := NewRepositoryInMemory(testTTLDuration, nil)

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -258,7 +258,7 @@ func TestFilesErr__balanceFileEndpoint(t *testing.T) {
 	repo := NewRepositoryInMemory(testTTLDuration, nil)
 	svc := NewService(repo)
 
-	resp, err := balanceFileEndpoint(svc, repo, nil)(context.TODO(), nil)
+	resp, err := balanceFileEndpoint(svc, repo, log.NewNopLogger())(context.TODO(), nil)
 	r, ok := resp.(balanceFileResponse)
 	if !ok {
 		t.Errorf("got %#v", resp)

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -254,6 +254,58 @@ func TestFiles__validateFileEndpoint(t *testing.T) {
 	}
 }
 
+func TestFilesErr__balanceFileEndpoint(t *testing.T) {
+	repo := NewRepositoryInMemory(testTTLDuration, nil)
+	svc := NewService(repo)
+
+	resp, err := balanceFileEndpoint(svc, repo, nil)(context.TODO(), nil)
+	r, ok := resp.(balanceFileResponse)
+	if !ok {
+		t.Errorf("got %#v", resp)
+	}
+	if err == nil || r.Err == nil {
+		t.Errorf("expected error: err=%v resp.Err=%v", err, r.Err)
+	}
+}
+
+func TestFiles__balanceFileEndpoint(t *testing.T) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(testTTLDuration, logger)
+	svc := NewService(repo)
+	router := MakeHTTPHandler(svc, repo, logger)
+
+	// write an ACH file into the repository
+	fd, err := os.Open(filepath.Join("..", "test", "testdata", "ppd-mixedDebitCredit-valid.json"))
+	if err != nil {
+		t.Fatalf("empty ACH file: %v", err)
+	}
+	defer fd.Close()
+
+	bs, _ := ioutil.ReadAll(fd)
+	file, _ := ach.FileFromJSON(bs)
+	repo.StoreFile(file)
+
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`{"routingNumber": "987654320", "accountNumber": "216112", "accountType": "checking", "description": "OFFSET"}`)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/files/%s/balance", file.ID), body)
+	req.Header.Set("X-Request-ID", base.ID())
+
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", w.Code)
+	}
+
+	var resp balanceFileResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.FileID == "" {
+		t.Error("empty FileID")
+	}
+}
+
 // TestFilesError__segmentFileEndpoint test an error returned from segmentFileEndpoint
 func TestFilesError__segmentFileEndpoint(t *testing.T) {
 	repo := NewRepositoryInMemory(testTTLDuration, nil)
@@ -267,7 +319,6 @@ func TestFilesError__segmentFileEndpoint(t *testing.T) {
 	if err == nil || r.Err == nil {
 		t.Errorf("expected error: err=%v resp.Err=%v", err, r.Err)
 	}
-
 }
 
 // TestFiles__segmentFileEndpoint tests segmentFileEndpoints

--- a/server/routing.go
+++ b/server/routing.go
@@ -170,6 +170,12 @@ func MakeHTTPHandler(s Service, repo Repository, logger log.Logger) http.Handler
 		encodeResponse,
 		options...,
 	))
+	r.Methods("POST").Path("/files/{fileID}/balance").Handler(httptransport.NewServer(
+		balanceFileEndpoint(s, repo, logger),
+		decodeBalanceFileRequest,
+		encodeResponse,
+		options...,
+	))
 	r.Methods("POST").Path("/files/{fileID}/segment").Handler(httptransport.NewServer(
 		segmentFileEndpoint(s, repo, logger),
 		decodeSegmentFileRequest,

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -335,6 +335,22 @@ func TestBalanceFile(t *testing.T) {
 	}
 }
 
+func TestBalanceFileErrors(t *testing.T) {
+	s := mockServiceInMemory()
+	if file, err := s.BalanceFile(base.ID(), &ach.Offset{}); err == nil {
+		t.Errorf("expected error file=%#v", file)
+	}
+
+	fh := ach.NewFileHeader()
+	fileID, err := s.CreateFile(&fh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file, err := s.BalanceFile(fileID, &ach.Offset{}); err == nil {
+		t.Errorf("expected error file=%#v", file)
+	}
+}
+
 // TestSegmentFile creates a Segmented File from an existing ACH File
 func TestSegmentFile(t *testing.T) {
 	s := mockServiceInMemory()


### PR DESCRIPTION
To "balance a file" we really need to apply the Offset record information onto every Batch.

For now we aren't offsetting IAT batches.

Issue: https://github.com/moov-io/ach/issues/565