### PR TITLE
reader: return whatever we have once the line limit is reached

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -132,7 +132,7 @@ func (r *Reader) Read() (File, error) {
 		r.lineNum++
 		if r.lineNum > maxLines {
 			r.errors.Add(ErrFileTooLong)
-			break
+			return r.File, r.errors
 		}
 
 		lineLength := len(line)


### PR DESCRIPTION
Otherwise we would still iterate through each row and that can run up the CPU.