### PR TITLE
batches: add LiftEffectiveEntryDate to return time.Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.4.0 (Unreleased)
+
+ADDITIONS
+
+- batches: Add `LiftEffectiveEntryDate()` to offer parsed `time.Time` values of `EffectiveEntryDate`
+
 ## v1.3.1 (Released 2020-01-22)
 
 BUG FIXES

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 )
 
@@ -322,4 +323,8 @@ func (bh *BatchHeader) BatchNumberField() string {
 
 func (bh *BatchHeader) settlementDateField() string {
 	return bh.alphaField(bh.settlementDate, 3)
+}
+
+func (bh *BatchHeader) LiftEffectiveEntryDate() (time.Time, error) {
+	return time.Parse("060102", bh.EffectiveEntryDate) // YYMMDD
 }

--- a/batchHeader_test.go
+++ b/batchHeader_test.go
@@ -545,3 +545,21 @@ func TestBatchHeaderENR__EffectiveEntryDateField(t *testing.T) {
 		t.Errorf("got %q (len=%d), expected space filled (len=6)", v, len(ans))
 	}
 }
+
+func TestBatchHeader__LiftEffectiveEntryDate(t *testing.T) {
+	bh := mockBatchHeader()
+	bh.EffectiveEntryDate = "190730"
+
+	if tt, err := bh.LiftEffectiveEntryDate(); err != nil {
+		t.Fatal(err)
+	} else {
+		if tt.String() != "2019-07-30 00:00:00 +0000 UTC" {
+			t.Errorf("tt=%v", tt)
+		}
+	}
+
+	bh.EffectiveEntryDate = "aaaaaaaa"
+	if _, err := bh.LiftEffectiveEntryDate(); err == nil {
+		t.Error("expected error")
+	}
+}


### PR DESCRIPTION
This has been used a couple times in Paygate and is a format that doesn't need to be shared in other client code.