### PR TITLE
addenda98: fix parsing with no spaces between routing and account number

### DIFF
--- a/addenda98.go
+++ b/addenda98.go
@@ -266,15 +266,21 @@ func (addenda98 *Addenda98) ParseCorrectedData() *CorrectedData {
 			}
 		}
 	case "C07": // Incorrect Routing Number, Incorrect DFI Account Number, and Incorrect Tranaction Code
-		parts := strings.Fields(addenda98.CorrectedData)
-		if len(parts) == 3 {
-			if n, err := strconv.Atoi(parts[2]); err == nil {
-				return &CorrectedData{
-					RoutingNumber:   parts[0],
-					AccountNumber:   parts[1],
-					TransactionCode: n,
-				}
+		var cd CorrectedData
+		if n := len(addenda98.CorrectedData); n > 9 {
+			cd.RoutingNumber = addenda98.CorrectedData[:9]
+		} else {
+			return nil
+		}
+		parts := strings.Fields(addenda98.CorrectedData[9:])
+		if len(parts) == 2 {
+			if n, err := strconv.Atoi(parts[1]); err == nil {
+				cd.AccountNumber = parts[0]
+				cd.TransactionCode = n
+				return &cd
 			}
+		} else {
+			return nil
 		}
 	case "C09": // Incorrect Individual Identification Number
 		if v := first(22, addenda98.CorrectedData); v != "" {

--- a/addenda98_test.go
+++ b/addenda98_test.go
@@ -400,6 +400,15 @@ func TestCorrectedData__ParseCorrectedData(t *testing.T) {
 	if v := run("C07", "987654320  12345  22"); v.RoutingNumber != "987654320" || v.AccountNumber != "12345" || v.TransactionCode != 22 {
 		t.Errorf("%#v", v)
 	}
+	if v := run("C07", "9876543201242415    22"); v.RoutingNumber != "987654320" || v.AccountNumber != "1242415" || v.TransactionCode != 22 {
+		t.Errorf("%#v", v)
+	}
+	if v := run("C07", "1234"); v != nil {
+		t.Errorf("expected nil: %v", v)
+	}
+	if v := run("C07", "987654320 1234 1234 1234"); v != nil {
+		t.Errorf("expected nil: %v", v)
+	}
 	if v := run("C09", "21345678    "); v.Identification != "21345678" {
 		t.Errorf("%#v", v)
 	}


### PR DESCRIPTION
Found when working on https://github.com/moov-io/paygate/issues/315 