### PR TITLE
fix: link to 'running ach server'

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Describing ACH file 'test/testdata/ppd-debit.ach'
 
 ## Getting Started
 
-- [Running ACH Server](./docs/index.md#running-moov-ach-server)
+- [Running ACH Server](./docs/README.md#running-moov-ach-server)
 - [Intro to ACH](./docs/intro.md)
 - [Create an ACH File](./docs/create-file.md)
 


### PR DESCRIPTION
Fix link that was changed in: [https://github.com/moov-io/ach/commit/f3b03dfeb9c7f94a5ef2f0c961bc0b8d3e4a0c37#diff-e3e2a9bfd88566b05001b02a3f51d286](https://github.com/moov-io/ach/commit/f3b03dfeb9c7f94a5ef2f0c961bc0b8d3e4a0c37#diff-e3e2a9bfd88566b05001b02a3f51d286)


link: [https://github.com/moov-io/ach/blob/master/docs/README.md](https://github.com/moov-io/ach/blob/master/docs/README.md)
Signed-off-by: sam <sam@freighttrust.com>