### PR TITLE
Remove parentheses from commented function references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ Create takes the Batch Header and Entry details and creates the proper sequence 
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchMTE) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/addenda02.go
+++ b/addenda02.go
@@ -59,7 +59,7 @@ type Addenda02 struct {
 	TerminalState string `json:"terminalState"`
 	// TraceNumber Standard Entry Detail Trace Number
 	//
-	// Use TraceNumberField() for a properly formatted string representation.
+	// Use TraceNumberField for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 	// validator is composed for data validation
 	validator
@@ -77,7 +77,7 @@ func NewAddenda02() *Addenda02 {
 
 // Parse takes the input record string and parses the Addenda02 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda02 *Addenda02) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda05.go
+++ b/addenda05.go
@@ -59,7 +59,7 @@ func NewAddenda05() *Addenda05 {
 
 // Parse takes the input record string and parses the Addenda05 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda05 *Addenda05) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda10.go
+++ b/addenda10.go
@@ -72,7 +72,7 @@ func NewAddenda10() *Addenda10 {
 
 // Parse takes the input record string and parses the Addenda10 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda10 *Addenda10) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda11.go
+++ b/addenda11.go
@@ -63,7 +63,7 @@ func NewAddenda11() *Addenda11 {
 
 // Parse takes the input record string and parses the Addenda11 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda11 *Addenda11) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda12.go
+++ b/addenda12.go
@@ -68,7 +68,7 @@ func NewAddenda12() *Addenda12 {
 
 // Parse takes the input record string and parses the Addenda12 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda12 *Addenda12) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda13.go
+++ b/addenda13.go
@@ -84,7 +84,7 @@ func NewAddenda13() *Addenda13 {
 
 // Parse takes the input record string and parses the Addenda13 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda13 *Addenda13) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda14.go
+++ b/addenda14.go
@@ -80,7 +80,7 @@ func NewAddenda14() *Addenda14 {
 
 // Parse takes the input record string and parses the Addenda14 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda14 *Addenda14) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda15.go
+++ b/addenda15.go
@@ -64,7 +64,7 @@ func NewAddenda15() *Addenda15 {
 
 // Parse takes the input record string and parses the Addenda15 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda15 *Addenda15) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda16.go
+++ b/addenda16.go
@@ -67,7 +67,7 @@ func NewAddenda16() *Addenda16 {
 
 // Parse takes the input record string and parses the Addenda16 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda16 *Addenda16) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda17.go
+++ b/addenda17.go
@@ -63,7 +63,7 @@ func NewAddenda17() *Addenda17 {
 
 // Parse takes the input record string and parses the Addenda17 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda17 *Addenda17) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda18.go
+++ b/addenda18.go
@@ -81,7 +81,7 @@ func NewAddenda18() *Addenda18 {
 
 // Parse takes the input record string and parses the Addenda18 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda18 *Addenda18) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda98.go
+++ b/addenda98.go
@@ -46,7 +46,7 @@ type Addenda98 struct {
 	CorrectedData string `json:"correctedData"`
 	// TraceNumber matches the Entry Detail Trace Number of the entry being returned.
 	//
-	// Use TraceNumberField() for a properly formatted string representation.
+	// Use TraceNumberField for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 
 	// validator is composed for data validation
@@ -83,7 +83,7 @@ func NewAddenda98() *Addenda98 {
 
 // Parse takes the input record string and parses the Addenda98 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (addenda98 *Addenda98) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/addenda99.go
+++ b/addenda99.go
@@ -62,7 +62,7 @@ type Addenda99 struct {
 	AddendaInformation string `json:"addendaInformation,omitempty"`
 	// TraceNumber matches the Entry Detail Trace Number of the entry being returned.
 	//
-	// Use TraceNumberField() for a properly formatted string representation.
+	// Use TraceNumberField for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 
 	// validator is composed for data validation
@@ -91,7 +91,7 @@ func NewAddenda99() *Addenda99 {
 
 // Parse takes the input record string and parses the Addenda99 values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (Addenda99 *Addenda99) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/advEntryDetail.go
+++ b/advEntryDetail.go
@@ -121,7 +121,7 @@ func NewADVEntryDetail() *ADVEntryDetail {
 }
 
 // Parse takes the input record string and parses the ADVEntryDetail values
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm
 // successful parsing and data validity.
 
 // Parse ADVEntryDetail

--- a/advFileControl.go
+++ b/advFileControl.go
@@ -57,7 +57,7 @@ type ADVFileControl struct {
 }
 
 // Parse takes the input record string and parses the FileControl values
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm
 // successful parsing and data validity.
 func (fc *ADVFileControl) Parse(record string) {
 	if utf8.RuneCountInString(record) < 71 {

--- a/batch.go
+++ b/batch.go
@@ -280,7 +280,7 @@ func ConvertBatchType(b Batch) Batcher {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *Batch) Create() error {
 	return errors.New("use an implementation of batch or NewBatch")
 }
@@ -767,7 +767,7 @@ func (batch *Batch) calculateEntryHash() int {
 		}
 	}
 
-	// This follows what is done in BatchControl.Parse()
+	// This follows what is done in BatchControl.Parse
 	// EntryHash is essentially the sum of all the RDFI routing numbers in the batch. If the sum exceeds 10 digits
 	// (because you have lots of Entry Detail Records), lop off the most significant digits of the sum until there
 	// are only 10.

--- a/batchACK.go
+++ b/batchACK.go
@@ -76,7 +76,7 @@ func (batch *BatchACK) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchACK) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchADV.go
+++ b/batchADV.go
@@ -73,7 +73,7 @@ func (batch *BatchADV) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchADV) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchARC.go
+++ b/batchARC.go
@@ -94,7 +94,7 @@ func (batch *BatchARC) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchARC) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchATX.go
+++ b/batchATX.go
@@ -92,7 +92,7 @@ func (batch *BatchATX) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchATX) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -99,7 +99,7 @@ func (batch *BatchBOC) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchBOC) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchCCD.go
+++ b/batchCCD.go
@@ -65,7 +65,7 @@ func (batch *BatchCCD) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchCCD) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchCIE.go
+++ b/batchCIE.go
@@ -86,7 +86,7 @@ func (batch *BatchCIE) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchCIE) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchCOR.go
+++ b/batchCOR.go
@@ -90,7 +90,7 @@ func (batch *BatchCOR) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchCOR) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchCTX.go
+++ b/batchCTX.go
@@ -90,7 +90,7 @@ func (batch *BatchCTX) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchCTX) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchControl.go
+++ b/batchControl.go
@@ -87,7 +87,7 @@ type BatchControl struct {
 
 // Parse takes the input record string and parses the EntryDetail values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (bc *BatchControl) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/batchDNE.go
+++ b/batchDNE.go
@@ -84,7 +84,7 @@ func (batch *BatchDNE) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchDNE) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchENR.go
+++ b/batchENR.go
@@ -85,7 +85,7 @@ func (batch *BatchENR) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchENR) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -151,7 +151,7 @@ func NewBatchHeader() *BatchHeader {
 
 // Parse takes the input record string and parses the BatchHeader values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (bh *BatchHeader) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/batchMTE.go
+++ b/batchMTE.go
@@ -83,7 +83,7 @@ func (batch *BatchMTE) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchMTE) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchPOP.go
+++ b/batchPOP.go
@@ -94,7 +94,7 @@ func (batch *BatchPOP) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchPOP) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -88,7 +88,7 @@ func (batch *BatchPOS) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchPOS) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchPPD.go
+++ b/batchPPD.go
@@ -66,7 +66,7 @@ func (batch *BatchPPD) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchPPD) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -88,7 +88,7 @@ func (batch *BatchRCK) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchRCK) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -102,7 +102,7 @@ func (batch *BatchSHR) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchSHR) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchTEL.go
+++ b/batchTEL.go
@@ -65,7 +65,7 @@ func (batch *BatchTEL) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchTEL) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchTRC.go
+++ b/batchTRC.go
@@ -82,7 +82,7 @@ func (batch *BatchTRC) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchTRC) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchTRX.go
+++ b/batchTRX.go
@@ -88,7 +88,7 @@ func (batch *BatchTRX) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchTRX) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -64,7 +64,7 @@ func (batch *BatchWEB) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchWEB) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/batchXCK.go
+++ b/batchXCK.go
@@ -86,7 +86,7 @@ func (batch *BatchXCK) Validate() error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (batch *BatchXCK) Create() error {
 	// generates sequence numbers and batch control
 	if err := batch.build(); err != nil {

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -73,7 +73,7 @@ type EntryDetail struct {
 	// in the associated Entry Detail Record, since the Trace Number is associated
 	// with an entry or item rather than a physical record.
 	//
-	// Use TraceNumberField() for a properly formatted string representation.
+	// Use TraceNumberField for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 	// Addenda02 for use with StandardEntryClassCode MTE, POS, and SHR
 	Addenda02 *Addenda02 `json:"addenda02,omitempty"`
@@ -193,7 +193,7 @@ func NewEntryDetail() *EntryDetail {
 
 // Parse takes the input record string and parses the EntryDetail values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (ed *EntryDetail) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/file.go
+++ b/file.go
@@ -100,7 +100,7 @@ type advFileControl struct {
 //
 // Callers should always check for a nil-error before using the returned file.
 //
-// The File returned may not be valid and callers should confirm with Validate().
+// The File returned may not be valid and callers should confirm with Validate.
 // Invalid files may be rejected by other Financial Institutions or ACH tools.
 //
 // Date and Time fields in formats: RFC 3339 and ISO 8601 will be parsed and rewritten
@@ -419,7 +419,7 @@ func (f *File) Create() error {
 				f.Batches[i].GetControl().BatchNumber = batchSeq
 			}
 			batchSeq++
-			// sum file entry and addenda records. Assume batch.Create() batch properly calculated control
+			// sum file entry and addenda records. Assume batch.Create batch properly calculated control
 			fileEntryAddendaCount = fileEntryAddendaCount + batch.GetControl().EntryAddendaCount
 			// add 2 for Batch header/control + entry added count
 			totalRecordsInFile = totalRecordsInFile + 2 + batch.GetControl().EntryAddendaCount
@@ -435,7 +435,7 @@ func (f *File) Create() error {
 				f.IATBatches[i].GetControl().BatchNumber = batchSeq
 			}
 			batchSeq++
-			// sum file entry and addenda records. Assume batch.Create() batch properly calculated control
+			// sum file entry and addenda records. Assume batch.Create batch properly calculated control
 			fileEntryAddendaCount = fileEntryAddendaCount + iatBatch.GetControl().EntryAddendaCount
 			// add 2 for Batch header/control + entry added count
 			totalRecordsInFile = totalRecordsInFile + 2 + iatBatch.GetControl().EntryAddendaCount
@@ -801,7 +801,7 @@ func (f *File) createFileADV() error {
 			f.Batches[i].GetADVControl().BatchNumber = batchSeq
 		}
 		batchSeq++
-		// sum file entry and addenda records. Assume batch.Create() batch properly calculated control
+		// sum file entry and addenda records. Assume batch.Create batch properly calculated control
 		fileEntryAddendaCount = fileEntryAddendaCount + batch.GetADVControl().EntryAddendaCount
 		// add 2 for Batch header/control + entry added count
 		totalRecordsInFile = totalRecordsInFile + 2 + batch.GetADVControl().EntryAddendaCount
@@ -836,7 +836,7 @@ func (f *File) createFileADV() error {
 // Error - Error or Nil
 // Callers should always check for a nil-error before using the returned file.
 //
-// The File returned may not be valid and callers should confirm with Validate(). Invalid files may
+// The File returned may not be valid and callers should confirm with Validate. Invalid files may
 // be rejected by other Financial Institutions or ACH tools.
 func (f *File) SegmentFile(_ *SegmentFileConfiguration) (*File, *File, error) {
 	if err := f.Validate(); err != nil {

--- a/fileControl.go
+++ b/fileControl.go
@@ -53,7 +53,7 @@ type FileControl struct {
 
 // Parse takes the input record string and parses the FileControl values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (fc *FileControl) Parse(record string) {
 	if utf8.RuneCountInString(record) < 55 {
 		return

--- a/fileHeader.go
+++ b/fileHeader.go
@@ -41,7 +41,7 @@ type FileHeader struct {
 	// point to which the file is being sent. The ach file format specifies a 10 character
 	// field begins with a blank space in the first position, followed by the four digit
 	// Federal Reserve Routing Symbol, the four digit ABA Institution Identifier, and the Check
-	// Digit (bTTTTAAAAC). ImmediateDestinationField() will append the blank space to the
+	// Digit (bTTTTAAAAC). ImmediateDestinationField will append the blank space to the
 	// routing number.
 	ImmediateDestination string `json:"immediateDestination"`
 
@@ -49,7 +49,7 @@ type FileHeader struct {
 	// point that is sending the file. The ach file format specifies a 10 character
 	// field begins with a blank space in the first position, followed by the four digit
 	// Federal Reserve Routing Symbol, the four digit ABA Institution Identifier, and the Check
-	// Digit (bTTTTAAAAC). ImmediateOriginField() will append the blank space to the
+	// Digit (bTTTTAAAAC). ImmediateOriginField will append the blank space to the
 	// routing number.
 	ImmediateOrigin string `json:"immediateOrigin"`
 
@@ -119,7 +119,7 @@ func NewFileHeader() FileHeader {
 
 // Parse takes the input record string and parses the FileHeader values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (fh *FileHeader) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return
@@ -156,7 +156,7 @@ func (fh *FileHeader) Parse(record string) {
 
 func trimRoutingNumberLeadingZero(s string) string {
 	if utf8.RuneCountInString(s) == 10 && s[0] == '0' && s != "0000000000" {
-		// trim off a leading 0 as ImmediateOriginField() or ImmediateDestinationField() will pad it back
+		// trim off a leading 0 as ImmediateOriginField or ImmediateDestinationField will pad it back
 		return strings.TrimSpace(s[1:])
 	}
 	return strings.TrimSpace(s)

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -534,7 +534,7 @@ func (iatBatch *IATBatch) addendaFieldInclusion(entry *IATEntryDetail) error {
 // setting any posting dates, sequence numbers, counts, and sums.
 //
 // Create implementations are free to modify computable fields in a file and should
-// call the Batch's Validate() function at the end of their execution.
+// call the Batch's Validate function at the end of their execution.
 func (iatBatch *IATBatch) Create() error {
 	// generates sequence numbers and batch control
 	if err := iatBatch.build(); err != nil {

--- a/iatBatchHeader.go
+++ b/iatBatchHeader.go
@@ -189,7 +189,7 @@ func NewIATBatchHeader() *IATBatchHeader {
 
 // Parse takes the input record string and parses the BatchHeader values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (iatBh *IATBatchHeader) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -76,7 +76,7 @@ type IATEntryDetail struct {
 	// in the associated Entry Detail Record, since the Trace Number is associated
 	// with an entry or item rather than a physical record.
 	//
-	// Use TraceNumberField() for a properly formatted string representation.
+	// Use TraceNumberField for a properly formatted string representation.
 	TraceNumber string `json:"traceNumber,omitempty"`
 	// Addenda10 is mandatory for IAT entries
 	//
@@ -147,7 +147,7 @@ func NewIATEntryDetail() *IATEntryDetail {
 
 // Parse takes the input record string and parses the EntryDetail values
 //
-// Parse provides no guarantee about all fields being filled in. Callers should make a Validate() call to confirm successful parsing and data validity.
+// Parse provides no guarantee about all fields being filled in. Callers should make a Validate call to confirm successful parsing and data validity.
 func (iatEd *IATEntryDetail) Parse(record string) {
 	if utf8.RuneCountInString(record) != 94 {
 		return


### PR DESCRIPTION
Mentioned in #907