### PR TITLE
addenda98: export ChangeCode struct

### DIFF
--- a/addenda98.go
+++ b/addenda98.go
@@ -54,7 +54,7 @@ type Addenda98 struct {
 }
 
 var (
-	changeCodeDict = map[string]*changeCode{}
+	changeCodeDict = map[string]*ChangeCode{}
 )
 
 func init() {
@@ -62,9 +62,9 @@ func init() {
 	changeCodeDict = makeChangeCodeDict()
 }
 
-// changeCode holds a change Code, Reason/Title, and Description
+// ChangeCode holds a change Code, Reason/Title, and Description
 // table of return codes exists in Part 4.2 of the NACHA corporate rules and guidelines
-type changeCode struct {
+type ChangeCode struct {
 	Code, Reason, Description string
 }
 
@@ -164,10 +164,18 @@ func (addenda98 *Addenda98) TraceNumberField() string {
 	return addenda98.stringField(addenda98.TraceNumber, 15)
 }
 
-func makeChangeCodeDict() map[string]*changeCode {
-	dict := make(map[string]*changeCode)
+func (addenda98 *Addenda98) ChangeCodeField() *ChangeCode {
+	code, ok := changeCodeDict[addenda98.ChangeCode]
+	if ok {
+		return code
+	}
+	return nil
+}
 
-	codes := []changeCode{
+func makeChangeCodeDict() map[string]*ChangeCode {
+	dict := make(map[string]*ChangeCode)
+
+	codes := []ChangeCode{
 		{"C01", "Incorrect bank account number", "Bank account number incorrect or formatted incorrectly"},
 		{"C02", "Incorrect transit/routing number", "Once valid transit/routing number must be changed"},
 		{"C03", "Incorrect transit/routing number and bank account number", "Once valid transit/routing number must be changed and causes a change to bank account number structure"},
@@ -181,8 +189,8 @@ func makeChangeCodeDict() map[string]*changeCode {
 		{"C12", "Incorrect company name and company ID", "Both the company name and company id are no longer valid and must be changed"},
 	}
 	// populate the map
-	for _, code := range codes {
-		dict[code.Code] = &code
+	for i := range codes {
+		dict[codes[i].Code] = &codes[i]
 	}
 	return dict
 }

--- a/addenda98_test.go
+++ b/addenda98_test.go
@@ -295,6 +295,12 @@ func TestAddenda98__ChangeCodeField(t *testing.T) {
 			t.Errorf("code.Code=%s", code.Code)
 		}
 	}
+
+	// invalid change code
+	addenda98.ChangeCode = "C99"
+	if code := addenda98.ChangeCodeField(); code != nil {
+		t.Errorf("unexpected change code: %v", code)
+	}
 }
 
 // testAddenda98TypeCodeNil validates TypeCode is ""

--- a/addenda98_test.go
+++ b/addenda98_test.go
@@ -270,6 +270,33 @@ func BenchmarkAddenda98TraceNumberField(b *testing.B) {
 	}
 }
 
+func TestAddenda98__ChangeCodeField(t *testing.T) {
+	addenda98 := mockAddenda98()
+	if addenda98.ChangeCode != "C01" {
+		t.Errorf("addenda98.ChangeCode=%s", addenda98.ChangeCode)
+	}
+	if code := addenda98.ChangeCodeField(); code == nil {
+		t.Fatal("nil Addenda98.ChangeCodeField")
+	} else {
+		if code.Code != "C01" {
+			t.Errorf("code.Code=%s", code.Code)
+		}
+		if code.Reason != "Incorrect bank account number" {
+			t.Errorf("code.Reason=%s", code.Reason)
+		}
+	}
+
+	// verify another change code
+	addenda98.ChangeCode = "C07"
+	if code := addenda98.ChangeCodeField(); code == nil {
+		t.Fatal("nil Addenda98.ChangeCodeField")
+	} else {
+		if code.Code != "C07" {
+			t.Errorf("code.Code=%s", code.Code)
+		}
+	}
+}
+
 // testAddenda98TypeCodeNil validates TypeCode is ""
 func testAddenda98TypeCodeNil(t testing.TB) {
 	addenda98 := mockAddenda98()


### PR DESCRIPTION
This allows applications (like paygate) to access the description of a NOC/COR change code.