### PR TITLE
entries: detect overflow when printing large amounts

### DIFF
--- a/entryDetail.go
+++ b/entryDetail.go
@@ -276,6 +276,9 @@ func (ed *EntryDetail) Validate() error {
 	if ed.Amount < 0 {
 		return fieldError("Amount", ErrNegativeAmount, ed.Amount)
 	}
+	if err := ed.amountOverflowsField(); err != nil {
+		return fieldError("Amount", err, ed.Amount)
+	}
 	if err := ed.isAlphanumeric(ed.IdentificationNumber); err != nil {
 		return fieldError("IdentificationNumber", err, ed.IdentificationNumber)
 	}
@@ -319,6 +322,18 @@ func (ed *EntryDetail) fieldInclusion() error {
 	}
 	if ed.TraceNumber == "" {
 		return fieldError("TraceNumber", ErrConstructor, ed.TraceNumberField())
+	}
+	return nil
+}
+
+func (ed *EntryDetail) amountOverflowsField() error {
+	intstr := strconv.Itoa(ed.Amount)
+	strstr := ed.AmountField()
+	if intstr == "0" && strstr == "0000000000" {
+		return nil // both are empty values
+	}
+	if len(intstr) > len(strstr) {
+		return fmt.Errorf("does not match formatted value %s", strstr)
 	}
 	return nil
 }

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -757,4 +758,17 @@ func TestEntryDetail__SetValidation(t *testing.T) {
 	// nil out
 	ed = nil
 	ed.SetValidation(&ValidateOpts{})
+}
+
+func TestEntryDetail__LargeAmountStrings(t *testing.T) {
+	ed := mockEntryDetail()
+	ed.Amount = math.MaxInt64
+
+	if err := ed.Validate(); err == nil {
+		t.Error("expected error")
+	} else {
+		if !strings.Contains(err.Error(), "Amount 9223372036854775807 does not match formatted value 6854775807") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
If the EntryDetail's Amount overflows what the NACHA file format allows the file is not valid.