### PR TITLE
fileHeader: remove ImmediateOrigin validation

### DIFF
--- a/fileHeader.go
+++ b/fileHeader.go
@@ -212,9 +212,6 @@ func (fh *FileHeader) Validate() error {
 	if fh.ImmediateDestination == "000000000" {
 		return fieldError("ImmediateDestination", ErrConstructor, fh.ImmediateDestination)
 	}
-	if err := CheckRoutingNumber(trimImmediateOriginLeadingZero(fh.ImmediateOrigin)); err != nil {
-		return fieldError("ImmediateOrigin", err, fh.ImmediateOrigin)
-	}
 	if err := CheckRoutingNumber(fh.ImmediateDestination); err != nil {
 		return fieldError("ImmediateDestination", err, fh.ImmediateDestination)
 	}

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -593,21 +593,18 @@ func TestFHImmediateDestinationInvalidCheckSum(t *testing.T) {
 	}
 }
 
-func TestFHImmediateOriginInvalidLength(t *testing.T) {
+func TestFHImmediateOriginValidate(t *testing.T) {
 	fh := mockFileHeader()
-	fh.ImmediateOrigin = "198387"
-	err := fh.Validate()
-	if !strings.Contains(err.Error(), "invalid routing number length") {
-		t.Errorf("%T: %s", err, err)
+	fh.ImmediateOrigin = "0000000000"
+	if err := fh.Validate(); err == nil {
+		t.Error("expected error")
 	}
-}
 
-func TestFHImmediateOriginInvalidCheckSum(t *testing.T) {
-	fh := mockFileHeader()
-	fh.ImmediateOrigin = "121042880"
-	err := fh.Validate()
-	if !strings.Contains(err.Error(), "routing number checksum mismatch") {
-		t.Errorf("%T: %s", err, err)
+	// use an alphanumeric code (NACHA rules allow this with specific
+	// agreements between the ODFI and originator)
+	fh.ImmediateOrigin = "ABC124"
+	if err := fh.Validate(); err != nil {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
NACHA rules state:

    This field may also be mutually defined between ODFI and Originator.
    For example, the ODFI may ask its Originator to put its Taxpayer
    Identification Number in this field

Fixes: https://github.com/moov-io/ach/issues/636