### PR TITLE
fix: make addenda optional on CIE batches

### DIFF
--- a/batchCIE.go
+++ b/batchCIE.go
@@ -66,9 +66,9 @@ func (batch *BatchCIE) Validate() error {
 		if entry.CreditOrDebit() != "C" {
 			return batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode)
 		}
-		// CIE must have one Addenda05 record
-		if len(entry.Addenda05) != 1 {
-			return batch.Error("AddendaCount", NewErrBatchRequiredAddendaCount(len(entry.Addenda05), 1))
+		// CIE must have a maximum of one Addenda05 record
+		if len(entry.Addenda05) > 1 {
+			return batch.Error("AddendaCount", NewErrBatchAddendaCount(len(entry.Addenda05), 1))
 		}
 		// Verify the TransactionCode is valid for a ServiceClassCode
 		if err := batch.ValidTranCodeForServiceClassCode(entry); err != nil {

--- a/batchCIE_test.go
+++ b/batchCIE_test.go
@@ -248,7 +248,7 @@ func testBatchCIEAddendaCount(t testing.TB) {
 	mockBatch := mockBatchCIE()
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !base.Match(err, NewErrBatchRequiredAddendaCount(2, 1)) {
+	if !base.Match(err, NewErrBatchAddendaCount(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -271,7 +271,7 @@ func testBatchCIEAddendaCountZero(t testing.TB) {
 	mockBatch := NewBatchCIE(mockBatchCIEHeader())
 	mockBatch.AddEntry(mockCIEEntryDetail())
 	err := mockBatch.Create()
-	if !base.Match(err, NewErrBatchRequiredAddendaCount(0, 1)) {
+	if !base.Match(err, nil) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -296,7 +296,7 @@ func testBatchCIEInvalidAddendum(t testing.TB) {
 	mockBatch.GetEntries()[0].Addenda02 = mockAddenda02()
 	mockBatch.Entries[0].AddendaRecordIndicator = 1
 	err := mockBatch.Create()
-	if !base.Match(err, NewErrBatchRequiredAddendaCount(0, 1)) {
+	if !base.Match(err, ErrBatchAddendaCategory) {
 		t.Errorf("%T: %s", err, err)
 	}
 }
@@ -422,7 +422,7 @@ func TestBatchCIEAddenda(t *testing.T) {
 	// mock batch already has one addenda. Creating two addenda should error
 	mockBatch.GetEntries()[0].AddAddenda05(mockAddenda05())
 	err := mockBatch.Create()
-	if !base.Match(err, NewErrBatchRequiredAddendaCount(2, 1)) {
+	if !base.Match(err, NewErrBatchAddendaCount(2, 1)) {
 		t.Errorf("%T: %s", err, err)
 	}
 }


### PR DESCRIPTION
This aligns with the spec, which stipulates that while CIE batches can
only have a maximum of one addenda record, including addenda is
optional.