### PR TITLE
Clean up read/write examples

### DIFF
--- a/examples/example_ackRead_test.go
+++ b/examples/example_ackRead_test.go
@@ -19,37 +19,38 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
-// Example_ackRead reads a ACK file
 func Example_ackRead() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "ack-read.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-
-	if err := achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Credit Total Amount: %v", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Batch Credit Total Amount: %v", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount)+"\n")
-	fmt.Printf("SEC Code: %v", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Original Trace Number: %v", achFile.Batches[0].GetEntries()[0].OriginalTraceNumberField())
+	fmt.Printf("Credit Total Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Batch Credit Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Original Trace Number: %s\n", achFile.Batches[0].GetEntries()[0].OriginalTraceNumberField())
 
 	// Output:
 	// Credit Total Amount: 0

--- a/examples/example_ackRead_test.go
+++ b/examples/example_ackRead_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,8 +46,8 @@ func Example_ackRead() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Credit Total Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
-	fmt.Printf("Batch Credit Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("Credit Total Amount: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
+	fmt.Printf("Batch Credit Total Amount: %d\n", achFile.Batches[0].GetEntries()[0].Amount)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Original Trace Number: %s\n", achFile.Batches[0].GetEntries()[0].OriginalTraceNumberField())
 

--- a/examples/example_ackWrite_test.go
+++ b/examples/example_ackWrite_test.go
@@ -24,17 +24,16 @@ import (
 	"github.com/moov-io/ach"
 )
 
-// Example_ackWrite writes an ACK File
 func Example_ackWrite() {
 	fh := mockFileHeader()
+
 	bh := ach.NewBatchHeader()
 	bh.ServiceClassCode = ach.CreditsOnly
 	bh.CompanyName = "Name on Account"
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.ACK
 	bh.CompanyEntryDescription = "Vndr Pay"
-	// need EffectiveEntryDate to be fixed so it can match output
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "23138010"
 
 	entry := ach.NewEntryDetail()
@@ -71,12 +70,12 @@ func Example_ackWrite() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[1].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[1].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_advRead_test.go
+++ b/examples/example_advRead_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,16 +46,16 @@ func Example_advRead() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Credit Total Amount: %s\n", strconv.Itoa(achFile.ADVControl.TotalCreditEntryDollarAmountInFile))
-	fmt.Printf("Debit Total Amount: %s\n", strconv.Itoa(achFile.ADVControl.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("OriginatorStatusCode: %s\n", strconv.Itoa(achFile.Batches[0].GetHeader().OriginatorStatusCode))
-	fmt.Printf("Batch Credit Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetADVControl().TotalCreditEntryDollarAmount))
-	fmt.Printf("Batch Debit Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetADVControl().TotalDebitEntryDollarAmount))
+	fmt.Printf("Credit Total Amount: %d\n", achFile.ADVControl.TotalCreditEntryDollarAmountInFile)
+	fmt.Printf("Debit Total Amount: %d\n", achFile.ADVControl.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("OriginatorStatusCode: %d\n", achFile.Batches[0].GetHeader().OriginatorStatusCode)
+	fmt.Printf("Batch Credit Total Amount: %d\n", achFile.Batches[0].GetADVControl().TotalCreditEntryDollarAmount)
+	fmt.Printf("Batch Debit Total Amount: %d\n", achFile.Batches[0].GetADVControl().TotalDebitEntryDollarAmount)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
-	fmt.Printf("Entry Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetADVEntries()[0].Amount))
-	fmt.Printf("Sequence Number: %s\n", strconv.Itoa(achFile.Batches[0].GetADVEntries()[0].SequenceNumber))
-	fmt.Printf("EntryOne Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetADVEntries()[1].Amount))
-	fmt.Printf("EntryOne Sequence Number: %s\n", strconv.Itoa(achFile.Batches[0].GetADVEntries()[1].SequenceNumber))
+	fmt.Printf("Entry Amount: %d\n", achFile.Batches[0].GetADVEntries()[0].Amount)
+	fmt.Printf("Sequence Number: %d\n", achFile.Batches[0].GetADVEntries()[0].SequenceNumber)
+	fmt.Printf("EntryOne Amount: %d\n", achFile.Batches[0].GetADVEntries()[1].Amount)
+	fmt.Printf("EntryOne Sequence Number: %d\n", achFile.Batches[0].GetADVEntries()[1].SequenceNumber)
 
 	// Output:
 	// Credit Total Amount: 50000

--- a/examples/example_advRead_test.go
+++ b/examples/example_advRead_test.go
@@ -28,44 +28,45 @@ import (
 )
 
 func Example_advRead() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "adv-read.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Credit Total Amount:%s", strconv.Itoa(achFile.ADVControl.TotalCreditEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Debit Total Amount:%s", strconv.Itoa(achFile.ADVControl.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("OriginatorStatusCode:%s", strconv.Itoa(achFile.Batches[0].GetHeader().OriginatorStatusCode)+"\n")
-	fmt.Printf("Batch Credit Total Amount:%s", strconv.Itoa(achFile.Batches[0].GetADVControl().TotalCreditEntryDollarAmount)+"\n")
-	fmt.Printf("Batch Debit Total Amount:%s", strconv.Itoa(achFile.Batches[0].GetADVControl().TotalDebitEntryDollarAmount)+"\n")
-	fmt.Printf("SEC Code:%s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Entry Amount:%s", strconv.Itoa(achFile.Batches[0].GetADVEntries()[0].Amount)+"\n")
-	fmt.Printf("Sequence Number:%s", strconv.Itoa(achFile.Batches[0].GetADVEntries()[0].SequenceNumber)+"\n")
-	fmt.Printf("EntryOne Amount:%s", strconv.Itoa(achFile.Batches[0].GetADVEntries()[1].Amount)+"\n")
-	fmt.Printf("EntryOne Sequence Number:%s", strconv.Itoa(achFile.Batches[0].GetADVEntries()[1].SequenceNumber)+"\n")
+	fmt.Printf("Credit Total Amount: %s\n", strconv.Itoa(achFile.ADVControl.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Debit Total Amount: %s\n", strconv.Itoa(achFile.ADVControl.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("OriginatorStatusCode: %s\n", strconv.Itoa(achFile.Batches[0].GetHeader().OriginatorStatusCode))
+	fmt.Printf("Batch Credit Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetADVControl().TotalCreditEntryDollarAmount))
+	fmt.Printf("Batch Debit Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetADVControl().TotalDebitEntryDollarAmount))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Entry Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetADVEntries()[0].Amount))
+	fmt.Printf("Sequence Number: %s\n", strconv.Itoa(achFile.Batches[0].GetADVEntries()[0].SequenceNumber))
+	fmt.Printf("EntryOne Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetADVEntries()[1].Amount))
+	fmt.Printf("EntryOne Sequence Number: %s\n", strconv.Itoa(achFile.Batches[0].GetADVEntries()[1].SequenceNumber))
 
 	// Output:
-	// Credit Total Amount:50000
-	// Debit Total Amount:250000
-	// OriginatorStatusCode:0
-	// Batch Credit Total Amount:50000
-	// Batch Debit Total Amount:250000
-	// SEC Code:ADV
-	// Entry Amount:50000
-	// Sequence Number:1
-	// EntryOne Amount:250000
-	// EntryOne Sequence Number:2
+	// Credit Total Amount: 50000
+	// Debit Total Amount: 250000
+	// OriginatorStatusCode: 0
+	// Batch Credit Total Amount: 50000
+	// Batch Debit Total Amount: 250000
+	// SEC Code: ADV
+	// Entry Amount: 50000
+	// Sequence Number: 1
+	// EntryOne Amount: 250000
+	// EntryOne Sequence Number: 2
 }

--- a/examples/example_advWrite_test.go
+++ b/examples/example_advWrite_test.go
@@ -33,13 +33,12 @@ func Example_advWrite() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.ADV
 	bh.CompanyEntryDescription = "Accounting"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 	bh.OriginatorStatusCode = 0
 
 	entry := ach.NewADVEntryDetail()
-
-	entry.TransactionCode = ach.CreditForDebitsOriginated //
+	entry.TransactionCode = ach.CreditForDebitsOriginated
 	entry.SetRDFI("231380104")
 	entry.DFIAccountNumber = "744-5678-99"
 	entry.Amount = 50000
@@ -54,7 +53,7 @@ func Example_advWrite() {
 	entry.SequenceNumber = 1
 
 	entryOne := ach.NewADVEntryDetail()
-	entryOne.TransactionCode = ach.DebitForCreditsOriginated //
+	entryOne.TransactionCode = ach.DebitForCreditsOriginated
 	entryOne.SetRDFI("231380104")
 	entryOne.DFIAccountNumber = "744-5678-99"
 	entryOne.Amount = 250000
@@ -84,12 +83,12 @@ func Example_advWrite() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetADVEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetADVEntries()[1].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetADVControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetADVEntries()[0].String())
+	fmt.Println(file.Batches[0].GetADVEntries()[1].String())
+	fmt.Println(file.Batches[0].GetADVControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -98,5 +97,4 @@ func Example_advWrite() {
 	// 682231380104744-5678-99    00000025000012104288211139 Name                    0011000010500002
 	// 828000000200462760200000000000000025000000000000000000050000Company Name, Inc  121042880000001
 	// 9000000000000000000000000000000000000000000000000000000
-
 }

--- a/examples/example_arcRead_debit_test.go
+++ b/examples/example_arcRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_arcReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 

--- a/examples/example_arcRead_debit_test.go
+++ b/examples/example_arcRead_debit_test.go
@@ -19,39 +19,40 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_arcReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "arc-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Check Serial Number: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 
 	// Output:
 	// Total Amount Debit: 250000
 	// SEC Code: ARC
 	// Check Serial Number: 123879654
-
 }

--- a/examples/example_arcWrite_debit_test.go
+++ b/examples/example_arcWrite_debit_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func Example_arcWriteDebit() {
-
 	fh := mockFileHeader()
 
 	bh := ach.NewBatchHeader()
@@ -34,7 +33,7 @@ func Example_arcWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.ARC
 	bh.CompanyEntryDescription = "ACH ARC"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -61,11 +60,11 @@ func Example_arcWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -73,5 +72,4 @@ func Example_arcWriteDebit() {
 	// 62723138010412345678         0000250000123879654      ABC Company             0121042880000001
 	// 82250000010023138010000000250000000000000000231380104                          121042880000001
 	// 9000001000001000000010023138010000000250000000000000000
-
 }

--- a/examples/example_atxRead_test.go
+++ b/examples/example_atxRead_test.go
@@ -19,43 +19,45 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_atxRead() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "atx-read.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Total Amount Credit: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Total Amount: %s", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount)+"\n")
-	fmt.Printf("Original Trace Number: %s", achFile.Batches[0].GetEntries()[0].OriginalTraceNumberField()+"\n")
-	fmt.Printf("Addenda1: %s", achFile.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("Addenda2: %s", achFile.Batches[0].GetEntries()[0].Addenda05[1].String()+"\n")
-	fmt.Printf("Total Amount: %s", strconv.Itoa(achFile.Batches[0].GetEntries()[1].Amount)+"\n")
-	fmt.Printf("Original Trace Number: %s", achFile.Batches[0].GetEntries()[1].OriginalTraceNumberField()+"\n")
-	fmt.Printf("Addenda1: %s", achFile.Batches[0].GetEntries()[1].Addenda05[0].String()+"\n")
-	fmt.Printf("Addenda2: %s", achFile.Batches[0].GetEntries()[1].Addenda05[1].String()+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("Original Trace Number: %s\n", achFile.Batches[0].GetEntries()[0].OriginalTraceNumberField())
+	fmt.Printf("Addenda1: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Printf("Addenda2: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[1].String())
+	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[1].Amount))
+	fmt.Printf("Original Trace Number: %s\n", achFile.Batches[0].GetEntries()[1].OriginalTraceNumberField())
+	fmt.Printf("Addenda1: %s\n", achFile.Batches[0].GetEntries()[1].Addenda05[0].String())
+	fmt.Printf("Addenda2: %s\n", achFile.Batches[0].GetEntries()[1].Addenda05[1].String())
 
 	// Output:
 	// Total Amount Debit: 0

--- a/examples/example_atxRead_test.go
+++ b/examples/example_atxRead_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,14 +46,14 @@ func Example_atxRead() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total Amount Credit: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
-	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("Total Amount: %d\n", achFile.Batches[0].GetEntries()[0].Amount)
 	fmt.Printf("Original Trace Number: %s\n", achFile.Batches[0].GetEntries()[0].OriginalTraceNumberField())
 	fmt.Printf("Addenda1: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
 	fmt.Printf("Addenda2: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[1].String())
-	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[1].Amount))
+	fmt.Printf("Total Amount: %d\n", achFile.Batches[0].GetEntries()[1].Amount)
 	fmt.Printf("Original Trace Number: %s\n", achFile.Batches[0].GetEntries()[1].OriginalTraceNumberField())
 	fmt.Printf("Addenda1: %s\n", achFile.Batches[0].GetEntries()[1].Addenda05[0].String())
 	fmt.Printf("Addenda2: %s\n", achFile.Batches[0].GetEntries()[1].Addenda05[1].String())

--- a/examples/example_atxWrite_test.go
+++ b/examples/example_atxWrite_test.go
@@ -33,7 +33,7 @@ func Example_atxWrite() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.ATX
 	bh.CompanyEntryDescription = "Vndr Pay"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "23138010"
 
 	entry := ach.NewEntryDetail()
@@ -100,14 +100,14 @@ func Example_atxWrite() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[1].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[1].Addenda05[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[1].String())
+	fmt.Println(file.Batches[0].GetEntries()[1].Addenda05[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_bocRead_debit_test.go
+++ b/examples/example_bocRead_debit_test.go
@@ -28,27 +28,28 @@ import (
 )
 
 func Example_bocReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "boc-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Check Serial Number: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 
 	// Output: Total Amount Debit: 250000
 	// SEC Code: BOC

--- a/examples/example_bocRead_debit_test.go
+++ b/examples/example_bocRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_bocReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 

--- a/examples/example_bocWrite_debit_test.go
+++ b/examples/example_bocWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_bocWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.BOC
 	bh.CompanyEntryDescription = "ACH BOC"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -60,11 +60,11 @@ func Example_bocWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_ccdRead_debit_test.go
+++ b/examples/example_ccdRead_debit_test.go
@@ -28,33 +28,34 @@ import (
 )
 
 func Example_ccdReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "ccd-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Total Amount Credit: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("CCD Entry Identification Number: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber+"\n")
-	fmt.Printf("CCD Entry Receiving Company: %s", achFile.Batches[0].GetEntries()[0].IndividualName+"\n")
-	fmt.Printf("CCD Entry Trace Number: %s", achFile.Batches[0].GetEntries()[0].TraceNumberField()+"\n")
-	fmt.Printf("CCD Fee Identification Number: %s", achFile.Batches[0].GetEntries()[1].IdentificationNumber+"\n")
-	fmt.Printf("CCD Fee Receiving Company: %s", achFile.Batches[0].GetEntries()[1].IndividualName+"\n")
-	fmt.Printf("CCD Fee Trace Number: %s", achFile.Batches[0].GetEntries()[1].TraceNumberField()+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("CCD Entry Identification Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
+	fmt.Printf("CCD Entry Receiving Company: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName)
+	fmt.Printf("CCD Entry Trace Number: %s\n", achFile.Batches[0].GetEntries()[0].TraceNumberField())
+	fmt.Printf("CCD Fee Identification Number: %s\n", achFile.Batches[0].GetEntries()[1].IdentificationNumber)
+	fmt.Printf("CCD Fee Receiving Company: %s\n", achFile.Batches[0].GetEntries()[1].IndividualName)
+	fmt.Printf("CCD Fee Trace Number: %s\n", achFile.Batches[0].GetEntries()[1].TraceNumberField())
 
 	// Output:
 	// Total Amount Debit: 500125

--- a/examples/example_ccdRead_debit_test.go
+++ b/examples/example_ccdRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,8 +46,8 @@ func Example_ccdReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total Amount Credit: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("CCD Entry Identification Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 	fmt.Printf("CCD Entry Receiving Company: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName)

--- a/examples/example_ccdWrite_debit_test.go
+++ b/examples/example_ccdWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_ccdWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.CCD
 	bh.CompanyEntryDescription = "Vndr Pay"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "031300012"
 
 	entry := ach.NewEntryDetail()
@@ -72,14 +72,15 @@ func Example_ccdWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[1].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[1].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
-	// Output: 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// Output:
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 CCDVndr Pay        190816   1031300010000001
 	// 627231380104744-5678-99      0000500000location #1234 Best Co. #1           S 0031300010000001
 	// 627231380104744-5678-99      0000000125Fee #1         Best Co. #1           S 0031300010000002

--- a/examples/example_cieRead_credit_test.go
+++ b/examples/example_cieRead_credit_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func Example_cieReadCredit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "cie-credit.ach"))
 	if err != nil {
 		log.Fatalln(err)
@@ -37,13 +38,13 @@ func Example_cieReadCredit() {
 	if err != nil {
 		log.Fatalf("reading file: %v\n", err)
 	}
-	// Validate the ACH file
-	if achFile.Validate(); err != nil {
-		log.Fatalf("validating file: %v\n", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
 		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
 	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))

--- a/examples/example_cieRead_credit_test.go
+++ b/examples/example_cieRead_credit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,8 +46,8 @@ func Example_cieReadCredit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total Amount Credit: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Addenda05: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
 

--- a/examples/example_cieWrite_credit_test.go
+++ b/examples/example_cieWrite_credit_test.go
@@ -33,7 +33,7 @@ func Example_cieWriteCredit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.CIE
 	bh.CompanyEntryDescription = "Payment"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()

--- a/examples/example_corRead_credit_test.go
+++ b/examples/example_corRead_credit_test.go
@@ -19,38 +19,39 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
-// Example_corReadCredit reads a COR file
 func Example_corReadCredit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "cor-read.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %v", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Total Amount Credit: %v", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %v", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Entry Detail: %v", achFile.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("Addenda98: %v", achFile.Batches[0].GetEntries()[0].Addenda98.String()+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Entry Detail: %s\n", achFile.Batches[0].GetEntries()[0].String())
+	fmt.Printf("Addenda98: %s\n", achFile.Batches[0].GetEntries()[0].Addenda98.String())
 
 	// Output:
 	// Total Amount Debit: 0

--- a/examples/example_corRead_credit_test.go
+++ b/examples/example_corRead_credit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,8 +46,8 @@ func Example_corReadCredit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total Amount Credit: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Entry Detail: %s\n", achFile.Batches[0].GetEntries()[0].String())
 	fmt.Printf("Addenda98: %s\n", achFile.Batches[0].GetEntries()[0].Addenda98.String())

--- a/examples/example_corWrite_credit_test.go
+++ b/examples/example_corWrite_credit_test.go
@@ -24,10 +24,7 @@ import (
 	"github.com/moov-io/ach"
 )
 
-// Example_corWriteCredit writes a COR file
 func Example_corWriteCredit() {
-	// Example transfer to write a COR File
-
 	fh := mockFileHeader()
 
 	bh := ach.NewBatchHeader()
@@ -61,7 +58,6 @@ func Example_corWriteCredit() {
 	// build the batch
 	batch := ach.NewBatchCOR(bh)
 	batch.AddEntry(entry)
-
 	if err := batch.Create(); err != nil {
 		log.Fatalf("Unexpected error building batch: %s\n", err)
 	}
@@ -74,12 +70,12 @@ func Example_corWriteCredit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda98.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda98.String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -88,5 +84,4 @@ func Example_corWriteCredit() {
 	// 798C01121042880000001      121042881918171614                                  091012980000088
 	// 82200000020023138010000000000000000000000000121042882                          121042880000001
 	// 9000001000001000000020023138010000000000000000000000000
-
 }

--- a/examples/example_ctxRead_debit_test.go
+++ b/examples/example_ctxRead_debit_test.go
@@ -19,37 +19,39 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_ctxReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "ctx-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Total Amount Credit: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Addenda1: %s", achFile.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("Addenda2: %s", achFile.Batches[0].GetEntries()[0].Addenda05[1].String()+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Addenda1: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Printf("Addenda2: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[1].String())
 
 	// Output:
 	// Total Amount Debit: 100000000
@@ -57,5 +59,4 @@ func Example_ctxReadDebit() {
 	// SEC Code: CTX
 	// Addenda1: 705Debit First Account                                                             00010000001
 	// Addenda2: 705Debit Second Account                                                            00020000001
-
 }

--- a/examples/example_ctxRead_debit_test.go
+++ b/examples/example_ctxRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,8 +46,8 @@ func Example_ctxReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total Amount Credit: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Addenda1: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
 	fmt.Printf("Addenda2: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[1].String())

--- a/examples/example_ctxWrite_debit_test.go
+++ b/examples/example_ctxWrite_debit_test.go
@@ -26,7 +26,6 @@ import (
 
 // Example_ctxWriteDebit writes a CTX debit file
 func Example_ctxWriteDebit() {
-
 	fh := mockFileHeader()
 
 	bh := ach.NewBatchHeader()
@@ -35,11 +34,10 @@ func Example_ctxWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.CTX
 	bh.CompanyEntryDescription = "ACH CTX"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
-
 	entry.TransactionCode = ach.CheckingDebit
 	entry.SetRDFI("231380104")
 	entry.DFIAccountNumber = "12345678"
@@ -78,13 +76,13 @@ func Example_ctxWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda05[1].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda05[1].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -94,5 +92,4 @@ func Example_ctxWriteDebit() {
 	// 705Debit Second Account                                                            00020000001
 	// 82250000030023138010000100000000000000000000231380104                          121042880000001
 	// 9000001000001000000030023138010000100000000000000000000
-
 }

--- a/examples/example_custom_transaction_code_test.go
+++ b/examples/example_custom_transaction_code_test.go
@@ -47,8 +47,7 @@ func Example_customTransactionCode() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.PPD
 	bh.CompanyEntryDescription = "Cash Back"
-	// fix EffectiveEntryDate for consistent output
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "987654320"
 	bh.SetValidation(validationOpts)
 
@@ -64,7 +63,6 @@ func Example_customTransactionCode() {
 	// build the batch
 	batch := ach.NewBatchPPD(bh)
 	batch.AddEntry(entry)
-
 	if err := batch.Create(); err != nil {
 		log.Fatalf("Unexpected error building batch: %s\n", err)
 	}
@@ -78,10 +76,9 @@ func Example_customTransactionCode() {
 	}
 
 	fmt.Printf("TransactionCode=%d\n", file.Batches[0].GetEntries()[0].TransactionCode)
-	fmt.Printf("%s\n", file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
 
 	// Output:
 	// TransactionCode=78
 	// 67812345678012567            0100000000               Jane Smith              0987654320000002
-
 }

--- a/examples/example_dneRead_test.go
+++ b/examples/example_dneRead_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_dneRead() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("Total Amount: %d\n", achFile.Batches[0].GetEntries()[0].Amount)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Payment Related Information: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
 

--- a/examples/example_dneRead_test.go
+++ b/examples/example_dneRead_test.go
@@ -27,33 +27,32 @@ import (
 	"github.com/moov-io/ach"
 )
 
-// Example_dneRead reads a DNR file
 func Example_dneRead() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "dne-read.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		panic(fmt.Sprintf("Issue reading file: %+v \n", err))
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount: %s", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Payment Related Information: %s", achFile.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
+	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Payment Related Information: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
 
 	// Output:
 	// Total Amount: 0
 	// SEC Code: DNE
 	// Payment Related Information: 705DATE OF DEATH*010218*CUSTOMERSSN*#########*AMOUNT*$$$$.cc\                      00010000001
-
 }

--- a/examples/example_dneWrite_test.go
+++ b/examples/example_dneWrite_test.go
@@ -34,7 +34,7 @@ func Example_dneWrite() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.DNE
 	bh.CompanyEntryDescription = "Death"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "23138010"
 	bh.OriginatorStatusCode = 2
 
@@ -67,12 +67,12 @@ func Example_dneWrite() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_enrRead_test.go
+++ b/examples/example_enrRead_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_enrRead() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("Total Amount: %d\n", achFile.Batches[0].GetEntries()[0].Amount)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Payment Related Information: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
 

--- a/examples/example_enrRead_test.go
+++ b/examples/example_enrRead_test.go
@@ -27,29 +27,29 @@ import (
 	"github.com/moov-io/ach"
 )
 
-// Example_enrRead reads a ENR file
 func Example_enrRead() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "enr-read.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		panic(fmt.Sprintf("Issue reading file: %+v \n", err))
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount: %s", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Payment Related Information: %s", achFile.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
+	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Payment Related Information: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
 
 	// Output:
 	// Total Amount: 0

--- a/examples/example_enrWrite_test.go
+++ b/examples/example_enrWrite_test.go
@@ -37,7 +37,6 @@ func Example_enrWrite() {
 	bh.ODFIIdentification = "23138010"
 
 	entry := ach.NewEntryDetail()
-
 	entry.TransactionCode = ach.CheckingDebit
 	entry.SetRDFI("031300012")
 	entry.DFIAccountNumber = "744-5678-99"
@@ -66,14 +65,15 @@ func Example_enrWrite() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
-	// Output: 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// Output:
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Name on Account                     231380104 ENRAUTOENROLL               1231380100000001
 	// 627031300012744-5678-99      0000000000031300010000001Best. #1                1231380100000001
 	// 70522*12200004*3*123987654321*777777777*DOE*JOHN*1\                                00010000001

--- a/examples/example_iatRead_mixedCreditDebit_test.go
+++ b/examples/example_iatRead_mixedCreditDebit_test.go
@@ -19,56 +19,57 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
-// Example_iatReadMixedCreditDebit reads a ACK file
 func Example_iatReadMixedCreditDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "iat-mixedCreditDebit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-
-	if err := achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("SEC Code: %s", achFile.IATBatches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Debit Entry: %s", achFile.IATBatches[0].Entries[0].String()+"\n")
-	fmt.Printf("Addenda10: %s", achFile.IATBatches[0].Entries[0].Addenda10.String()+"\n")
-	fmt.Printf("Addenda11: %s", achFile.IATBatches[0].Entries[0].Addenda11.String()+"\n")
-	fmt.Printf("Addenda12: %s", achFile.IATBatches[0].Entries[0].Addenda12.String()+"\n")
-	fmt.Printf("Addenda13: %s", achFile.IATBatches[0].Entries[0].Addenda13.String()+"\n")
-	fmt.Printf("Addenda14: %s", achFile.IATBatches[0].Entries[0].Addenda14.String()+"\n")
-	fmt.Printf("Addenda15: %s", achFile.IATBatches[0].Entries[0].Addenda15.String()+"\n")
-	fmt.Printf("Addenda16: %s", achFile.IATBatches[0].Entries[0].Addenda16.String()+"\n")
-	fmt.Printf("Addenda17: %s", achFile.IATBatches[0].Entries[0].Addenda17[0].String()+"\n")
-	fmt.Printf("Addenda18: %s", achFile.IATBatches[0].Entries[0].Addenda18[0].String()+"\n")
-	fmt.Printf("Total File Debit Amount: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Credit Entry: %s", achFile.IATBatches[0].Entries[1].String()+"\n")
-	fmt.Printf("Addenda10: %s", achFile.IATBatches[0].Entries[1].Addenda10.String()+"\n")
-	fmt.Printf("Addenda11: %s", achFile.IATBatches[0].Entries[1].Addenda11.String()+"\n")
-	fmt.Printf("Addenda12: %s", achFile.IATBatches[0].Entries[1].Addenda12.String()+"\n")
-	fmt.Printf("Addenda13: %s", achFile.IATBatches[0].Entries[1].Addenda13.String()+"\n")
-	fmt.Printf("Addenda14: %s", achFile.IATBatches[0].Entries[1].Addenda14.String()+"\n")
-	fmt.Printf("Addenda15: %s", achFile.IATBatches[0].Entries[1].Addenda15.String()+"\n")
-	fmt.Printf("Addenda16: %s", achFile.IATBatches[0].Entries[1].Addenda16.String()+"\n")
-	fmt.Printf("Addenda17: %s", achFile.IATBatches[0].Entries[1].Addenda17[0].String()+"\n")
-	fmt.Printf("Addenda18: %s", achFile.IATBatches[0].Entries[1].Addenda18[0].String()+"\n")
-	fmt.Printf("Total File Credit Amount: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
+	fmt.Printf("SEC Code: %s\n", achFile.IATBatches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Debit Entry: %s\n", achFile.IATBatches[0].Entries[0].String())
+	fmt.Printf("Addenda10: %s\n", achFile.IATBatches[0].Entries[0].Addenda10.String())
+	fmt.Printf("Addenda11: %s\n", achFile.IATBatches[0].Entries[0].Addenda11.String())
+	fmt.Printf("Addenda12: %s\n", achFile.IATBatches[0].Entries[0].Addenda12.String())
+	fmt.Printf("Addenda13: %s\n", achFile.IATBatches[0].Entries[0].Addenda13.String())
+	fmt.Printf("Addenda14: %s\n", achFile.IATBatches[0].Entries[0].Addenda14.String())
+	fmt.Printf("Addenda15: %s\n", achFile.IATBatches[0].Entries[0].Addenda15.String())
+	fmt.Printf("Addenda16: %s\n", achFile.IATBatches[0].Entries[0].Addenda16.String())
+	fmt.Printf("Addenda17: %s\n", achFile.IATBatches[0].Entries[0].Addenda17[0].String())
+	fmt.Printf("Addenda18: %s\n", achFile.IATBatches[0].Entries[0].Addenda18[0].String())
+	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Credit Entry: %s\n", achFile.IATBatches[0].Entries[1].String())
+	fmt.Printf("Addenda10: %s\n", achFile.IATBatches[0].Entries[1].Addenda10.String())
+	fmt.Printf("Addenda11: %s\n", achFile.IATBatches[0].Entries[1].Addenda11.String())
+	fmt.Printf("Addenda12: %s\n", achFile.IATBatches[0].Entries[1].Addenda12.String())
+	fmt.Printf("Addenda13: %s\n", achFile.IATBatches[0].Entries[1].Addenda13.String())
+	fmt.Printf("Addenda14: %s\n", achFile.IATBatches[0].Entries[1].Addenda14.String())
+	fmt.Printf("Addenda15: %s\n", achFile.IATBatches[0].Entries[1].Addenda15.String())
+	fmt.Printf("Addenda16: %s\n", achFile.IATBatches[0].Entries[1].Addenda16.String())
+	fmt.Printf("Addenda17: %s\n", achFile.IATBatches[0].Entries[1].Addenda17[0].String())
+	fmt.Printf("Addenda18: %s\n", achFile.IATBatches[0].Entries[1].Addenda18[0].String())
+	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
 
 	// Output:
 	// SEC Code: IAT

--- a/examples/example_iatRead_mixedCreditDebit_test.go
+++ b/examples/example_iatRead_mixedCreditDebit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -58,7 +57,7 @@ func Example_iatReadMixedCreditDebit() {
 	fmt.Printf("Addenda16: %s\n", achFile.IATBatches[0].Entries[0].Addenda16.String())
 	fmt.Printf("Addenda17: %s\n", achFile.IATBatches[0].Entries[0].Addenda17[0].String())
 	fmt.Printf("Addenda18: %s\n", achFile.IATBatches[0].Entries[0].Addenda18[0].String())
-	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total File Debit Amount: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("Credit Entry: %s\n", achFile.IATBatches[0].Entries[1].String())
 	fmt.Printf("Addenda10: %s\n", achFile.IATBatches[0].Entries[1].Addenda10.String())
 	fmt.Printf("Addenda11: %s\n", achFile.IATBatches[0].Entries[1].Addenda11.String())
@@ -69,7 +68,7 @@ func Example_iatReadMixedCreditDebit() {
 	fmt.Printf("Addenda16: %s\n", achFile.IATBatches[0].Entries[1].Addenda16.String())
 	fmt.Printf("Addenda17: %s\n", achFile.IATBatches[0].Entries[1].Addenda17[0].String())
 	fmt.Printf("Addenda18: %s\n", achFile.IATBatches[0].Entries[1].Addenda18[0].String())
-	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total File Credit Amount: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 
 	// Output:
 	// SEC Code: IAT

--- a/examples/example_iatWrite_mixedCreditDebit_test.go
+++ b/examples/example_iatWrite_mixedCreditDebit_test.go
@@ -40,7 +40,7 @@ func Example_iatWriteMixedCreditDebit() {
 	bh.ISOOriginatingCurrencyCode = "CAD"
 	bh.ISODestinationCurrencyCode = "USD"
 	bh.ODFIIdentification = "23138010"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 
 	entry := ach.NewIATEntryDetail()
 	entry.TransactionCode = ach.CheckingDebit
@@ -123,8 +123,6 @@ func Example_iatWriteMixedCreditDebit() {
 	entryTwo.SetTraceNumber("23138010", 2)
 	entryTwo.Category = ach.CategoryForward
 
-	//addenda
-
 	addenda10Two := ach.NewAddenda10()
 	addenda10Two.TransactionTypeCode = "ANN"
 	addenda10Two.ForeignPaymentAmount = 100000
@@ -204,29 +202,29 @@ func Example_iatWriteMixedCreditDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("SEC Code: %s", achFile.IATBatches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Debit Entry: %s", achFile.IATBatches[0].Entries[0].String()+"\n")
-	fmt.Printf("Addenda10: %s", achFile.IATBatches[0].Entries[0].Addenda10.String()+"\n")
-	fmt.Printf("Addenda11: %s", achFile.IATBatches[0].Entries[0].Addenda11.String()+"\n")
-	fmt.Printf("Addenda12: %s", achFile.IATBatches[0].Entries[0].Addenda12.String()+"\n")
-	fmt.Printf("Addenda13: %s", achFile.IATBatches[0].Entries[0].Addenda13.String()+"\n")
-	fmt.Printf("Addenda14: %s", achFile.IATBatches[0].Entries[0].Addenda14.String()+"\n")
-	fmt.Printf("Addenda15: %s", achFile.IATBatches[0].Entries[0].Addenda15.String()+"\n")
-	fmt.Printf("Addenda16: %s", achFile.IATBatches[0].Entries[0].Addenda16.String()+"\n")
-	fmt.Printf("Addenda17: %s", achFile.IATBatches[0].Entries[0].Addenda17[0].String()+"\n")
-	fmt.Printf("Addenda18: %s", achFile.IATBatches[0].Entries[0].Addenda18[0].String()+"\n")
-	fmt.Printf("Total File Debit Amount: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Credit Entry: %s", achFile.IATBatches[0].Entries[1].String()+"\n")
-	fmt.Printf("Addenda10: %s", achFile.IATBatches[0].Entries[1].Addenda10.String()+"\n")
-	fmt.Printf("Addenda11: %s", achFile.IATBatches[0].Entries[1].Addenda11.String()+"\n")
-	fmt.Printf("Addenda12: %s", achFile.IATBatches[0].Entries[1].Addenda12.String()+"\n")
-	fmt.Printf("Addenda13: %s", achFile.IATBatches[0].Entries[1].Addenda13.String()+"\n")
-	fmt.Printf("Addenda14: %s", achFile.IATBatches[0].Entries[1].Addenda14.String()+"\n")
-	fmt.Printf("Addenda15: %s", achFile.IATBatches[0].Entries[1].Addenda15.String()+"\n")
-	fmt.Printf("Addenda16: %s", achFile.IATBatches[0].Entries[1].Addenda16.String()+"\n")
-	fmt.Printf("Addenda17: %s", achFile.IATBatches[0].Entries[1].Addenda17[0].String()+"\n")
-	fmt.Printf("Addenda18: %s", achFile.IATBatches[0].Entries[1].Addenda18[0].String()+"\n")
-	fmt.Printf("Total File Credit Amount: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
+	fmt.Printf("SEC Code: %s\n", achFile.IATBatches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Debit Entry: %s\n", achFile.IATBatches[0].Entries[0].String())
+	fmt.Printf("Addenda10: %s\n", achFile.IATBatches[0].Entries[0].Addenda10.String())
+	fmt.Printf("Addenda11: %s\n", achFile.IATBatches[0].Entries[0].Addenda11.String())
+	fmt.Printf("Addenda12: %s\n", achFile.IATBatches[0].Entries[0].Addenda12.String())
+	fmt.Printf("Addenda13: %s\n", achFile.IATBatches[0].Entries[0].Addenda13.String())
+	fmt.Printf("Addenda14: %s\n", achFile.IATBatches[0].Entries[0].Addenda14.String())
+	fmt.Printf("Addenda15: %s\n", achFile.IATBatches[0].Entries[0].Addenda15.String())
+	fmt.Printf("Addenda16: %s\n", achFile.IATBatches[0].Entries[0].Addenda16.String())
+	fmt.Printf("Addenda17: %s\n", achFile.IATBatches[0].Entries[0].Addenda17[0].String())
+	fmt.Printf("Addenda18: %s\n", achFile.IATBatches[0].Entries[0].Addenda18[0].String())
+	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Credit Entry: %s\n", achFile.IATBatches[0].Entries[1].String())
+	fmt.Printf("Addenda10: %s\n", achFile.IATBatches[0].Entries[1].Addenda10.String())
+	fmt.Printf("Addenda11: %s\n", achFile.IATBatches[0].Entries[1].Addenda11.String())
+	fmt.Printf("Addenda12: %s\n", achFile.IATBatches[0].Entries[1].Addenda12.String())
+	fmt.Printf("Addenda13: %s\n", achFile.IATBatches[0].Entries[1].Addenda13.String())
+	fmt.Printf("Addenda14: %s\n", achFile.IATBatches[0].Entries[1].Addenda14.String())
+	fmt.Printf("Addenda15: %s\n", achFile.IATBatches[0].Entries[1].Addenda15.String())
+	fmt.Printf("Addenda16: %s\n", achFile.IATBatches[0].Entries[1].Addenda16.String())
+	fmt.Printf("Addenda17: %s\n", achFile.IATBatches[0].Entries[1].Addenda17[0].String())
+	fmt.Printf("Addenda18: %s\n", achFile.IATBatches[0].Entries[1].Addenda18[0].String())
+	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
 
 	// Output:
 	// SEC Code: IAT

--- a/examples/example_mteRead_debit_test.go
+++ b/examples/example_mteRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_mteReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("Total Amount: %d\n", achFile.Batches[0].GetEntries()[0].Amount)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Addenda02: %s\n", achFile.Batches[0].GetEntries()[0].Addenda02.String())
 

--- a/examples/example_mteRead_debit_test.go
+++ b/examples/example_mteRead_debit_test.go
@@ -28,31 +28,31 @@ import (
 )
 
 func Example_mteReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "mte-read.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		panic(fmt.Sprintf("Issue reading file: %+v \n", err))
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount: %s", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Addenda02: %s", achFile.Batches[0].GetEntries()[0].Addenda02.String()+"\n")
+	fmt.Printf("Total Amount: %s\n", strconv.Itoa(achFile.Batches[0].GetEntries()[0].Amount))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Addenda02: %s\n", achFile.Batches[0].GetEntries()[0].Addenda02.String())
 
 	// Output:
 	// Total Amount: 10000
 	// SEC Code: MTE
 	// Addenda02: 702          2005091234561224      321 East Market Street     ANYTOWN        VA231380100000001
-
 }

--- a/examples/example_mteWrite_debit_test.go
+++ b/examples/example_mteWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_mteWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.MTE
 	bh.CompanyEntryDescription = "CASH WITHDRAW"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "23138010"
 
 	entry := ach.NewEntryDetail()
@@ -72,11 +72,11 @@ func Example_mteWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -84,5 +84,4 @@ func Example_mteWriteDebit() {
 	// 627031300012744-5678-99      0000010000031300010000001JANE DOE                1231380100000001
 	// 82250000020003130001000000010000000000000000231380104                          231380100000001
 	// 9000001000001000000020003130001000000010000000000000000
-
 }

--- a/examples/example_popRead_debit_test.go
+++ b/examples/example_popRead_debit_test.go
@@ -53,7 +53,8 @@ func Example_popReadDebit() {
 	fmt.Printf("POP Terminal City: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[9:13])
 	fmt.Printf("POP Terminal State: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[13:15])
 
-	// Output: Total Amount Debit: 250500
+	// Output:
+	// Total Amount Debit: 250500
 	// SEC Code: POP
 	// POP Check Serial Number: 123456789
 	// POP Terminal City: PHIL

--- a/examples/example_popRead_debit_test.go
+++ b/examples/example_popRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_popReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("POP Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[0:9])
 	fmt.Printf("POP Terminal City: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[9:13])

--- a/examples/example_popRead_debit_test.go
+++ b/examples/example_popRead_debit_test.go
@@ -19,37 +19,39 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_popReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "pop-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("POP Check Serial Number: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber[0:9]+"\n")
-	fmt.Printf("POP Terminal City: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber[9:13]+"\n")
-	fmt.Printf("POP Terminal State: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber[13:15]+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("POP Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[0:9])
+	fmt.Printf("POP Terminal City: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[9:13])
+	fmt.Printf("POP Terminal State: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[13:15])
 
 	// Output: Total Amount Debit: 250500
 	// SEC Code: POP

--- a/examples/example_popWrite_debit_test.go
+++ b/examples/example_popWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_popWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.POP
 	bh.CompanyEntryDescription = "ACH POP"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -62,11 +62,11 @@ func Example_popWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -74,5 +74,4 @@ func Example_popWriteDebit() {
 	// 62723138010412345678         0000250500123456   PHILPAWade Arnold             0121042880000001
 	// 82250000010023138010000000250500000000000000231380104                          121042880000001
 	// 9000001000001000000010023138010000000250500000000000000
-
 }

--- a/examples/example_posRead_debit_test.go
+++ b/examples/example_posRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_posReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("POS Card Transaction Type: %s\n", achFile.Batches[0].GetEntries()[0].DiscretionaryData)
 	fmt.Printf("POS Trace Number: %s\n", achFile.Batches[0].GetEntries()[0].TraceNumber)

--- a/examples/example_posRead_debit_test.go
+++ b/examples/example_posRead_debit_test.go
@@ -19,36 +19,38 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_posReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "pos-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("POS Card Transaction Type: %s", achFile.Batches[0].GetEntries()[0].DiscretionaryData+"\n")
-	fmt.Printf("POS Trace Number: %s", achFile.Batches[0].GetEntries()[0].TraceNumber+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("POS Card Transaction Type: %s\n", achFile.Batches[0].GetEntries()[0].DiscretionaryData)
+	fmt.Printf("POS Trace Number: %s\n", achFile.Batches[0].GetEntries()[0].TraceNumber)
 
 	// Output:
 	// Total Amount Debit: 100000000

--- a/examples/example_posWrite_debit_test.go
+++ b/examples/example_posWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_posWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.POS
 	bh.CompanyEntryDescription = "Sale"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -74,12 +74,12 @@ func Example_posWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda02.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda02.String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_ppdRead_credit_test.go
+++ b/examples/example_ppdRead_credit_test.go
@@ -27,29 +27,29 @@ import (
 	"github.com/moov-io/ach"
 )
 
-// Example_ppdReadCredit reads a PPD credit file
 func Example_ppdReadCredit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "ppd-credit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Total File Debit Amount: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Total File Credit Amount: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
 
 	// Output:
 	// SEC Code: PPD

--- a/examples/example_ppdRead_credit_test.go
+++ b/examples/example_ppdRead_credit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -48,8 +47,8 @@ func Example_ppdReadCredit() {
 	}
 
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
-	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total File Debit Amount: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total File Credit Amount: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 
 	// Output:
 	// SEC Code: PPD

--- a/examples/example_ppdRead_debit_test.go
+++ b/examples/example_ppdRead_debit_test.go
@@ -27,29 +27,29 @@ import (
 	"github.com/moov-io/ach"
 )
 
-// Example_ppdReadDebit reads a PPD debit file
 func Example_ppdReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "ppd-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Total File Debit Amount: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Total File Credit Amount: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
 
 	// Output:
 	// SEC Code: PPD

--- a/examples/example_ppdRead_debit_test.go
+++ b/examples/example_ppdRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -48,8 +47,8 @@ func Example_ppdReadDebit() {
 	}
 
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
-	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total File Debit Amount: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total File Credit Amount: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 
 	// Output:
 	// SEC Code: PPD

--- a/examples/example_ppdRead_segmentFile_test.go
+++ b/examples/example_ppdRead_segmentFile_test.go
@@ -19,56 +19,57 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_ppdReadSegmentFile() {
-	// open a file for reading. Any io.Reader Can be used
+	// Open a file for reading, any io.Reader can be used
 	fCredit, err := os.Open(filepath.Join("testdata", "segmentFile-ppd-credit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
-	r := ach.NewReader(fCredit)
-	achFile, err := r.Read()
+	rCredit := ach.NewReader(fCredit)
+	achFileCredit, err := rCredit.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
+	if err := achFileCredit.Create(); err != nil {
+		log.Fatalf("creating file: %v\n", err)
 	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
-	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+	// Validate the ACH file
+	if err := achFileCredit.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	// open a file for reading. Any io.Reader Can be used
+	// Open a file for reading, any io.Reader can be used
 	fDebit, err := os.Open(filepath.Join("testdata", "segmentFile-ppd-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	rDebit := ach.NewReader(fDebit)
 	achFileDebit, err := rDebit.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFileDebit.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
+	if err := achFileDebit.Create(); err != nil {
+		log.Fatalf("creating file: %v\n", err)
 	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
-	if achFileDebit.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+	// Validate the ACH file
+	if err := achFileDebit.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Credit Amount: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Total Debit Amount: %s", strconv.Itoa(achFileDebit.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFileDebit.Batches[0].GetHeader().StandardEntryClassCode+"\n")
+	fmt.Printf("Total Credit Amount: %s\n", strconv.Itoa(achFileCredit.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFileCredit.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Total Debit Amount: %s\n", strconv.Itoa(achFileDebit.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFileDebit.Batches[0].GetHeader().StandardEntryClassCode)
 
 	// Output:
 	// Total Credit Amount: 200000000

--- a/examples/example_ppdRead_segmentFile_test.go
+++ b/examples/example_ppdRead_segmentFile_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -66,9 +65,9 @@ func Example_ppdReadSegmentFile() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Credit Amount: %s\n", strconv.Itoa(achFileCredit.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total Credit Amount: %d\n", achFileCredit.Control.TotalCreditEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFileCredit.Batches[0].GetHeader().StandardEntryClassCode)
-	fmt.Printf("Total Debit Amount: %s\n", strconv.Itoa(achFileDebit.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Debit Amount: %d\n", achFileDebit.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFileDebit.Batches[0].GetHeader().StandardEntryClassCode)
 
 	// Output:

--- a/examples/example_ppdWrite_credit_test.go
+++ b/examples/example_ppdWrite_credit_test.go
@@ -34,8 +34,7 @@ func Example_ppdWriteCredit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.PPD
 	bh.CompanyEntryDescription = "REG.SALARY"
-	// need EffectiveEntryDate to be fixed so it can match output
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -62,11 +61,11 @@ func Example_ppdWriteCredit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_ppdWrite_debit_test.go
+++ b/examples/example_ppdWrite_debit_test.go
@@ -35,8 +35,7 @@ func Example_ppdWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.PPD
 	bh.CompanyEntryDescription = "REG.SALARY"
-	// need EffectiveEntryDate to be fixed so it can match output
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -62,11 +61,11 @@ func Example_ppdWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -74,5 +73,4 @@ func Example_ppdWriteDebit() {
 	// 627231380104123456789        0200000000               Debit Account           0121042880000001
 	// 82250000010023138010000200000000000000000000231380104                          121042880000001
 	// 9000001000001000000010023138010000200000000000000000000
-
 }

--- a/examples/example_ppdWrite_segmentFile_test.go
+++ b/examples/example_ppdWrite_segmentFile_test.go
@@ -81,5 +81,4 @@ func Example_ppdWriteSegmentFile() {
 	// credit 0: 622231380104987654321        0100000000               Credit Account 1        0121042880000002
 	// credit 1: 622231380104837098765        0100000000               Credit Account 2        0121042880000003
 	// debit 0: 627231380104123456789        0200000000               Debit Account           0121042880000001
-
 }

--- a/examples/example_rckRead_debit_test.go
+++ b/examples/example_rckRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_rckReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 

--- a/examples/example_rckRead_debit_test.go
+++ b/examples/example_rckRead_debit_test.go
@@ -28,28 +28,28 @@ import (
 )
 
 func Example_rckReadDebit() {
-	// open a file for reading. Any io.Reader Can be used
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "rck-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Check Serial Number: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 
 	// Output:
 	// Total Amount Debit: 2400

--- a/examples/example_rckWrite_debit_test.go
+++ b/examples/example_rckWrite_debit_test.go
@@ -33,11 +33,11 @@ func Example_rckWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.RCK
 	bh.CompanyEntryDescription = "REDEPCHECK"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	// Identifies the receivers account information
-	// can be multiple entry's per batch
+	// can be multiple entries per batch
 	entry := ach.NewEntryDetail()
 	entry.TransactionCode = ach.CheckingDebit
 	entry.SetRDFI("231380104")
@@ -62,11 +62,11 @@ func Example_rckWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_shrRead_debit_test.go
+++ b/examples/example_shrRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_shrReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("SHR Card Expiration Date: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[0:4])
 	fmt.Printf("SHR Document Reference Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[4:15])

--- a/examples/example_shrRead_debit_test.go
+++ b/examples/example_shrRead_debit_test.go
@@ -19,37 +19,39 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_shrReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "shr-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("SHR Card Expiration Date: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber[0:4]+"\n")
-	fmt.Printf("SHR Document Reference Number: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber[4:15]+"\n")
-	fmt.Printf("SHR Individual Card Account Number: %s", achFile.Batches[0].GetEntries()[0].IndividualName)
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("SHR Card Expiration Date: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[0:4])
+	fmt.Printf("SHR Document Reference Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber[4:15])
+	fmt.Printf("SHR Individual Card Account Number: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName)
 
 	// Output:
 	// Total Amount Debit: 100000000

--- a/examples/example_shrWrite_debit_test.go
+++ b/examples/example_shrWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_shrWrite() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.SHR
 	bh.CompanyEntryDescription = "Payment"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -76,12 +76,12 @@ func Example_shrWrite() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda02.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda02.String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_telRead_debit_test.go
+++ b/examples/example_telRead_debit_test.go
@@ -28,29 +28,29 @@ import (
 )
 
 func Example_telReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "tel-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 
 	// Output:
 	// Total Amount Debit: 50000
 	// SEC Code: TEL
-
 }

--- a/examples/example_telRead_debit_test.go
+++ b/examples/example_telRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_telReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 
 	// Output:

--- a/examples/example_telWrite_debit_test.go
+++ b/examples/example_telWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_telWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.TEL
 	bh.CompanyEntryDescription = "Payment"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -59,11 +59,11 @@ func Example_telWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -71,5 +71,4 @@ func Example_telWriteDebit() {
 	// 62723138010412345678         0000050000               Receiver Account Name   0121042880000001
 	// 82250000010023138010000000050000000000000000231380104                          121042880000001
 	// 9000001000001000000010023138010000000050000000000000000
-
 }

--- a/examples/example_trcRead_debit_test.go
+++ b/examples/example_trcRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_trcReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 	fmt.Printf("Process Control Field: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName[0:6])

--- a/examples/example_trcRead_debit_test.go
+++ b/examples/example_trcRead_debit_test.go
@@ -28,30 +28,31 @@ import (
 )
 
 func Example_trcReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "trc-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Check Serial Number: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber+"\n")
-	fmt.Printf("Process Control Field: %s", achFile.Batches[0].GetEntries()[0].IndividualName[0:6]+"\n")
-	fmt.Printf("Item Research Number: %s", achFile.Batches[0].GetEntries()[0].IndividualName[6:22]+"\n")
-	fmt.Printf("Item Type Indicator: %s", achFile.Batches[0].GetEntries()[0].DiscretionaryData+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
+	fmt.Printf("Process Control Field: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName[0:6])
+	fmt.Printf("Item Research Number: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName[6:22])
+	fmt.Printf("Item Type Indicator: %s\n", achFile.Batches[0].GetEntries()[0].DiscretionaryData)
 
 	// Output:
 	// Total Amount Debit: 250000

--- a/examples/example_trcWrite_debit_test.go
+++ b/examples/example_trcWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_trcWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.TRC
 	bh.CompanyEntryDescription = "ACH TRC"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -62,16 +62,16 @@ func Example_trcWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
-	// Output: 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
+	// Output:
+	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
 	// 5225Payee Name                          231380104 TRCACH TRC         190816   1121042880000001
 	// 62723138010412345678         0000250000123456789012345CHECK11234567890123456010121042880000001
 	// 82250000010023138010000000250000000000000000231380104                          121042880000001
 	// 9000001000001000000010023138010000000250000000000000000
-
 }

--- a/examples/example_trxRead_debit_test.go
+++ b/examples/example_trxRead_debit_test.go
@@ -19,38 +19,40 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
 func Example_trxReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "trx-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Total Amount Credit: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Item Type Indicator: %s", achFile.Batches[0].GetEntries()[0].ItemTypeIndicator()+"\n")
-	fmt.Printf("Addenda1: %s", achFile.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("Addenda2: %s", achFile.Batches[0].GetEntries()[0].Addenda05[1].String()+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Item Type Indicator: %s\n", achFile.Batches[0].GetEntries()[0].ItemTypeIndicator())
+	fmt.Printf("Addenda1: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Printf("Addenda2: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[1].String())
 
 	// Output:
 	// Total Amount Debit: 250000
@@ -59,5 +61,4 @@ func Example_trxReadDebit() {
 	// Item Type Indicator: 01
 	// Addenda1: 705Debit First Account                                                             00010000001
 	// Addenda2: 705Debit Second Account                                                            00020000001
-
 }

--- a/examples/example_trxRead_debit_test.go
+++ b/examples/example_trxRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,8 +46,8 @@ func Example_trxReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total Amount Credit: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total Amount Credit: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Item Type Indicator: %s\n", achFile.Batches[0].GetEntries()[0].ItemTypeIndicator())
 	fmt.Printf("Addenda1: %s\n", achFile.Batches[0].GetEntries()[0].Addenda05[0].String())

--- a/examples/example_trxWrite_debit_test.go
+++ b/examples/example_trxWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_trxWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.TRX
 	bh.CompanyEntryDescription = "ACH TRX"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -75,13 +75,13 @@ func Example_trxWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda05[1].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda05[1].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678

--- a/examples/example_webRead_credit_test.go
+++ b/examples/example_webRead_credit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -48,8 +47,8 @@ func Example_webReadCredit() {
 	}
 
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
-	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
-	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
+	fmt.Printf("Total File Debit Amount: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
+	fmt.Printf("Total File Credit Amount: %d\n", achFile.Control.TotalCreditEntryDollarAmountInFile)
 
 	// Output:
 	// SEC Code: WEB

--- a/examples/example_webRead_credit_test.go
+++ b/examples/example_webRead_credit_test.go
@@ -19,41 +19,40 @@ package examples
 
 import (
 	"fmt"
-	"github.com/moov-io/ach"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/moov-io/ach"
 )
 
-// Example_webReadCredit reads a WEB credit file
 func Example_webReadCredit() {
-	// open a file for reading. Any io.Reader Can be used
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "web-credit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Total File Debit Amount: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("Total File Credit Amount: %s", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile)+"\n")
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Total File Debit Amount: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total File Credit Amount: %s\n", strconv.Itoa(achFile.Control.TotalCreditEntryDollarAmountInFile))
 
 	// Output:
 	// SEC Code: WEB
 	// Total File Debit Amount: 0
 	// Total File Credit Amount: 10000
-
 }

--- a/examples/example_webWrite_credit_test.go
+++ b/examples/example_webWrite_credit_test.go
@@ -34,8 +34,7 @@ func Example_webWriteCredit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.WEB
 	bh.CompanyEntryDescription = "Subscribe"
-	// need EffectiveEntryDate to be fixed so it can match output
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -57,7 +56,6 @@ func Example_webWriteCredit() {
 	// build the batch
 	batch := ach.NewBatchWEB(bh)
 	batch.AddEntry(entry)
-
 	if err := batch.Create(); err != nil {
 		log.Fatalf("Unexpected error building batch: %s\n", err)
 	}
@@ -70,12 +68,12 @@ func Example_webWriteCredit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].Addenda05[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetEntries()[0].Addenda05[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -84,5 +82,4 @@ func Example_webWriteCredit() {
 	// 705PAY-GATE payment\                                                               00010000001
 	// 82200000020023138010000000000000000000010000231380104                          121042880000001
 	// 9000001000001000000020023138010000000000000000000010000
-
 }

--- a/examples/example_xckRead_debit_test.go
+++ b/examples/example_xckRead_debit_test.go
@@ -28,29 +28,30 @@ import (
 )
 
 func Example_xckReadDebit() {
+	// Open a file for reading, any io.Reader can be used
 	f, err := os.Open(filepath.Join("testdata", "xck-debit.ach"))
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	r := ach.NewReader(f)
 	achFile, err := r.Read()
 	if err != nil {
-		fmt.Printf("Issue reading file: %+v \n", err)
+		log.Fatalf("reading file: %v\n", err)
 	}
-	// ensure we have a validated file structure
-	if achFile.Validate(); err != nil {
-		fmt.Printf("Could not validate entire read file: %v", err)
-	}
-	// If you trust the file but it's formatting is off building will probably resolve the malformed file.
+	// If you trust the file but its formatting is off, building will probably resolve the malformed file
 	if err := achFile.Create(); err != nil {
-		fmt.Printf("Could not create file with read properties: %v", err)
+		log.Fatalf("creating file: %v\n", err)
+	}
+	// Validate the ACH file
+	if err := achFile.Validate(); err != nil {
+		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile)+"\n")
-	fmt.Printf("SEC Code: %s", achFile.Batches[0].GetHeader().StandardEntryClassCode+"\n")
-	fmt.Printf("Check Serial Number: %s", achFile.Batches[0].GetEntries()[0].IdentificationNumber+"\n")
-	fmt.Printf("Process Control Field: %s", achFile.Batches[0].GetEntries()[0].IndividualName[0:6]+"\n")
-	fmt.Printf("Item Research Number: %s", achFile.Batches[0].GetEntries()[0].IndividualName[6:22]+"\n")
+	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
+	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
+	fmt.Printf("Process Control Field: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName[0:6])
+	fmt.Printf("Item Research Number: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName[6:22])
 
 	// Output:
 	// Total Amount Debit: 250000
@@ -58,5 +59,4 @@ func Example_xckReadDebit() {
 	// Check Serial Number: 123456789012345
 	// Process Control Field: CHECK1
 	// Item Research Number: 1234567890123456
-
 }

--- a/examples/example_xckRead_debit_test.go
+++ b/examples/example_xckRead_debit_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/moov-io/ach"
 )
@@ -47,7 +46,7 @@ func Example_xckReadDebit() {
 		log.Fatalf("validating file: %v\n", err)
 	}
 
-	fmt.Printf("Total Amount Debit: %s\n", strconv.Itoa(achFile.Control.TotalDebitEntryDollarAmountInFile))
+	fmt.Printf("Total Amount Debit: %d\n", achFile.Control.TotalDebitEntryDollarAmountInFile)
 	fmt.Printf("SEC Code: %s\n", achFile.Batches[0].GetHeader().StandardEntryClassCode)
 	fmt.Printf("Check Serial Number: %s\n", achFile.Batches[0].GetEntries()[0].IdentificationNumber)
 	fmt.Printf("Process Control Field: %s\n", achFile.Batches[0].GetEntries()[0].IndividualName[0:6])

--- a/examples/example_xckWrite_debit_test.go
+++ b/examples/example_xckWrite_debit_test.go
@@ -33,7 +33,7 @@ func Example_xckWriteDebit() {
 	bh.CompanyIdentification = fh.ImmediateOrigin
 	bh.StandardEntryClassCode = ach.XCK
 	bh.CompanyEntryDescription = "ACH XCK"
-	bh.EffectiveEntryDate = "190816"
+	bh.EffectiveEntryDate = "190816" // need EffectiveEntryDate to be fixed so it can match output
 	bh.ODFIIdentification = "121042882"
 
 	entry := ach.NewEntryDetail()
@@ -61,11 +61,11 @@ func Example_xckWriteDebit() {
 		log.Fatalf("Unexpected error building file: %s\n", err)
 	}
 
-	fmt.Printf("%s", file.Header.String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetHeader().String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetEntries()[0].String()+"\n")
-	fmt.Printf("%s", file.Batches[0].GetControl().String()+"\n")
-	fmt.Printf("%s", file.Control.String()+"\n")
+	fmt.Println(file.Header.String())
+	fmt.Println(file.Batches[0].GetHeader().String())
+	fmt.Println(file.Batches[0].GetEntries()[0].String())
+	fmt.Println(file.Batches[0].GetControl().String())
+	fmt.Println(file.Control.String())
 
 	// Output:
 	// 101 031300012 2313801041908161055A094101Federal Reserve Bank   My Bank Name           12345678
@@ -73,5 +73,4 @@ func Example_xckWriteDebit() {
 	// 62723138010412345678         0000250000123456789012345CHECK11234567890123456  0121042880000001
 	// 82250000010023138010000000250000000000000000231380104                          121042880000001
 	// 9000001000001000000010023138010000000250000000000000000
-
 }


### PR DESCRIPTION
Made read and write examples consistent by cleaning up formatting, comments, and a few minor bugs. Referred to https://github.com/moov-io/ach/pull/847 for many of the changes.

If these changes are helpful, I can do the same for the almost-identical read/write test files in the 'test' directory.