### PR TITLE
api: align Go JSON tags with OpenAPI spec by removing unnecessary omitempty tags and adding in missing required fields

### DIFF
--- a/addenda05.go
+++ b/addenda05.go
@@ -37,12 +37,12 @@ type Addenda05 struct {
 	// SequenceNumber is consecutively assigned to each Addenda05 Record following
 	// an Entry Detail Record. The first addenda05 sequence number must always
 	// be a "1".
-	SequenceNumber int `json:"sequenceNumber,omitempty"`
+	SequenceNumber int `json:"sequenceNumber"`
 	// EntryDetailSequenceNumber contains the ascending sequence number section of the Entry
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda10.go
+++ b/addenda10.go
@@ -55,7 +55,7 @@ type Addenda10 struct {
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda11.go
+++ b/addenda11.go
@@ -46,7 +46,7 @@ type Addenda11 struct {
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda12.go
+++ b/addenda12.go
@@ -51,7 +51,7 @@ type Addenda12 struct {
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda13.go
+++ b/addenda13.go
@@ -67,7 +67,7 @@ type Addenda13 struct {
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda14.go
+++ b/addenda14.go
@@ -63,7 +63,7 @@ type Addenda14 struct {
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda15.go
+++ b/addenda15.go
@@ -47,7 +47,7 @@ type Addenda15 struct {
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda16.go
+++ b/addenda16.go
@@ -50,7 +50,7 @@ type Addenda16 struct {
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda17.go
+++ b/addenda17.go
@@ -41,12 +41,12 @@ type Addenda17 struct {
 	// SequenceNumber is consecutively assigned to each Addenda17 Record following
 	// an Entry Detail Record. The first addenda17 sequence number must always
 	// be a "1".
-	SequenceNumber int `json:"sequenceNumber,omitempty"`
+	SequenceNumber int `json:"sequenceNumber"`
 	// EntryDetailSequenceNumber contains the ascending sequence number section of the Entry
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/addenda18.go
+++ b/addenda18.go
@@ -59,12 +59,12 @@ type Addenda18 struct {
 	// SequenceNumber is consecutively assigned to each Addenda18 Record following
 	// an Entry Detail Record. The first addenda18 sequence number must always
 	// be a "1".
-	SequenceNumber int `json:"sequenceNumber,omitempty"`
+	SequenceNumber int `json:"sequenceNumber"`
 	// EntryDetailSequenceNumber contains the ascending sequence number section of the Entry
 	// Detail or Corporate Entry Detail Record's trace number This number is
 	// the same as the last seven digits of the trace number of the related
 	// Entry Detail Record or Corporate Entry Detail Record.
-	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber,omitempty"`
+	EntryDetailSequenceNumber int `json:"entryDetailSequenceNumber"`
 	// validator is composed for data validation
 	validator
 	// converters is composed for ACH to GoLang Converters

--- a/advEntryDetail.go
+++ b/advEntryDetail.go
@@ -77,7 +77,7 @@ type ADVEntryDetail struct {
 	// JulianDay
 	JulianDay int `json:"julianDay"`
 	// SequenceNumber
-	SequenceNumber int `json:"sequenceNumber,omitempty"`
+	SequenceNumber int `json:"sequenceNumber"`
 	// Addenda99 for use with Returns
 	Addenda99 *Addenda99 `json:"addenda99,omitempty"`
 	// Category defines if the entry is a Forward, Return, or NOC

--- a/batch.go
+++ b/batch.go
@@ -30,9 +30,9 @@ import (
 type Batch struct {
 	// id is a client defined string used as a reference to this record. accessed via ID/SetID
 	id         string
-	Header     *BatchHeader      `json:"batchHeader,omitempty"`
-	Entries    []*EntryDetail    `json:"entryDetails,omitempty"`
-	Control    *BatchControl     `json:"batchControl,omitempty"`
+	Header     *BatchHeader      `json:"batchHeader"`
+	Entries    []*EntryDetail    `json:"entryDetails"`
+	Control    *BatchControl     `json:"batchControl"`
 	ADVEntries []*ADVEntryDetail `json:"advEntryDetails,omitempty"`
 	ADVControl *ADVBatchControl  `json:"advBatchControl,omitempty"`
 

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -64,7 +64,7 @@ type BatchHeader struct {
 	// Determines addenda records (required or optional PLUS one or up to 9,999 records).
 	// Determines rules to follow (return time frames).
 	// Some SEC codes require specific data in predetermined fields within the ACH record
-	StandardEntryClassCode string `json:"standardEntryClassCode,omitempty"`
+	StandardEntryClassCode string `json:"standardEntryClassCode"`
 
 	// CompanyEntryDescription A description of the entries contained in the batch
 	//
@@ -115,7 +115,7 @@ type BatchHeader struct {
 	// in the Batch Header Record and the Batch Control Record is the same,
 	// the ascending sequence number should be assigned by batch and not by
 	// record.
-	BatchNumber int `json:"batchNumber,omitempty"`
+	BatchNumber int `json:"batchNumber"`
 
 	// validator is composed for data validation
 	validator

--- a/fileControl.go
+++ b/fileControl.go
@@ -33,7 +33,7 @@ type FileControl struct {
 	BatchCount int `json:"batchCount"`
 	// BlockCount total number of records in the file (include all headers and trailer) divided
 	// by 10 (This number must be evenly divisible by 10. If not, additional records consisting of all 9's are added to the file after the initial '9' record to fill out the block 10.)
-	BlockCount int `json:"blockCount,omitempty"`
+	BlockCount int `json:"blockCount"`
 	// EntryAddendaCount is a tally of each Entry Detail Record and each Addenda
 	// Record processed, within either the batch or file as appropriate.
 	EntryAddendaCount int `json:"entryAddendaCount"`

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -34,9 +34,9 @@ import (
 type IATBatch struct {
 	// ID is a client defined string used as a reference to this record.
 	ID      string            `json:"id"`
-	Header  *IATBatchHeader   `json:"IATBatchHeader,omitempty"`
-	Entries []*IATEntryDetail `json:"IATEntryDetails,omitempty"`
-	Control *BatchControl     `json:"batchControl,omitempty"`
+	Header  *IATBatchHeader   `json:"IATBatchHeader"`
+	Entries []*IATEntryDetail `json:"IATEntryDetails"`
+	Control *BatchControl     `json:"batchControl"`
 
 	// category defines if the entry is a Forward, Return, or NOC
 	category string

--- a/iatBatchHeader.go
+++ b/iatBatchHeader.go
@@ -106,7 +106,7 @@ type IATBatchHeader struct {
 	// Determines addenda records (required or optional PLUS one or up to 9,999 records).
 	// Determines rules to follow (return time frames).
 	// Some SEC codes require specific data in predetermined fields within the ACH record
-	StandardEntryClassCode string `json:"standardEntryClassCode,omitempty"`
+	StandardEntryClassCode string `json:"standardEntryClassCode"`
 
 	// CompanyEntryDescription A description of the entries contained in the batch
 	//
@@ -163,7 +163,7 @@ type IATBatchHeader struct {
 	// in the Batch Header Record and the Batch Control Record is the same,
 	// the ascending sequence number should be assigned by batch and not by
 	// record.
-	BatchNumber int `json:"batchNumber,omitempty"`
+	BatchNumber int `json:"batchNumber"`
 
 	// validator is composed for data validation
 	validator

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -66,7 +66,7 @@ type IATEntryDetail struct {
 	// AddendaRecordIndicator indicates the existence of an Addenda Record.
 	// A value of "1" indicates that one or more addenda records follow,
 	// and "0" means no such record is present.
-	AddendaRecordIndicator int `json:"addendaRecordIndicator,omitempty"`
+	AddendaRecordIndicator int `json:"addendaRecordIndicator"`
 	// TraceNumber assigned by the ODFI in ascending sequence, is included in each
 	// Entry Detail Record, Corporate Entry Detail Record, and addenda Record.
 	// Trace Numbers uniquely identify each entry within a batch in an ACH input file.
@@ -82,36 +82,36 @@ type IATEntryDetail struct {
 	//
 	// The Addenda10 Record identifies the Receiver of the transaction and the dollar amount of
 	// the payment.
-	Addenda10 *Addenda10 `json:"addenda10,omitempty"`
+	Addenda10 *Addenda10 `json:"addenda10"`
 	// Addenda11 is mandatory for IAT entries
 	//
 	// The Addenda11 record identifies key information related to the Originator of
 	// the entry.
-	Addenda11 *Addenda11 `json:"addenda11,omitempty"`
+	Addenda11 *Addenda11 `json:"addenda11"`
 	// Addenda12 is mandatory for IAT entries
 	//
 	// The Addenda12 record identifies key information related to the Originator of
 	// the entry.
-	Addenda12 *Addenda12 `json:"addenda12,omitempty"`
+	Addenda12 *Addenda12 `json:"addenda12"`
 	// Addenda13 is mandatory for IAT entries
 	//
 	// The Addenda13 contains information related to the financial institution originating the entry.
 	// For inbound IAT entries, the Fourth Addenda Record must contain information to identify the
 	// foreign financial institution that is providing the funding and payment instruction for
 	// the IAT entry.
-	Addenda13 *Addenda13 `json:"addenda13,omitempty"`
+	Addenda13 *Addenda13 `json:"addenda13"`
 	// Addenda14 is mandatory for IAT entries
 	//
 	// The Addenda14 identifies the Receiving financial institution holding the Receiver's account.
-	Addenda14 *Addenda14 `json:"addenda14,omitempty"`
+	Addenda14 *Addenda14 `json:"addenda14"`
 	// Addenda15 is mandatory for IAT entries
 	//
 	// The Addenda15 record identifies key information related to the Receiver.
-	Addenda15 *Addenda15 `json:"addenda15,omitempty"`
+	Addenda15 *Addenda15 `json:"addenda15"`
 	// Addenda16 is mandatory for IAt entries
 	//
 	// Addenda16 record identifies additional key information related to the Receiver.
-	Addenda16 *Addenda16 `json:"addenda16,omitempty"`
+	Addenda16 *Addenda16 `json:"addenda16"`
 	// Addenda17 is optional for IAT entries
 	//
 	// This is an optional Addenda Record used to provide payment-related data. There i a maximum of up to two of these

--- a/merge.go
+++ b/merge.go
@@ -28,7 +28,7 @@ const NACHAFileLineLimit = 10000
 
 // MergeFiles is a helper function for consolidating an array of ACH Files into as few files
 // as possible. This is useful for optimizing cost and network efficiency.
-// This operation will override batch numbers in each file to ensure they do not collide. The ascending batch numbers will start at 1. 
+// This operation will override batch numbers in each file to ensure they do not collide. The ascending batch numbers will start at 1.
 //
 // Per NACHA rules files must remain under 10,000 lines (when rendered in their ASCII encoding)
 //

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -681,9 +681,11 @@ components:
     BatchHeader:
       required:
         - serviceClassCode
+        - standardEntryClassCode
         - companyName
         - companyIdentification
         - ODFIIdentification
+        - batchNumber
       properties:
         ID:
           type: string
@@ -1574,6 +1576,7 @@ components:
           example: 1
       required:
         - serviceClassCode 
+        - standardEntryClassCode
         - foreignExchangeIndicator
         - foreignExchangeReferenceIndicator
         - foreignExchangeReference
@@ -1582,6 +1585,7 @@ components:
         - ISOOriginatingCurrencyCode
         - ISODestinationCurrencyCode
         - ODFIIdentification
+        - batchNumber
     IATEntryDetail:
       properties:
         ID:
@@ -1609,7 +1613,7 @@ components:
           type: string
           description: Last digit in RDFI routing number.
           example: "0"
-        AddendaRecords:
+        addendaRecords:
           type: number
           description: Number of Addenda Records
           example: 1
@@ -1626,7 +1630,7 @@ components:
           type: string
           description: Signifies if the record has been screened against OFAC records
           example: 'Y'
-        SecondaryOFACScreeningIndicator:
+        secondaryOFACScreeningIndicator:
           type: string
           description: Signifies if the record has been screened against OFAC records by a secondary entry
           example: 'Y'
@@ -1669,11 +1673,11 @@ components:
        - transactionCode
        - RDFIIdentification
        - checkDigit
-       - AddendaRecords
+       - addendaRecords
        - amount
        - DFIAccountNumber
        - OFACScreeningIndicator
-       - SecondaryOFACScreeningIndicator
+       - secondaryOFACScreeningIndicator
        - addendaRecordIndicator
        - addenda10
        - addenda11
@@ -1688,8 +1692,11 @@ components:
         - RDFIIdentification
         - checkDigit
         - DFIAccountNumber
+        - adviceRoutingNumber
         - amount
         - individualName
+        - achOperatorRoutingNumber
+        - sequenceNumber
       properties:
         ID:
           type: string


### PR DESCRIPTION
Fixes #855