### PR TITLE
optimized and refactored FlattenBatches(); added benchmarks

### DIFF
--- a/file.go
+++ b/file.go
@@ -1081,14 +1081,14 @@ func (f *File) FlattenBatches() (*File, error) {
 		}
 	}
 
-	IATBatchesByHeader := make(map[string]IATBatch)
+	IATBatchesByHeader := make(map[string]*IATBatch)
 	if f.IATBatches != nil {
 		for _, b := range f.IATBatches {
 			bhKey := getHeader(b.GetHeader())
 			_, found := IATBatchesByHeader[bhKey]
 			if !found {
 				newBatch := NewIATBatch(b.GetHeader())
-				IATBatchesByHeader[bhKey] = newBatch
+				IATBatchesByHeader[bhKey] = &newBatch
 				out.AddIATBatch(newBatch)
 			}
 
@@ -1117,7 +1117,7 @@ func (f *File) FlattenBatches() (*File, error) {
 		go func(b IATBatch) {
 			defer wg.Done()
 			_ = b.Create()
-		}(b)
+		}(*b)
 	}
 
 	wg.Wait()

--- a/file.go
+++ b/file.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/moov-io/base"
@@ -1043,95 +1044,94 @@ func segmentFileBatchAddADVEntry(creditBatch Batcher, debitBatch Batcher, entry 
 	}
 }
 
-// FlattenBatches flattens File Batches by consolidating batches with the same BatchHeader data into one Batch.
+// FlattenBatches flattens the file's batches by consolidating batches with the same BatchHeader data into one Batch.
 func (f *File) FlattenBatches() (*File, error) {
-	of := NewFile()
+	out := NewFile()
 
+	// Helper method to fetch the batch header without the trace number
+	getHeader := func(batchHeader fmt.Stringer) string {
+		return batchHeader.String()[:87]
+	}
+
+	batchesByHeader := make(map[string]Batcher)
 	if f.Batches != nil {
-		// Slice of BatchHeaders
-		sbh := make([]string, 0)
 		for _, b := range f.Batches {
-			bh := b.GetHeader()
-			bh.BatchNumber = 0
-			sbh = append(sbh, bh.String())
-		}
-		// Remove duplicate BatchHeader entries
-		sbh = removeDuplicateBatchHeaders(sbh)
-		// Add new batches for flattened file
-		for _, record := range sbh {
-			bh := &BatchHeader{}
-			bh.Parse(record)
+			bhKey := getHeader(b.GetHeader())
+			_, found := batchesByHeader[bhKey]
+			if !found {
+				newBatch, err := NewBatch(b.GetHeader())
+				if err != nil {
+					return nil, err
+				}
 
-			b, _ := NewBatch(bh)
-			of.AddBatch(b)
-		}
-		for _, batch := range f.Batches {
-			fbh := batch.GetHeader().String()[:87]
-			// Add entries for batches
-			for i, ofBatch := range of.Batches {
-				if strings.EqualFold(fbh, ofBatch.GetHeader().String()[:87]) {
-					if ofBatch.GetHeader().StandardEntryClassCode == "ADV" {
-						entries := batch.GetADVEntries()
-						for _, advEntry := range entries {
-							of.Batches[i].AddADVEntry(advEntry)
-						}
-					} else {
-						entries := batch.GetEntries()
-						for _, entry := range entries {
-							of.Batches[i].AddEntry(entry)
-						}
-					}
-					_ = of.Batches[i].Create()
+				batchesByHeader[bhKey] = newBatch
+				out.AddBatch(newBatch)
+			}
+
+			newBatch := batchesByHeader[bhKey]
+			if newBatch.GetHeader().StandardEntryClassCode == "ADV" {
+				for _, e := range b.GetADVEntries() {
+					newBatch.AddADVEntry(e)
+				}
+			} else {
+				for _, e := range b.GetEntries() {
+					newBatch.AddEntry(e)
 				}
 			}
 		}
 	}
 
+	IATBatchesByHeader := make(map[string]IATBatch)
 	if f.IATBatches != nil {
-		// Slice of IATBatchHeaders
-		sIATBh := make([]string, 0)
-		for _, iatB := range f.IATBatches {
-			bh := iatB.GetHeader()
-			bh.BatchNumber = 0
-			sIATBh = append(sIATBh, bh.String())
-		}
-		// Remove duplicate IATBatchHeader entries
-		sIATBh = removeDuplicateBatchHeaders(sIATBh)
-		// Add new IATBatches for flattened file
-		for _, record := range sIATBh {
-			iatBh := &IATBatchHeader{}
-			iatBh.Parse(record)
+		for _, b := range f.IATBatches {
+			bhKey := getHeader(b.GetHeader())
+			_, found := IATBatchesByHeader[bhKey]
+			if !found {
+				newBatch := NewIATBatch(b.GetHeader())
+				IATBatchesByHeader[bhKey] = newBatch
+				out.AddIATBatch(newBatch)
+			}
 
-			b := NewIATBatch(iatBh)
-			of.AddIATBatch(b)
-		}
-		for _, iatBatch := range f.IATBatches {
-			fbh := iatBatch.GetHeader().String()[:87]
-			// Add entries for IATBatches
-			for i, ofBatch := range of.IATBatches {
-				if strings.EqualFold(fbh, ofBatch.GetHeader().String()[:87]) {
-					iatEntries := iatBatch.GetEntries()
-					for _, iatEntry := range iatEntries {
-						// reset TraceNumber
-						iatEntry.TraceNumber = ""
-						of.IATBatches[i].AddEntry(iatEntry)
-					}
-				}
-				_ = of.IATBatches[i].Create()
+			newBatch := IATBatchesByHeader[bhKey]
+			for _, e := range b.GetEntries() {
+				// reset TraceNumber
+				e.TraceNumber = ""
+				newBatch.AddEntry(e)
 			}
 		}
 	}
+
+	// Set batches to valid state
+	wg := sync.WaitGroup{}
+
+	wg.Add(len(batchesByHeader))
+	for _, b := range batchesByHeader {
+		go func(b Batcher) {
+			defer wg.Done()
+			_ = b.Create()
+		}(b)
+	}
+
+	wg.Add(len(IATBatchesByHeader))
+	for _, b := range IATBatchesByHeader {
+		go func(b IATBatch) {
+			defer wg.Done()
+			_ = b.Create()
+		}(b)
+	}
+
+	wg.Wait()
 
 	// Add FileHeaderData.
-	f.addFileHeaderData(of)
+	f.addFileHeaderData(out)
 
-	if err := of.Create(); err != nil {
+	if err := out.Create(); err != nil {
 		return nil, err
 	}
-	if err := of.Validate(); err != nil {
+	if err := out.Validate(); err != nil {
 		return nil, err
 	}
-	return of, nil
+	return out, nil
 }
 
 //Validates that the batch numbers are ascending
@@ -1147,21 +1147,4 @@ func (f *File) isSequenceAscending() error {
 	}
 
 	return nil
-}
-
-// removeDuplicateBatchHeaders removes duplicate batch header
-func removeDuplicateBatchHeaders(s []string) []string {
-	encountered := map[string]bool{}
-
-	// Create a map of all unique elements.
-	for v := range s {
-		encountered[s[v]] = true
-	}
-
-	// Place all keys from the map into a slice.
-	result := make([]string, 0)
-	for key := range encountered {
-		result = append(result, key)
-	}
-	return result
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/moov-io/base v0.15.4
 	github.com/prometheus/client_golang v1.9.0
+	github.com/stretchr/testify v1.7.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -833,6 +833,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/server/benchmark_test.go
+++ b/server/benchmark_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	numTransactions = 80_000
-	numBatches      = 2000
+	numTransactions = 75000
+	numBatches      = 1000
 )
 
 func init() {

--- a/server/benchmark_test.go
+++ b/server/benchmark_test.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/moov-io/ach"
+)
+
+const (
+	numTransactions = 80_000
+	numBatches      = 2000
+)
+
+func init() {
+	fmt.Printf("Benchmarks for ACH file with %d transactions split up in %d batches\n", numTransactions, numBatches)
+}
+
+// Benchmark creating a large ACH file through the Go library
+func BenchmarkCreateBigFile__Library(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		createBigFile(b, numTransactions, numBatches)
+	}
+}
+
+// Benchmark creating a large ACH file through the HTTP server
+func BenchmarkCreateBigFile__Server(b *testing.B) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(24*time.Hour, logger)
+	service := NewService(repo)
+	// setup our HTTP handler
+	handler := MakeHTTPHandler(service, repo, logger)
+	// Spin up a local HTTP server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Create a file with 75K entries and convert it to a NACHA file
+	bb := &bytes.Buffer{}
+	writer := ach.NewWriter(bb)
+	f := createBigFile(b, numTransactions, numBatches)
+	if err := writer.Write(f); err != nil {
+		b.Fatal(err)
+	}
+
+	// Make the request
+	for i := 0; i < b.N; i++ {
+		req, err := http.NewRequest("POST", server.URL+"/files/create", bytes.NewReader(bb.Bytes()))
+		if err != nil {
+			b.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			b.Fatalf("non-200 response code: %v", resp.StatusCode)
+		}
+	}
+}
+
+// Benchmark for flattening an ACH file
+func Benchmark__FlattenBigFile(b *testing.B) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(24*time.Hour, logger)
+	service := NewService(repo)
+	// setup our HTTP handler
+	handler := MakeHTTPHandler(service, repo, logger)
+	// Spin up a local HTTP server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Create a file with 75K entries and convert it to a NACHA file
+	bb := &bytes.Buffer{}
+	writer := ach.NewWriter(bb)
+	f := createBigFile(b, numTransactions, numBatches)
+	if err := writer.Write(f); err != nil {
+		b.Fatal(err)
+	}
+
+	if err := repo.StoreFile(f); err != nil {
+		b.Fatal(err)
+	}
+
+	// Make the request
+	url := fmt.Sprintf("%s/files/%s/flatten", server.URL, f.ID)
+	for i := 0; i < b.N; i++ {
+		req, err := http.NewRequest("POST", url, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.Log(string(body))
+			b.Fatalf("non-200 response code: %v", resp.StatusCode)
+
+		}
+	}
+}
+
+func createBigFile(b *testing.B, numTransactions int, numBatches int) *ach.File {
+	f := ach.NewFile()
+	f.ID = "foo"
+	f.Header = *mockFileHeader()
+
+	if numTransactions < numBatches {
+		b.Fatal("numTransactions must be greater than numBatches")
+	}
+
+	if (numTransactions % numBatches) != 0 {
+		b.Fatal("number of transactions must be evenly distributed across batches")
+	}
+
+	entriesPerBatch := numTransactions / numBatches
+
+	traceNumSeq := 0
+	// Create and add the batch
+	for i := 0; i < numBatches; i++ {
+		// Create entries and add to current batch
+		batch := ach.NewBatchWEB(mockBatchHeaderWeb())
+
+		for j := 0; j < entriesPerBatch; j++ {
+			entry := ach.NewEntryDetail()
+			entry.ID = "98765"
+			entry.TransactionCode = ach.CheckingCredit
+			entry.SetRDFI("231380104")
+			entry.DFIAccountNumber = "123456789"
+			entry.Amount = 1
+			entry.IndividualName = "Wade Arnold"
+
+			traceNumSeq += 1
+			entry.SetTraceNumber(batch.Header.ODFIIdentification, traceNumSeq)
+			//entry.TraceNumber = fmt.Sprintf("%d", i+j)
+			entry.SetPaymentType("S")
+
+			batch.AddEntry(entry)
+		}
+
+		if err := batch.Create(); err != nil {
+			b.Fatal(err)
+		}
+		f.AddBatch(batch)
+	}
+
+	if err := f.Create(); err != nil {
+		b.Fatal(err)
+	}
+	if err := f.Validate(); err != nil {
+		b.Fatal(err)
+	}
+
+	return f
+}


### PR DESCRIPTION
Fixes #854 

This PR brings down the benchmark for `FlattenFiles()` from `~22s` to `~.3s`, a 100x improvement:
```
Benchmarks for ACH file with 75,000 transactions split up in 1,000 batches
goos: darwin
goarch: amd64
pkg: github.com/moov-io/ach/server
Benchmark__FlattenBigFile
Benchmark__FlattenBigFile-16    	       3	 334161791 ns/op
```