### PR TITLE
entries: allow custom TransactionCodes

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -979,11 +979,18 @@ func (batch *Batch) ValidTranCodeForServiceClassCode(entry *EntryDetail) error {
 		return batch.Error("TransactionCode", ErrBatchTransactionCode, entry.TransactionCode)
 	}
 
+	if entry.validateOpts != nil && entry.validateOpts.CheckTransactionCode != nil {
+		// We're unable to validate the ServiceClassCode with custom TransactionCode validation.
+		return nil
+	}
+
 	switch batch.Header.ServiceClassCode {
 	case AutomatedAccountingAdvices:
 		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
 
 	case MixedDebitsAndCredits:
+		return nil
+
 	case CreditsOnly:
 		if entry.CreditOrDebit() != "C" {
 			return batch.Error("TransactionCode", NewErrBatchServiceClassTranCode(batch.Header.ServiceClassCode, entry.TransactionCode))

--- a/batchHeader_test.go
+++ b/batchHeader_test.go
@@ -563,3 +563,12 @@ func TestBatchHeader__LiftEffectiveEntryDate(t *testing.T) {
 		t.Error("expected error")
 	}
 }
+
+func TestBatchHeader__SetValidation(t *testing.T) {
+	bh := NewBatchHeader()
+	bh.SetValidation(&ValidateOpts{})
+
+	// nil out
+	bh = nil
+	bh.SetValidation(&ValidateOpts{})
+}

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -20,6 +20,7 @@ package ach
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -736,4 +737,24 @@ func TestEntryDetail__ParseNOC(t *testing.T) {
 	if entries[0].Category != CategoryNOC {
 		t.Errorf("EntryDetail.Category=%s\n  %#v", entries[0].Category, entries[0])
 	}
+}
+
+func TestEntryDetail__SetValidation(t *testing.T) {
+	ed := mockEntryDetail()
+	ed.SetValidation(&ValidateOpts{
+		CheckTransactionCode: func(code int) error {
+			if code == 999 {
+				return nil
+			}
+			return fmt.Errorf("unexpected TransactionCode: %d", code)
+		},
+	})
+	ed.TransactionCode = 999
+	if err := ed.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	// nil out
+	ed = nil
+	ed.SetValidation(&ValidateOpts{})
 }

--- a/examples/example_custom_transaction_code_test.go
+++ b/examples/example_custom_transaction_code_test.go
@@ -1,0 +1,87 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package examples
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/moov-io/ach"
+)
+
+// Example_customTransactionCode writes an ACH file with a non-standard NACHA TransactionCodes
+func Example_customTransactionCode() {
+	validationOpts := &ach.ValidateOpts{
+		// CheckTransactionCode lets us override the standard set of NACHA
+		// codes for applications which use custom TransactionCode values.
+		CheckTransactionCode: func(code int) error {
+			// Is it a custom TransactionCode of ours?
+			if code == 78 {
+				return nil
+			}
+			// Is it a NACHA standard code?
+			return ach.StandardTransactionCode(code)
+		},
+	}
+
+	fh := mockFileHeader()
+
+	bh := ach.NewBatchHeader()
+	bh.ServiceClassCode = ach.CreditsOnly
+	bh.CompanyName = "My Company"
+	bh.CompanyIdentification = fh.ImmediateOrigin
+	bh.StandardEntryClassCode = ach.PPD
+	bh.CompanyEntryDescription = "Cash Back"
+	// fix EffectiveEntryDate for consistent output
+	bh.EffectiveEntryDate = "190816"
+	bh.ODFIIdentification = "987654320"
+	bh.SetValidation(validationOpts)
+
+	entry := ach.NewEntryDetail()
+	entry.TransactionCode = 78 // example of a custom code
+	entry.SetRDFI("123456780")
+	entry.DFIAccountNumber = "12567"
+	entry.Amount = 100000000
+	entry.SetTraceNumber(bh.ODFIIdentification, 2)
+	entry.IndividualName = "Jane Smith"
+	entry.SetValidation(validationOpts)
+
+	// build the batch
+	batch := ach.NewBatchPPD(bh)
+	batch.AddEntry(entry)
+
+	if err := batch.Create(); err != nil {
+		log.Fatalf("Unexpected error building batch: %s\n", err)
+	}
+
+	// build the file
+	file := ach.NewFile()
+	file.SetHeader(fh)
+	file.AddBatch(batch)
+	if err := file.Create(); err != nil {
+		log.Fatalf("Unexpected error building file: %s\n", err)
+	}
+
+	fmt.Printf("TransactionCode=%d\n", file.Batches[0].GetEntries()[0].TransactionCode)
+	fmt.Printf("%s\n", file.Batches[0].GetEntries()[0].String())
+
+	// Output:
+	// TransactionCode=78
+	// 67812345678012567            0100000000               Jane Smith              0987654320000002
+
+}

--- a/file.go
+++ b/file.go
@@ -549,6 +549,9 @@ type ValidateOpts struct {
 	// This also allows for custom TraceNumbers which aren't prefixed with
 	// a routing number as required by the NACHA specification.
 	BypassDestinationValidation bool `json:"bypassDestinationValidation"`
+
+	// CheckTransactionCode allows for custom validation of TransactionCode values
+	CheckTransactionCode func(code int) error
 }
 
 // ValidateWith performs NACHA format rule checks on each record according to their specification

--- a/validators.go
+++ b/validators.go
@@ -285,6 +285,11 @@ func (v *validator) isTypeCode(code string) error {
 //		"3" designates a credit, or
 //		"8" designates a debit.
 func (v *validator) isTransactionCode(code int) error {
+	return StandardTransactionCode(code)
+}
+
+// StandardTransactionCode checks the provided TransactionCode to verify it is a valid NACHA value.
+func StandardTransactionCode(code int) error {
 	switch code {
 	// TransactionCode if the receivers account is:
 	case


### PR DESCRIPTION
Allowing custom TransactionCodes allows extra features to be written using ACH files. This is commonly used for products created in the past few years. 

There's also a branch with https://github.com/moov-io/ach/pull/729 -- https://github.com/moov-io/ach/tree/custom-entry-fields 