### PR TITLE
file: add ValidateWith to override specific default validations

### DIFF
--- a/file.go
+++ b/file.go
@@ -505,7 +505,30 @@ func (f *File) SetHeader(h FileHeader) *File {
 //
 // Validate will never modify the file.
 func (f *File) Validate() error {
-	if err := f.Header.Validate(); err != nil {
+	return f.ValidateWith(nil)
+}
+
+// ValidateOpts contains specific overrides from the default set of validations
+// performed on a NACHA file, records and various fields within.
+type ValidateOpts struct {
+	// RequireABAOrigin can be set to enable routing number validation
+	// over the ImmediateOrigin file header field.
+	RequireABAOrigin bool
+
+	// BypassOriginValidation can be set to skip validation for the
+	// ImmediateOrigin file header field.
+	BypassOriginValidation bool
+}
+
+// ValidateWith performs NACHA format rule checks on each record according to their specification
+// overlayed with any custom flags.
+// The first error encountered is returned and stops the parsing.
+func (f *File) ValidateWith(opts *ValidateOpts) error {
+	if opts == nil {
+		opts = &ValidateOpts{}
+	}
+
+	if err := f.Header.ValidateWith(opts); err != nil {
 		return err
 	}
 

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -712,3 +712,29 @@ func BenchmarkFileHeaderCreationTime(b *testing.B) {
 		testFileHeaderCreationTime(b)
 	}
 }
+
+func TestFileHeader__ValidateOrigin(t *testing.T) {
+	fh := mockFileHeader()
+	fh.ImmediateOrigin = "0000000000"
+
+	err := fh.ValidateWith(&ValidateOpts{
+		RequireABAOrigin: true,
+	})
+	if err != nil {
+		if !strings.Contains(err.Error(), ErrConstructor.Error()) {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	err = fh.ValidateWith(&ValidateOpts{})
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	err = fh.ValidateWith(&ValidateOpts{
+		BypassOriginValidation: true,
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
We're starting to see more vendor or FI specific overrides and should keep those separate from the default validator set.