### PR TITLE
batch: error if our offset account type is unknown

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1092,6 +1092,11 @@ func (b *Batch) upsertOffsets() error {
 		}
 	}
 
+	// Make sure the offset account type is valid
+	if err := b.offset.AccountType.validate(); err != nil {
+		return err
+	}
+
 	// Create our debit offset EntryDetail
 	debitED := createOffsetEntryDetail(b.offset, b)
 	debitED.TraceNumber = strconv.Itoa(lastTraceNumber(b.Entries) + 1)

--- a/batch_test.go
+++ b/batch_test.go
@@ -1382,7 +1382,7 @@ func TestBatch__upsertOffsetsErr(t *testing.T) {
 	b.WithOffset(&Offset{
 		RoutingNumber: "121042882",
 		AccountNumber: "123456789",
-		AccountType:   OffsetAccountType(0),
+		AccountType:   OffsetAccountType("invalid"),
 		Description:   "test offset",
 	})
 	if err := b.Create(); err == nil {

--- a/batcher.go
+++ b/batcher.go
@@ -17,6 +17,10 @@
 
 package ach
 
+import (
+	"fmt"
+)
+
 // Batcher abstract the different ACH batch types that can exist in a file.
 // Each batch type is defined by SEC (Standard Entry Class) code in the Batch Header
 // * SEC identifies the payment type (product) found within an ACH batch-using a 3-character code
@@ -62,3 +66,12 @@ const (
 	OffsetChecking OffsetAccountType = "checking"
 	OffsetSavings  OffsetAccountType = "savings"
 )
+
+func (t OffsetAccountType) validate() error {
+	switch t {
+	case OffsetChecking, OffsetSavings:
+		return nil
+	default:
+		return fmt.Errorf("unknown offset account type: %s", t)
+	}
+}

--- a/batcher_test.go
+++ b/batcher_test.go
@@ -1,0 +1,34 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ach
+
+import (
+	"testing"
+)
+
+func TestOffsetAccountType(t *testing.T) {
+	if err := OffsetChecking.validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := OffsetSavings.validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := OffsetAccountType("invalid").validate(); err == nil {
+		t.Error("expected error")
+	}
+}


### PR DESCRIPTION
This came up as a linter error with OffsetAccountType(0) being an unexpected type casting.

https://travis-ci.com/github/moov-io/ach/jobs/354042702 