### PR TITLE
server: read ValidateOpts in POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ ADDITIONS
 - batches: Add `LiftEffectiveEntryDate()` to offer parsed `time.Time` values of `EffectiveEntryDate`
 - cmd/server: add version handler to admin HTTP server
 - file: add BypassDestinationValidation to ValidateOpts
-- file: add ValidateWith to override specific default validations
+- file: add `ValidateWith` to override specific default validations
 - file: support setting ValidateOpts on struct for calling Create()
 - reader: morph lines to 94 characters if they end in spaces
-- server: read ValidateOpts in HTTP validate route
+- server: read `ValidateOpts` in HTTP validate route
 - server: return fileID on create errors, enforce marshaled errors as strings
+- file: support setting `ValidateOpts` on struct for calling `Create()`
 
 BUG FIXES
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -206,6 +206,37 @@ paths:
       tags: ['ACH Files']
       summary: Validate file
       description: Validates the existing file. You need only supply the unique File identifier that was returned upon creation.
+      operationId: checkFile
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - name: X-Request-ID
+          in: header
+          description: Optional Request ID allows application developer to trace requests through the systems logs
+          example: rs4f9915
+          schema:
+            type: string
+        - name: fileID
+          in: path
+          description: File ID
+          required: true
+          schema:
+            type: string
+            example: 3f2d23ee214
+      responses:
+        '200':
+          description: File validated successfully without errors.
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
+        '400':
+          description: Validation failed. Check response for errors
+    post:
+      tags: ['ACH Files']
+      summary: Validate file
+      description: Validates the existing file. You need only supply the unique File identifier that was returned upon creation.
       operationId: validateFile
       security:
         - bearerAuth: []
@@ -236,7 +267,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/File'
+                $ref: 'https://raw.githubusercontent.com/moov-io/api/master/openapi-common.yaml#/components/schemas/Error'
         '400':
           description: Validation failed. Check response for errors
   /files/{fileID}/segment:

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -282,10 +282,10 @@ func TestFiles__ValidateOpts(t *testing.T) {
 	// validate, expect failure
 	w := httptest.NewRecorder()
 	body := strings.NewReader(`{"requireABAOrigin": true}`)
-	req := httptest.NewRequest("GET", fmt.Sprintf("/files/%s/validate", file.ID), body)
+	req := httptest.NewRequest("POST", fmt.Sprintf("/files/%s/validate", file.ID), body)
 
 	router := mux.NewRouter()
-	router.Methods("GET").Path("/files/{id}/validate").Handler(
+	router.Methods("POST").Path("/files/{id}/validate").Handler(
 		httptransport.NewServer(validateFileEndpoint(svc, logger), decodeValidateFileRequest, encodeResponse),
 	)
 
@@ -304,7 +304,7 @@ func TestFiles__ValidateOpts(t *testing.T) {
 	// retry, but with different ValidateOpts
 	w = httptest.NewRecorder()
 	body = strings.NewReader(`{"requireABAOrigin": true}`)
-	req = httptest.NewRequest("GET", fmt.Sprintf("/files/%s/validate", file.ID), body)
+	req = httptest.NewRequest("POST", fmt.Sprintf("/files/%s/validate", file.ID), body)
 	router.ServeHTTP(w, req)
 	w.Flush()
 

--- a/server/routing.go
+++ b/server/routing.go
@@ -142,6 +142,12 @@ func MakeHTTPHandler(s Service, repo Repository, logger log.Logger) http.Handler
 		encodeResponse,
 		options...,
 	))
+	r.Methods("POST").Path("/files/{id}/validate").Handler(httptransport.NewServer(
+		validateFileEndpoint(s, logger),
+		decodeValidateFileRequest,
+		encodeResponse,
+		options...,
+	))
 	r.Methods("DELETE").Path("/files/{id}").Handler(httptransport.NewServer(
 		deleteFileEndpoint(s, logger),
 		decodeDeleteFileRequest,


### PR DESCRIPTION
This came up where a lot of HTTP clients don't allow `GET` requests to have request bodies. Since it's not uniformly allowed we need to accept `POST` as well. 

I don't like that there are now two endpoints/calls to validate a file. 