### PR TITLE
fix fileHeader destination and origin formatting when bypass validation is set

### DIFF
--- a/fileHeader.go
+++ b/fileHeader.go
@@ -297,10 +297,11 @@ func (fh *FileHeader) ImmediateDestinationField() string {
 	if fh.ImmediateDestination == "" {
 		return strings.Repeat(" ", 10)
 	}
-	if fh.validateOpts != nil && fh.validateOpts.BypassDestinationValidation {
-		return fh.stringField(strings.TrimSpace(fh.ImmediateDestination), 10)
+	fh.ImmediateDestination = strings.TrimSpace(fh.ImmediateDestination)
+	if fh.validateOpts != nil && fh.validateOpts.BypassDestinationValidation && len(fh.ImmediateDestination) == 10 {
+		return fh.ImmediateDestination
 	}
-	return " " + fh.stringField(strings.TrimSpace(fh.ImmediateDestination), 9)
+	return " " + fh.stringField(fh.ImmediateDestination, 9)
 }
 
 // ImmediateOriginField gets the immediate origin number with 0 padding
@@ -308,10 +309,11 @@ func (fh *FileHeader) ImmediateOriginField() string {
 	if fh.ImmediateOrigin == "" {
 		return strings.Repeat(" ", 10)
 	}
-	if fh.validateOpts != nil && fh.validateOpts.BypassOriginValidation {
-		return fh.stringField(strings.TrimSpace(fh.ImmediateOrigin), 10)
+	fh.ImmediateOrigin = strings.TrimSpace(fh.ImmediateOrigin)
+	if fh.validateOpts != nil && fh.validateOpts.BypassOriginValidation && len(fh.ImmediateOrigin) == 10 {
+		return fh.ImmediateOrigin
 	}
-	return " " + fh.stringField(strings.TrimSpace(fh.ImmediateOrigin), 9)
+	return " " + fh.stringField(fh.ImmediateOrigin, 9)
 }
 
 // FileCreationDateField gets the file creation date in YYMMDD (year, month, day) format


### PR DESCRIPTION
Fixes issue #814 and extends the PR #817 

This PR fixes an issue caused by this commit https://github.com/moov-io/ach/commit/e72a6afdb4279f377d4f05282ea6c2f8b02e2907 in which a `0` gets set between the ImmediateDestination and ImmediateOrigin where it should just be a `space`

Example of the issue:
`101 231380104 1210428821806140000A094101Federal Reserve Bank   My Bank Name                   `
would get transformed to 
`101023138010401210428821806140000A094101Federal Reserve Bank   My Bank Name                   `