### PR TITLE
reader: use RuneCountInString instead of len()

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/moov-io/base"
 )
@@ -135,7 +136,7 @@ func (r *Reader) Read() (File, error) {
 			return r.File, r.errors
 		}
 
-		lineLength := len(line)
+		lineLength := utf8.RuneCountInString(line)
 
 		switch {
 		case r.lineNum == 1 && lineLength > RecordLength && lineLength%RecordLength == 0:


### PR DESCRIPTION
We use `utf8.RuneCountInString(record) != 94` in several areas of the code except our `Reader.Read()` method. 

We should change this from `len()` to be consistent.