### PR TITLE
fix: allow POS batches to contain credits

### DIFF
--- a/batchPOS.go
+++ b/batchPOS.go
@@ -63,17 +63,7 @@ func (batch *BatchPOS) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, POS)
 	}
 
-	// POS detail entries can only be a debit, ServiceClassCode must allow debits
-	switch batch.Header.ServiceClassCode {
-	case MixedDebitsAndCredits, CreditsOnly:
-		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
-	}
-
 	for _, entry := range batch.Entries {
-		// POS detail entries must be a debit
-		if entry.CreditOrDebit() != "D" {
-			return batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode)
-		}
 		if err := entry.isCardTransactionType(entry.DiscretionaryData); err != nil {
 			return batch.Error("CardTransactionType", ErrBatchInvalidCardTransactionType, entry.DiscretionaryData)
 		}


### PR DESCRIPTION
This also loosens the service class code and permits POS batches to be
mixed, credit-only, or debit-only.

While the spec initially defines POS entries as debits, it when
elaborates:

Also an adjusting or other credit Entry related to such debit Entry,
transfer of funds, or obligation.