### PR TITLE
Adds human-readable ACH parsing to the webui

### DIFF
--- a/cmd/webui/ach/ach_js.go
+++ b/cmd/webui/ach/ach_js.go
@@ -8,6 +8,7 @@ import (
 	"syscall/js"
 
 	"github.com/moov-io/ach"
+	"github.com/moov-io/ach/cmd/achcli/describe"
 )
 
 func parseACH(input string) (string, error) {
@@ -21,6 +22,14 @@ func parseACH(input string) (string, error) {
 	if err := json.NewEncoder(&buf).Encode(file); err != nil {
 		return "", err
 	}
+	return buf.String(), nil
+}
+
+func parseReadable(file *ach.File) (string, error) {
+	var buf bytes.Buffer
+	// passing nil for the masking Opts to be
+	// consistent with the JSON output that is not masked
+	describe.File(&buf, file, nil)
 	return buf.String(), nil
 }
 
@@ -78,8 +87,31 @@ func printACH() js.Func {
 	})
 }
 
+func printReadable() js.Func {
+	return js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		if len(args) != 1 {
+			return "Invalid no of arguments passed"
+		}
+		r := strings.NewReader(args[0].String())
+		file, err := ach.NewReader(r).Read()
+		if err != nil {
+			msg := fmt.Sprintf("unable to parse ach file: %v", err)
+			fmt.Println(msg)
+			return msg
+		}
+		parsed, err := parseReadable(&file)
+		if err != nil {
+			fmt.Printf("unable to convert ach file to readable format %s\n", err)
+			return "There was an error formatting the output"
+		}
+
+		return parsed
+	})
+}
+
 func main() {
 	js.Global().Set("parseACH", prettyPrintJSON())
 	js.Global().Set("parseJSON", printACH())
+	js.Global().Set("parseReadable", printReadable())
 	<-make(chan bool)
 }

--- a/cmd/webui/ach/ach_js.go
+++ b/cmd/webui/ach/ach_js.go
@@ -27,9 +27,8 @@ func parseACH(input string) (string, error) {
 
 func parseReadable(file *ach.File) (string, error) {
 	var buf bytes.Buffer
-	// passing nil for the masking Opts to be
-	// consistent with the JSON output that is not masked
-	describe.File(&buf, file, nil)
+	opts := describe.Opts{MaskNames: false, MaskAccountNumbers: false}
+	describe.File(&buf, file, &opts)
 	return buf.String(), nil
 }
 
@@ -48,7 +47,7 @@ func prettyJson(input string) (string, error) {
 func prettyPrintJSON() js.Func {
 	return js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
 		if len(args) != 1 {
-			return "Invalid no of arguments passed"
+			return "Invalid number of arguments passed"
 		}
 		parsed, err := parseACH(args[0].String())
 		if err != nil {
@@ -69,7 +68,7 @@ func prettyPrintJSON() js.Func {
 func printACH() js.Func {
 	return js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
 		if len(args) != 1 {
-			return "Invalid no of arguments passed"
+			return "Invalid number of arguments passed"
 		}
 		file, err := ach.FileFromJSON([]byte(args[0].String()))
 		if err != nil {
@@ -90,7 +89,7 @@ func printACH() js.Func {
 func printReadable() js.Func {
 	return js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
 		if len(args) != 1 {
-			return "Invalid no of arguments passed"
+			return "Invalid number of arguments passed"
 		}
 		r := strings.NewReader(args[0].String())
 		file, err := ach.NewReader(r).Read()
@@ -101,7 +100,7 @@ func printReadable() js.Func {
 		}
 		parsed, err := parseReadable(&file)
 		if err != nil {
-			fmt.Printf("unable to convert ach file to readable format %s\n", err)
+			fmt.Printf("unable to convert ach file to human-readable format %s\n", err)
 			return "There was an error formatting the output"
 		}
 

--- a/cmd/webui/assets/index.html
+++ b/cmd/webui/assets/index.html
@@ -48,10 +48,10 @@
             gap: 1rem;
             height: 100%;
         }
-        [id="jsoninput"] {
+        [id="contentinput"] {
             grid-area: input;
         }
-        [id="jsonoutput"] {
+        [id="contentoutput"] {
             grid-area: output;
         }
         header {
@@ -95,15 +95,18 @@
         <svg class="logo" viewBox="0 0 113 33" xmlns="http://www.w3.org/2000/svg"><title>Moov</title><path d="m30.5593 4.18774h-29.71722c-.454013 0-.8254784.36365-.8254784.8081v23.05086c0 .5455.3508294.9091.8461174.9091h8.977081c.454 0 .8255-.3636.8255-.8081v-18.18208c0-.16162.1444-.30304.3095-.30304h1.8574c.1651 0 .3095.14142.3095.30304v18.18208c0 .4445.3715.8081.8255.8081h6.3768c.454 0 .8255-.3636.8255-.8081v-18.18208c0-.16162.1445-.30304.3095-.30304h1.878c.1651 0 .3096.14142.3096.30304v18.18208c0 .4445.3714.8081.8254.8081h9.0184c.454 0 .8255-.3636.8255-.8081v-19.89928c.0619-2.42429-1.4446-4.06068-3.7766-4.06068z"/><path d="m112.055 4.18774h-9.019c-.454 0-.825.36365-.825.8081v18.18216c0 .1616-.145.303-.31.303h-1.857c-.1652 0-.3096-.1414-.3096-.303v-18.18216c0-.44445-.3715-.8081-.8255-.8081h-9.0184c-.5159 0-.8461.36365-.8461.90911v8.06075c0 .0808 0 .1616.0207.2424l2.5177 12.8487c.3095 1.5758.9905 2.7071 2.559 2.7071h13.7032c1.568 0 2.249-1.1313 2.559-2.7071l2.517-12.8487c.021-.0808.021-.1616.021-.2424v-8.06075c-.041-.54546-.392-.90911-.887-.90911z"/><path d="m56.7682 4.18774h-16.2c-2.3526 0-3.8385 1.61619-3.8385 4.06068v16.64678c0 2.4444 1.4859 4.0606 3.8385 4.0606h16.2c2.3526 0 3.8385-1.6162 3.8385-4.0606v-16.64678c0-2.42429-1.4859-4.06068-3.8385-4.06068zm-6.8515 19.01046c0 .1616-.1444.303-.3095.303h-1.8573c-.1651 0-.3096-.1414-.3096-.303v-13.23258c0-.16162.1445-.30304.3096-.30304h1.8573c.1651 0 .3095.14142.3095.30304z"/><path d="m82.9979 4.18774h-16.2c-2.3526 0-3.8384 1.61619-3.8384 4.06068v16.64678c0 2.4444 1.4858 4.0606 3.8384 4.0606h16.2c2.3527 0 3.8385-1.6162 3.8385-4.0606v-16.64678c0-2.42429-1.4858-4.06068-3.8385-4.06068zm-6.8514 19.01046c0 .1616-.1445.303-.3096.303h-1.8573c-.1651 0-.3095-.1414-.3095-.303v-13.23258c0-.16162.1444-.30304.3095-.30304h1.8573c.1651 0 .3096.14142.3096.30304z"/></svg>
         <h1>ACH File Parser</h3>
             <p>
-                This tool converts ACH files into their JSON definition using Moov's <a href="https://github.com/moov-io/ach">ACH library</a>. Paste an ACH file on the left and the equivalent JSON will be generated to the right.
+                This tool converts ACH files into their JSON definition or a human-readable format using Moov's <a href="https://github.com/moov-io/ach">ACH library</a>. Paste an ACH file on the left and the formatted version will be generated to the right.
+            </p>
+            <p>
                 For an example, try some of our <a href="https://github.com/moov-io/ach/tree/master/test/testdata">test files</a>.
             </p>
     </header>
-    <textarea id="jsoninput" name="jsoninput" cols="80" rows="40" placeholder="Paste your ACH file contents here..." required></textarea>
-    <textarea id="jsonoutput" name="jsonoutput" cols="80" rows="40" readonly></textarea>
+    <textarea id="contentinput" name="contentinput" cols="80" rows="40" placeholder="Paste your ACH file contents here..." required></textarea>
+    <textarea id="contentoutput" name="contentoutput" cols="80" rows="40" readonly></textarea>
     <div id="buttons">
-        <button type="submit" onclick="convertToJson(jsoninput.value)">Parse ACH file</button>
-        <button type="button" onclick="convertToAch(jsoninput.value)">Parse JSON contents</button>
+        <button type="submit" onclick="convertToJson(contentinput.value)">Parse ACH file to JSON</button>
+        <button type="button" onclick="convertToReadable(contentinput.value)">Parse ACH file to human-readable</button>
+        <button type="button" onclick="convertToAch(contentinput.value)">Parse JSON to ACH file</button>
         <button type="submit" onclick="clearForms()">Clear Forms</button>
     </div>
     <div>
@@ -114,22 +117,29 @@
 </body>
 <script>
     const convertToJson = function(input) {
-        jsonoutput.value = parseACH(input)
-        jsonoutput.setSelectionRange(0,0)
-        jsonoutput.focus()
+        contentoutput.value = parseACH(input)
+        contentoutput.setSelectionRange(0,0)
+        contentoutput.focus()
     }
 
     const convertToAch = function(input) {
-        jsonoutput.value = parseJSON(input)
-        jsonoutput.setSelectionRange(0,0)
-        jsonoutput.focus()
+        contentoutput.value = parseJSON(input)
+        contentoutput.setSelectionRange(0,0)
+        contentoutput.focus()
+    }
+
+    const convertToReadable = function(input) {
+        contentoutput.value = parseReadable(input)
+        contentoutput.setSelectionRange(0,0)
+        contentoutput.focus()
     }
 
     const clearForms = function() {
-        jsoninput.value = ""
-        jsonoutput.value = ""
+        contentinput.value = ""
+        contentoutput.value = ""
         document.getElementById('input-file').value = ''
     }
+
     achform.addEventListener('submit', (event) => {
         event.preventDefault();
     })
@@ -141,7 +151,7 @@
         const input = event.target
         if ('files' in input && input.files.length > 0) {
             placeFileContent(
-                document.getElementById('jsonoutput'),
+                document.getElementById('contentoutput'),
                 input.files[0])
         }
     }

--- a/cmd/webui/assets/index.html
+++ b/cmd/webui/assets/index.html
@@ -38,7 +38,7 @@
         }
         p {
             font-size: .875rem;
-            max-width: 44rem;
+            max-width: 45rem;
         }
         [id="achform"] {
             display: grid;
@@ -95,7 +95,7 @@
         <svg class="logo" viewBox="0 0 113 33" xmlns="http://www.w3.org/2000/svg"><title>Moov</title><path d="m30.5593 4.18774h-29.71722c-.454013 0-.8254784.36365-.8254784.8081v23.05086c0 .5455.3508294.9091.8461174.9091h8.977081c.454 0 .8255-.3636.8255-.8081v-18.18208c0-.16162.1444-.30304.3095-.30304h1.8574c.1651 0 .3095.14142.3095.30304v18.18208c0 .4445.3715.8081.8255.8081h6.3768c.454 0 .8255-.3636.8255-.8081v-18.18208c0-.16162.1445-.30304.3095-.30304h1.878c.1651 0 .3096.14142.3096.30304v18.18208c0 .4445.3714.8081.8254.8081h9.0184c.454 0 .8255-.3636.8255-.8081v-19.89928c.0619-2.42429-1.4446-4.06068-3.7766-4.06068z"/><path d="m112.055 4.18774h-9.019c-.454 0-.825.36365-.825.8081v18.18216c0 .1616-.145.303-.31.303h-1.857c-.1652 0-.3096-.1414-.3096-.303v-18.18216c0-.44445-.3715-.8081-.8255-.8081h-9.0184c-.5159 0-.8461.36365-.8461.90911v8.06075c0 .0808 0 .1616.0207.2424l2.5177 12.8487c.3095 1.5758.9905 2.7071 2.559 2.7071h13.7032c1.568 0 2.249-1.1313 2.559-2.7071l2.517-12.8487c.021-.0808.021-.1616.021-.2424v-8.06075c-.041-.54546-.392-.90911-.887-.90911z"/><path d="m56.7682 4.18774h-16.2c-2.3526 0-3.8385 1.61619-3.8385 4.06068v16.64678c0 2.4444 1.4859 4.0606 3.8385 4.0606h16.2c2.3526 0 3.8385-1.6162 3.8385-4.0606v-16.64678c0-2.42429-1.4859-4.06068-3.8385-4.06068zm-6.8515 19.01046c0 .1616-.1444.303-.3095.303h-1.8573c-.1651 0-.3096-.1414-.3096-.303v-13.23258c0-.16162.1445-.30304.3096-.30304h1.8573c.1651 0 .3095.14142.3095.30304z"/><path d="m82.9979 4.18774h-16.2c-2.3526 0-3.8384 1.61619-3.8384 4.06068v16.64678c0 2.4444 1.4858 4.0606 3.8384 4.0606h16.2c2.3527 0 3.8385-1.6162 3.8385-4.0606v-16.64678c0-2.42429-1.4858-4.06068-3.8385-4.06068zm-6.8514 19.01046c0 .1616-.1445.303-.3096.303h-1.8573c-.1651 0-.3095-.1414-.3095-.303v-13.23258c0-.16162.1444-.30304.3095-.30304h1.8573c.1651 0 .3096.14142.3096.30304z"/></svg>
         <h1>ACH File Parser</h3>
             <p>
-                This tool converts ACH files into their JSON definition or a human-readable format using Moov's <a href="https://github.com/moov-io/ach">ACH library</a>. Paste an ACH file on the left and the formatted version will be generated to the right.
+                This tool converts ACH files into their JSON definition or a human-readable format using Moov's <a href="https://github.com/moov-io/ach">ACH library</a>. Paste an ACH file on the left, in Nacha or JSON format, and the formatted version will be generated to the right.
             </p>
             <p>
                 For an example, try some of our <a href="https://github.com/moov-io/ach/tree/master/test/testdata">test files</a>.
@@ -103,12 +103,15 @@
     </header>
     <textarea id="contentinput" name="contentinput" cols="80" rows="40" placeholder="Paste your ACH file contents here..." required></textarea>
     <textarea id="contentoutput" name="contentoutput" cols="80" rows="40" readonly></textarea>
+
     <div id="buttons">
-        <button type="submit" onclick="convertToJson(contentinput.value)">Parse ACH file to JSON</button>
-        <button type="button" onclick="convertToReadable(contentinput.value)">Parse ACH file to human-readable format</button>
-        <button type="button" onclick="convertToAch(contentinput.value)">Parse JSON to ACH file</button>
-        <button type="submit" onclick="clearForms()">Clear Forms</button>
+        <label for="buttons">View above content as:</label><br>
+        <button type="submit" onclick="convertToJson(contentinput.value)">JSON</button>
+        <button type="button" onclick="convertToAch(contentinput.value)">Nacha</button>
+        <button type="button" onclick="convertToReadable(contentinput.value)">Human-Readable</button>
+        <button type="submit" onclick="clearForms()">Clear Form</button>
     </div>
+
     <div>
         <label for="input-file">Specify a file:</label><br>
         <input type="file" id="input-file">

--- a/cmd/webui/assets/index.html
+++ b/cmd/webui/assets/index.html
@@ -105,7 +105,7 @@
     <textarea id="contentoutput" name="contentoutput" cols="80" rows="40" readonly></textarea>
     <div id="buttons">
         <button type="submit" onclick="convertToJson(contentinput.value)">Parse ACH file to JSON</button>
-        <button type="button" onclick="convertToReadable(contentinput.value)">Parse ACH file to human-readable</button>
+        <button type="button" onclick="convertToReadable(contentinput.value)">Parse ACH file to human-readable format</button>
         <button type="button" onclick="convertToAch(contentinput.value)">Parse JSON to ACH file</button>
         <button type="submit" onclick="clearForms()">Clear Forms</button>
     </div>

--- a/cmd/webui/assets/wasm_exec.js
+++ b/cmd/webui/assets/wasm_exec.js
@@ -11,6 +11,7 @@
 	// - Node.js
 	// - Electron
 	// - Parcel
+	// - Webpack
 
 	if (typeof global !== "undefined") {
 		// global already exists
@@ -28,7 +29,7 @@
 
 	if (!global.fs && global.require) {
 		const fs = require("fs");
-		if (Object.keys(fs) !== 0) {
+		if (typeof fs === "object" && fs !== null && Object.keys(fs).length !== 0) {
 			global.fs = fs;
 		}
 	}
@@ -101,13 +102,16 @@
 		}
 	}
 
-	if (!global.crypto) {
+	if (!global.crypto && global.require) {
 		const nodeCrypto = require("crypto");
 		global.crypto = {
 			getRandomValues(b) {
 				nodeCrypto.randomFillSync(b);
 			},
 		};
+	}
+	if (!global.crypto) {
+		throw new Error("global.crypto is not available, polyfill required (getRandomValues only)");
 	}
 
 	if (!global.performance) {
@@ -119,12 +123,18 @@
 		};
 	}
 
-	if (!global.TextEncoder) {
+	if (!global.TextEncoder && global.require) {
 		global.TextEncoder = require("util").TextEncoder;
 	}
+	if (!global.TextEncoder) {
+		throw new Error("global.TextEncoder is not available, polyfill required");
+	}
 
-	if (!global.TextDecoder) {
+	if (!global.TextDecoder && global.require) {
 		global.TextDecoder = require("util").TextDecoder;
+	}
+	if (!global.TextDecoder) {
+		throw new Error("global.TextDecoder is not available, polyfill required");
 	}
 
 	// End of polyfills for common API.
@@ -254,6 +264,7 @@
 
 					// func wasmExit(code int32)
 					"runtime.wasmExit": (sp) => {
+						sp >>>= 0;
 						const code = this.mem.getInt32(sp + 8, true);
 						this.exited = true;
 						delete this._inst;
@@ -266,6 +277,7 @@
 
 					// func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
 					"runtime.wasmWrite": (sp) => {
+						sp >>>= 0;
 						const fd = getInt64(sp + 8);
 						const p = getInt64(sp + 16);
 						const n = this.mem.getInt32(sp + 24, true);
@@ -274,16 +286,19 @@
 
 					// func resetMemoryDataView()
 					"runtime.resetMemoryDataView": (sp) => {
+						sp >>>= 0;
 						this.mem = new DataView(this._inst.exports.mem.buffer);
 					},
 
 					// func nanotime1() int64
 					"runtime.nanotime1": (sp) => {
+						sp >>>= 0;
 						setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
 					},
 
 					// func walltime1() (sec int64, nsec int32)
 					"runtime.walltime1": (sp) => {
+						sp >>>= 0;
 						const msec = (new Date).getTime();
 						setInt64(sp + 8, msec / 1000);
 						this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true);
@@ -291,6 +306,7 @@
 
 					// func scheduleTimeoutEvent(delay int64) int32
 					"runtime.scheduleTimeoutEvent": (sp) => {
+						sp >>>= 0;
 						const id = this._nextCallbackTimeoutID;
 						this._nextCallbackTimeoutID++;
 						this._scheduledTimeouts.set(id, setTimeout(
@@ -310,6 +326,7 @@
 
 					// func clearTimeoutEvent(id int32)
 					"runtime.clearTimeoutEvent": (sp) => {
+						sp >>>= 0;
 						const id = this.mem.getInt32(sp + 8, true);
 						clearTimeout(this._scheduledTimeouts.get(id));
 						this._scheduledTimeouts.delete(id);
@@ -317,11 +334,13 @@
 
 					// func getRandomData(r []byte)
 					"runtime.getRandomData": (sp) => {
+						sp >>>= 0;
 						crypto.getRandomValues(loadSlice(sp + 8));
 					},
 
 					// func finalizeRef(v ref)
 					"syscall/js.finalizeRef": (sp) => {
+						sp >>>= 0;
 						const id = this.mem.getUint32(sp + 8, true);
 						this._goRefCounts[id]--;
 						if (this._goRefCounts[id] === 0) {
@@ -334,44 +353,51 @@
 
 					// func stringVal(value string) ref
 					"syscall/js.stringVal": (sp) => {
+						sp >>>= 0;
 						storeValue(sp + 24, loadString(sp + 8));
 					},
 
 					// func valueGet(v ref, p string) ref
 					"syscall/js.valueGet": (sp) => {
+						sp >>>= 0;
 						const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
-						sp = this._inst.exports.getsp(); // see comment above
+						sp = this._inst.exports.getsp() >>> 0; // see comment above
 						storeValue(sp + 32, result);
 					},
 
 					// func valueSet(v ref, p string, x ref)
 					"syscall/js.valueSet": (sp) => {
+						sp >>>= 0;
 						Reflect.set(loadValue(sp + 8), loadString(sp + 16), loadValue(sp + 32));
 					},
 
 					// func valueDelete(v ref, p string)
 					"syscall/js.valueDelete": (sp) => {
+						sp >>>= 0;
 						Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16));
 					},
 
 					// func valueIndex(v ref, i int) ref
 					"syscall/js.valueIndex": (sp) => {
+						sp >>>= 0;
 						storeValue(sp + 24, Reflect.get(loadValue(sp + 8), getInt64(sp + 16)));
 					},
 
 					// valueSetIndex(v ref, i int, x ref)
 					"syscall/js.valueSetIndex": (sp) => {
+						sp >>>= 0;
 						Reflect.set(loadValue(sp + 8), getInt64(sp + 16), loadValue(sp + 24));
 					},
 
 					// func valueCall(v ref, m string, args []ref) (ref, bool)
 					"syscall/js.valueCall": (sp) => {
+						sp >>>= 0;
 						try {
 							const v = loadValue(sp + 8);
 							const m = Reflect.get(v, loadString(sp + 16));
 							const args = loadSliceOfValues(sp + 32);
 							const result = Reflect.apply(m, v, args);
-							sp = this._inst.exports.getsp(); // see comment above
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 56, result);
 							this.mem.setUint8(sp + 64, 1);
 						} catch (err) {
@@ -382,11 +408,12 @@
 
 					// func valueInvoke(v ref, args []ref) (ref, bool)
 					"syscall/js.valueInvoke": (sp) => {
+						sp >>>= 0;
 						try {
 							const v = loadValue(sp + 8);
 							const args = loadSliceOfValues(sp + 16);
 							const result = Reflect.apply(v, undefined, args);
-							sp = this._inst.exports.getsp(); // see comment above
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 40, result);
 							this.mem.setUint8(sp + 48, 1);
 						} catch (err) {
@@ -397,11 +424,12 @@
 
 					// func valueNew(v ref, args []ref) (ref, bool)
 					"syscall/js.valueNew": (sp) => {
+						sp >>>= 0;
 						try {
 							const v = loadValue(sp + 8);
 							const args = loadSliceOfValues(sp + 16);
 							const result = Reflect.construct(v, args);
-							sp = this._inst.exports.getsp(); // see comment above
+							sp = this._inst.exports.getsp() >>> 0; // see comment above
 							storeValue(sp + 40, result);
 							this.mem.setUint8(sp + 48, 1);
 						} catch (err) {
@@ -412,11 +440,13 @@
 
 					// func valueLength(v ref) int
 					"syscall/js.valueLength": (sp) => {
+						sp >>>= 0;
 						setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
 					},
 
 					// valuePrepareString(v ref) (ref, int)
 					"syscall/js.valuePrepareString": (sp) => {
+						sp >>>= 0;
 						const str = encoder.encode(String(loadValue(sp + 8)));
 						storeValue(sp + 16, str);
 						setInt64(sp + 24, str.length);
@@ -424,17 +454,20 @@
 
 					// valueLoadString(v ref, b []byte)
 					"syscall/js.valueLoadString": (sp) => {
+						sp >>>= 0;
 						const str = loadValue(sp + 8);
 						loadSlice(sp + 16).set(str);
 					},
 
 					// func valueInstanceOf(v ref, t ref) bool
 					"syscall/js.valueInstanceOf": (sp) => {
+						sp >>>= 0;
 						this.mem.setUint8(sp + 24, (loadValue(sp + 8) instanceof loadValue(sp + 16)) ? 1 : 0);
 					},
 
 					// func copyBytesToGo(dst []byte, src ref) (int, bool)
 					"syscall/js.copyBytesToGo": (sp) => {
+						sp >>>= 0;
 						const dst = loadSlice(sp + 8);
 						const src = loadValue(sp + 32);
 						if (!(src instanceof Uint8Array || src instanceof Uint8ClampedArray)) {
@@ -449,6 +482,7 @@
 
 					// func copyBytesToJS(dst ref, src []byte) (int, bool)
 					"syscall/js.copyBytesToJS": (sp) => {
+						sp >>>= 0;
 						const dst = loadValue(sp + 8);
 						const src = loadSlice(sp + 16);
 						if (!(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)) {
@@ -469,6 +503,9 @@
 		}
 
 		async run(instance) {
+			if (!(instance instanceof WebAssembly.Instance)) {
+				throw new Error("Go.run: WebAssembly.Instance expected");
+			}
 			this._inst = instance;
 			this.mem = new DataView(this._inst.exports.mem.buffer);
 			this._values = [ // JS values that Go currently has references to, indexed by reference id
@@ -556,6 +593,7 @@
 	}
 
 	if (
+		typeof module !== "undefined" &&
 		global.require &&
 		global.require.main === module &&
 		global.process &&


### PR DESCRIPTION
Ports the human-readable formatting from the command line `achcli` to the `webui`. 

Note: It might be worth changing the input and output `textarea`s to vertical rather than horizontal to accommodate the wrapping that can happen with the human-readable content.

cc @adamdecaf