### PR TITLE
files: ImmediateOrigin should be space prefixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.3.0 (Unreleased)
+
+BREAKING CHANGES
+
+- `ImmediateOrigin` values are written with a leading space instead of a zero (`0`) due to post-2013 NACHA guidelines.
+
 ## v1.2.1 (Released 2019-10-11)
 
 BUG FIXES

--- a/examples/example_ackWrite_test.go
+++ b/examples/example_ackWrite_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 // Example_ackWrite writes an ACK File
@@ -78,7 +79,7 @@ func Example_ackWrite() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5220Name on Account                     231380104 ACKVndr Pay        190816   1231380100000001
 	// 624031300012744-5678-99      0000000000031300010000001Best. #1                0231380100000001
 	// 624031300012744-5678-99      0000000000031300010000002Best. #1                0231380100000002

--- a/examples/example_advWrite_test.go
+++ b/examples/example_advWrite_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_advWrite() {
@@ -91,7 +92,7 @@ func Example_advWrite() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5280Company Name, In                    231380104 ADVAccounting      190816   0121042880000001
 	// 681231380104744-5678-99    00000005000012104288211131 Name                    0011000010500001
 	// 682231380104744-5678-99    00000025000012104288211139 Name                    0011000010500002

--- a/examples/example_arcWrite_debit_test.go
+++ b/examples/example_arcWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_arcWriteDebit() {
@@ -67,7 +68,7 @@ func Example_arcWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Payee Name                          231380104 ARCACH ARC         190816   1121042880000001
 	// 62723138010412345678         0000250000123879654      ABC Company             0121042880000001
 	// 82250000010023138010000000250000000000000000231380104                          121042880000001

--- a/examples/example_atxWrite_test.go
+++ b/examples/example_atxWrite_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_atxWrite() {
@@ -109,7 +110,7 @@ func Example_atxWrite() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5220Name on Account                     231380104 ATXVndr Pay        190816   1231380100000001
 	// 624031300012744-5678-99      00000000000313000100000010002Receiver Company  011231380100000001
 	// 705Credit account 1 for service                                                    00010000001

--- a/examples/example_bocWrite_debit_test.go
+++ b/examples/example_bocWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_bocWriteDebit() {
@@ -66,7 +67,7 @@ func Example_bocWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Payee Name                          231380104 BOCACH BOC         190816   1121042880000001
 	// 62723138010412345678         0000250000123879654      ABC Company             0121042880000001
 	// 82250000010023138010000000250000000000000000231380104                          121042880000001

--- a/examples/example_ccdWrite_debit_test.go
+++ b/examples/example_ccdWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_ccdWriteDebit() {
@@ -78,7 +79,7 @@ func Example_ccdWriteDebit() {
 	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
 	fmt.Printf("%s", file.Control.String()+"\n")
 
-	// Output: 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// Output: 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 CCDVndr Pay        190816   1031300010000001
 	// 627231380104744-5678-99      0000500000location #1234 Best Co. #1           S 0031300010000001
 	// 627231380104744-5678-99      0000000125Fee #1         Best Co. #1           S 0031300010000002

--- a/examples/example_corWrite_credit_test.go
+++ b/examples/example_corWrite_credit_test.go
@@ -82,7 +82,7 @@ func Example_corWriteCredit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5220Your Company, in                    121042882 CORVendor Pay      000000   1121042880000001
 	// 621231380104744-5678-99      0000000000location #23   Best Co. #23            1121042880000001
 	// 798C01121042880000001      121042881918171614                                  091012980000088

--- a/examples/example_ctxWrite_debit_test.go
+++ b/examples/example_ctxWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 // Example_ctxWriteDebit writes a CTX debit file
@@ -86,7 +87,7 @@ func Example_ctxWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 CTXACH CTX         190816   1121042880000001
 	// 62723138010412345678         010000000045689033       0002Receiver Company  011121042880000001
 	// 705Debit First Account                                                             00010000001

--- a/examples/example_dneWrite_test.go
+++ b/examples/example_dneWrite_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 // Example_dneWrite writes a DNR file
@@ -74,7 +75,7 @@ func Example_dneWrite() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5220Name on Account                     231380104 DNEDeath           190816   2231380100000001
 	// 621031300012744-5678-99      0000000000031300010000001Best. #1                1231380100000001
 	// 705    DATE OF DEATH*010218*CUSTOMERSSN*#########*AMOUNT*$$$$.cc\                  00010000001

--- a/examples/example_enrWrite_test.go
+++ b/examples/example_enrWrite_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 // Example_enrWrite writes and ENR file
@@ -72,7 +73,7 @@ func Example_enrWrite() {
 	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
 	fmt.Printf("%s", file.Control.String()+"\n")
 
-	// Output: 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// Output: 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 ENRAUTOENROLL               1231380100000001
 	// 627031300012744-5678-99      0000000000031300010000001Best. #1                1231380100000001
 	// 70522*12200004*3*123987654321*777777777*DOE*JOHN*1\                                00010000001

--- a/examples/example_mteWrite_debit_test.go
+++ b/examples/example_mteWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_mteWriteDebit() {
@@ -78,7 +79,7 @@ func Example_mteWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Merchant with AT                    231380104 MTECASH WITHD      190816   1231380100000001
 	// 627031300012744-5678-99      0000010000031300010000001JANE DOE                1231380100000001
 	// 82250000020003130001000000010000000000000000231380104                          231380100000001

--- a/examples/example_popWrite_debit_test.go
+++ b/examples/example_popWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_popWriteDebit() {
@@ -68,7 +69,7 @@ func Example_popWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Originator                          231380104 POPACH POP         190816   1121042880000001
 	// 62723138010412345678         0000250500123456   PHILPAWade Arnold             0121042880000001
 	// 82250000010023138010000000250500000000000000231380104                          121042880000001

--- a/examples/example_posWrite_debit_test.go
+++ b/examples/example_posWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_posWriteDebit() {
@@ -81,7 +82,7 @@ func Example_posWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 POSSale            190816   1121042880000001
 	// 62723138010412345678         0100000000               Receiver Account Name 011121042880000001
 	// 702REFONEAREFTERM021000490614123456Target Store 0049          PHILADELPHIA   PA121042880000001

--- a/examples/example_ppdWrite_credit_test.go
+++ b/examples/example_ppdWrite_credit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 // Example_ppdWriteCredit writes a PPD credit file
@@ -68,7 +69,7 @@ func Example_ppdWriteCredit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5220Name on Account                     231380104 PPDREG.SALARY      190816   1121042880000001
 	// 622231380104987654321        0100000000               Credit Account 1        0121042880000002
 	// 82200000010023138010000000000000000100000000231380104                          121042880000001

--- a/examples/example_ppdWrite_debit_test.go
+++ b/examples/example_ppdWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 // // Example_ppdWriteDebit writes a PPD debit file
@@ -68,7 +69,7 @@ func Example_ppdWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 PPDREG.SALARY      190816   1121042880000001
 	// 627231380104123456789        0200000000               Debit Account           0121042880000001
 	// 82250000010023138010000200000000000000000000231380104                          121042880000001

--- a/examples/example_rckWrite_debit_test.go
+++ b/examples/example_rckWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_rckWriteDebit() {
@@ -68,7 +69,7 @@ func Example_rckWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 RCKREDEPCHECK      190816   1121042880000001
 	// 62723138010412345678         0000002400123123123      Wade Arnold             0121042880000001
 	// 82250000010023138010000000002400000000000000231380104                          121042880000001

--- a/examples/example_shrWrite_debit_test.go
+++ b/examples/example_shrWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_shrWrite() {
@@ -83,7 +84,7 @@ func Example_shrWrite() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 SHRPayment         190816   1121042880000001
 	// 62723138010412345678         01000000000722123456789100001234567891123456789011121042880000001
 	// 702REFONEAREFTERM021000490614123456Target Store 0049          PHILADELPHIA   PA121042880000001

--- a/examples/example_telWrite_debit_test.go
+++ b/examples/example_telWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_telWriteDebit() {
@@ -65,7 +66,7 @@ func Example_telWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 TELPayment         190816   1121042880000001
 	// 62723138010412345678         0000050000               Receiver Account Name   0121042880000001
 	// 82250000010023138010000000050000000000000000231380104                          121042880000001

--- a/examples/example_trcWrite_debit_test.go
+++ b/examples/example_trcWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_trcWriteDebit() {
@@ -67,7 +68,7 @@ func Example_trcWriteDebit() {
 	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
 	fmt.Printf("%s", file.Control.String()+"\n")
 
-	// Output: 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// Output: 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Payee Name                          231380104 TRCACH TRC         190816   1121042880000001
 	// 62723138010412345678         0000250000123456789012345CHECK11234567890123456010121042880000001
 	// 82250000010023138010000000250000000000000000231380104                          121042880000001

--- a/examples/example_trxWrite_debit_test.go
+++ b/examples/example_trxWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_trxWriteDebit() {
@@ -83,7 +84,7 @@ func Example_trxWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 TRXACH TRX         190816   1121042880000001
 	// 62723138010412345678         000025000045689033       0002Receiver Company  011121042880000001
 	// 705Debit First Account                                                             00010000001

--- a/examples/example_webWrite_credit_test.go
+++ b/examples/example_webWrite_credit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 // Example_webWriteCredit writes a WEB credit file
@@ -77,7 +78,7 @@ func Example_webWriteCredit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5220Name on Account                     231380104 WEBSubscribe       190816   1121042880000001
 	// 62223138010412345678         0000010000#789654        John Doe              S 1121042880000001
 	// 705PAY-GATE payment\                                                               00010000001

--- a/examples/example_xckWrite_debit_test.go
+++ b/examples/example_xckWrite_debit_test.go
@@ -19,8 +19,9 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_xckWriteDebit() {
@@ -67,7 +68,7 @@ func Example_xckWriteDebit() {
 	fmt.Printf("%s", file.Control.String()+"\n")
 
 	// Output:
-	// 101 03130001202313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Payee Name                          231380104 XCKACH XCK         190816   1121042880000001
 	// 62723138010412345678         0000250000123456789012345CHECK11234567890123456  0121042880000001
 	// 82250000010023138010000000250000000000000000231380104                          121042880000001

--- a/fileHeader.go
+++ b/fileHeader.go
@@ -36,20 +36,21 @@ type FileHeader struct {
 	recordType string
 	// PriorityCode consists of the numerals 01
 	priorityCode string
+
 	// ImmediateDestination contains the Routing Number of the ACH Operator or receiving
-	// point to which the file is being sent.  The ach file format specifies a 10 character
-	// field  begins with a blank space in the first position, followed by the four digit
+	// point to which the file is being sent. The ach file format specifies a 10 character
+	// field begins with a blank space in the first position, followed by the four digit
 	// Federal Reserve Routing Symbol, the four digit ABA Institution Identifier, and the Check
-	// Digit (bTTTTAAAAC).  ImmediateDestinationField() will append the blank space to the
+	// Digit (bTTTTAAAAC). ImmediateDestinationField() will append the blank space to the
 	// routing number.
 	ImmediateDestination string `json:"immediateDestination"`
 
 	// ImmediateOrigin contains the Routing Number of the ACH Operator or sending
-	// point that is sending the file. The ach file format specifies a 10 character field
-	// which can begin with a blank space, 0 or 1 in the first position, followed by the four digit
+	// point that is sending the file. The ach file format specifies a 10 character
+	// field begins with a blank space in the first position, followed by the four digit
 	// Federal Reserve Routing Symbol, the four digit ABA Institution Identifier, and the Check
-	// Digit (bTTTTAAAAC).  ImmediateOriginField() will prepend a 0 to the routing number to match
-	// the field size.
+	// Digit (bTTTTAAAAC). ImmediateOriginField() will append the blank space to the
+	// routing number.
 	ImmediateOrigin string `json:"immediateOrigin"`
 
 	// FileCreationDate is the date on which the file is prepared by an ODFI (ACH input files)
@@ -154,9 +155,9 @@ func (fh *FileHeader) Parse(record string) {
 func trimImmediateOriginLeadingZero(s string) string {
 	if utf8.RuneCountInString(s) == 10 && s[0] == '0' && s != "0000000000" {
 		// trim off a leading 0 as ImmediateOriginField() will pad it back
-		return s[1:]
+		return strings.TrimSpace(s[1:])
 	}
-	return s
+	return strings.TrimSpace(s)
 }
 
 // String writes the FileHeader struct to a 94 character string.
@@ -267,7 +268,10 @@ func (fh *FileHeader) ImmediateDestinationField() string {
 
 // ImmediateOriginField gets the immediate origin number with 0 padding
 func (fh *FileHeader) ImmediateOriginField() string {
-	return fh.stringField(fh.ImmediateOrigin, 10)
+	if fh.ImmediateOrigin == "" {
+		return strings.Repeat(" ", 10)
+	}
+	return " " + fh.stringField(strings.TrimSpace(fh.ImmediateOrigin), 9)
 }
 
 // FileCreationDateField gets the file creation date in YYMMDD (year, month, day) format

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -78,15 +78,15 @@ func TestFileHeader__ImmediateOrigin(t *testing.T) {
 		t.Errorf("got %q", v)
 	}
 	header.ImmediateOrigin = "123456789" // 9 digit routing number
-	if v := header.ImmediateOriginField(); v != "0123456789" {
+	if v := header.ImmediateOriginField(); v != " 123456789" {
 		t.Errorf("got %q", v)
 	}
-	header.ImmediateOrigin = "0123456789" // 0 + routing number
-	if v := header.ImmediateOriginField(); v != "0123456789" {
+	header.ImmediateOrigin = trimImmediateOriginLeadingZero("0123456789") // 0 + routing number
+	if v := header.ImmediateOriginField(); v != " 123456789" {
 		t.Errorf("got %q", v)
 	}
-	header.ImmediateOrigin = "1123456789" // 1 + routing number
-	if v := header.ImmediateOriginField(); v != "1123456789" {
+	header.ImmediateOrigin = trimImmediateOriginLeadingZero("1123456789") // 1 + routing number
+	if v := header.ImmediateOriginField(); v != " 112345678" {
 		t.Errorf("got %q", v)
 	}
 
@@ -122,8 +122,8 @@ func parseFileHeader(t testing.TB) {
 	if record.ImmediateDestinationField() != " 076401251" {
 		t.Errorf("ImmediateDestination Expected ' 076401251' got: %v", record.ImmediateDestinationField())
 	}
-	if record.ImmediateOriginField() != "0076401251" {
-		t.Errorf("ImmediateOrigin Expected '  0076401251' got: %v", record.ImmediateOriginField())
+	if record.ImmediateOriginField() != " 076401251" {
+		t.Errorf("ImmediateOrigin Expected ' 076401251' got: %v", record.ImmediateOriginField())
 	}
 
 	if record.FileCreationDateField() != "180729" {

--- a/reader_test.go
+++ b/reader_test.go
@@ -381,7 +381,7 @@ func BenchmarkFileLineLong(b *testing.B) {
 // testFileFileHeaderErr validates error flows back from the parser
 func testFileFileHeaderErr(t testing.TB) {
 	fh := mockFileHeader()
-	//fh.ImmediateOrigin = "0"
+	// fh.ImmediateOrigin = "0000000000"
 	fh.ImmediateOrigin = ""
 	r := NewReader(strings.NewReader(fh.String()))
 	// necessary to have a file control not nil


### PR DESCRIPTION
According to post-2013 NACHA rules `ImmediateOrigin` should be space prefixed instead of previously `0` prefixed. We originally coded to 2013 specifications. 