### PR TITLE
validators: ensure alpha routing number check digit is invalid

### DIFF
--- a/validators_test.go
+++ b/validators_test.go
@@ -25,11 +25,12 @@ import (
 func TestValidators__checkDigit(t *testing.T) {
 	cases := map[string]int{
 		// invalid
-		"":         -1,
-		"123456":   -1,
-		"1a8ab":    -1,
-		"0730002a": -1,
-		"0730A002": -1,
+		"":          -1,
+		"123456":    -1,
+		"1a8ab":     -1,
+		"0730002a":  -1,
+		"0730A002":  -1,
+		"YYYYYYYYY": -1, // users often mask ABA numbers
 		// valid
 		"07300022": 8, // Wells Fargo - Iowa
 		"10200007": 6, // Wells Fargo - Colorado


### PR DESCRIPTION
A user had masked the routing number in a bug report today, so we should make sure that routing number check digit is always invalid.