### PR TITLE
build: ignore OpenAPI generator jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ test/fuzz-reader/corpus/*.tar.gz
 
 go-licenser*.tar.gz
 go-licenser
+
+openapi-generator*.jar


### PR DESCRIPTION
<img width="704" alt="Screen Shot 2020-02-24 at 1 31 51 PM" src="https://user-images.githubusercontent.com/120951/75192896-0a297500-570a-11ea-99a1-b30ac7d30679.png">
