### PR TITLE
ImmediateOriginField update

### DIFF
--- a/fileHeader.go
+++ b/fileHeader.go
@@ -302,6 +302,9 @@ func (fh *FileHeader) ImmediateOriginField() string {
 	if fh.ImmediateOrigin == "" {
 		return strings.Repeat(" ", 10)
 	}
+	if fh.validateOpts != nil && fh.validateOpts.BypassOriginValidation {
+		return fh.stringField(strings.TrimSpace(fh.ImmediateOrigin), 10)
+	}
 	return " " + fh.stringField(strings.TrimSpace(fh.ImmediateOrigin), 9)
 }
 

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -90,6 +90,13 @@ func TestFileHeader__ImmediateOrigin(t *testing.T) {
 		t.Errorf("got %q", v)
 	}
 
+	// Test with BypassOriginValidation
+	header.SetValidation(&ValidateOpts{BypassOriginValidation: true})
+	header.ImmediateOrigin = "1234567899"
+	if v := header.ImmediateOriginField(); v != header.ImmediateOrigin {
+		t.Errorf("got %q", v)
+	}
+
 	// make sure our trim works that we hook into FileHeader.Parse(..)
 	if v := trimImmediateOriginLeadingZero("0123456789"); v != "123456789" {
 		t.Errorf("got %q", v)


### PR DESCRIPTION
@adamdecaf  @wadearnold 
This allows for the ImmediateOriginField to be the full 10 characters that the bank is asking for in cases when the bank is asking for something other than a valid routing number in bTTTTAAAC format.

ValidateOpts.BypassOriginValidation allows us to get through the validate routine but ImmediateOriginField() is still formatting the field.

Since the NACHA specification says "This field may also be mutually defined between the ODFI and Originator", we need to be able to specify the full 10 characters requested.