### PR TITLE
file: call FileFromJSON inside File.UnmarshalJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ADDITIONS
 - server: read `ValidateOpts` in HTTP validate route
 - server: return fileID on create errors, enforce marshaled errors as strings
 - file: support setting `ValidateOpts` on struct for calling `Create()`
+- file: struct unmarshaling works again, it was depreciated for a couple releases
 
 BUG FIXES
 

--- a/file.go
+++ b/file.go
@@ -169,9 +169,16 @@ func FileFromJSON(bs []byte) (*File, error) {
 	return file, nil
 }
 
-// UnmarshalJSON returns error json struct tag unmarshal is deprecated, use ach.FileFromJSON instead
+// UnmarshalJSON parses a JSON blob with ach.FileFromJSON
 func (f *File) UnmarshalJSON(p []byte) error {
-	return errors.New("json struct tag unmarshal is deprecated, use ach.FileFromJSON instead")
+	file, err := FileFromJSON(p)
+	if err != nil {
+		return err
+	}
+	if file != nil {
+		*f = *file
+	}
+	return nil
 }
 
 type batchesJSON struct {

--- a/file_test.go
+++ b/file_test.go
@@ -484,9 +484,14 @@ func TestFile__readFromJson(t *testing.T) {
 
 	// ensure we error on struct tag unmarshal
 	var f File
-	err = json.Unmarshal(bs, &f)
-	if !strings.Contains(err.Error(), "use ach.FileFromJSON instead") {
-		t.Error("expected error, see FileFromJson definition")
+	if err := json.Unmarshal(bs, &f); err != nil {
+		t.Error(err)
+	}
+	if f.Header.ImmediateOrigin != "121042882" || f.Header.ImmediateDestination != "231380104" {
+		t.Errorf("FileHeader=%#v", f.Header)
+	}
+	if err := f.Validate(); err != nil {
+		t.Error(err)
 	}
 
 	if err := file.Validate(); err != nil {
@@ -952,9 +957,14 @@ func TestFileADV__readFromJson(t *testing.T) {
 
 	// ensure we error on struct tag unmarshal
 	var f File
-	err = json.Unmarshal(bs, &f)
-	if !strings.Contains(err.Error(), "use ach.FileFromJSON instead") {
-		t.Error("expected error, see FileFromJson definition")
+	if err := json.Unmarshal(bs, &f); err != nil {
+		t.Error(err)
+	}
+	if f.Header.ImmediateOrigin != "121042882" || f.Header.ImmediateDestination != "231380104" {
+		t.Errorf("FileHeader=%#v", f.Header)
+	}
+	if err := f.Validate(); err != nil {
+		t.Error(err)
 	}
 
 	if err := file.Validate(); err != nil {


### PR DESCRIPTION
This lets us use struct unmarhsaling which is the default expectation for users of our library.

It was deprecated for a couple releases, but I realized we can have it work as expected. 