### PR TITLE
fix wget command to fetch achcli binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The package [`github.com/moov-io/ach`](https://pkg.go.dev/github.com/moov-io/ach
 On each release there's an `achcli` utility released. This tool can display ACH files in a human-readable format which is easier to read than their plaintext format.
 
 ```
-$ wget -O achcli https://github.com/moov-io/ach/releases/download/v1.6.1/achcli-darwin-amd64 && chmod +x achcli
+$ wget -O ./achcli https://github.com/moov-io/ach/releases/download/v1.6.3/achcli-darwin-amd64 && chmod +x ./achcli
 
 $ achcli test/testdata/ppd-debit.ach
 Describing ACH file 'test/testdata/ppd-debit.ach'


### PR DESCRIPTION
This PR fixes an issue with using the `wget` command to pull the `achcli` library. Using `./achcli` over `achcli` fixes it.

A comment from one of our engineers: 
> On many *nix systems the former won’t work as a security feature, so the binary would need to be on your path