### PR TITLE
file: allow for missing file header and control

### DIFF
--- a/file.go
+++ b/file.go
@@ -598,10 +598,10 @@ type ValidateOpts struct {
 	// AllowZeroBatches allows the file to have zero batches
 	AllowZeroBatches bool `json:"allowZeroBatches"`
 
-	// AllowMissingFileHeader
+	// AllowMissingFileHeader allows a file to be read without a FileHeader record.
 	AllowMissingFileHeader bool `json:"allowMissingFileHeader"`
 
-	// AllowMissingFileControl
+	// AllowMissingFileControl allows a file to be read without a FileControl record.
 	AllowMissingFileControl bool `json:"allowMissingFileControl"`
 
 	// BypassCompanyIdentificationMatch allows batches in which the Company Identification field

--- a/file.go
+++ b/file.go
@@ -591,6 +591,12 @@ type ValidateOpts struct {
 	// AllowZeroBatches allows the file to have zero batches
 	AllowZeroBatches bool `json:"allowZeroBatches"`
 
+	// AllowMissingFileHeader
+	AllowMissingFileHeader bool `json:"allowMissingFileHeader"`
+
+	// AllowMissingFileControl
+	AllowMissingFileControl bool `json:"allowMissingFileControl"`
+
 	// BypassCompanyIdentificationMatch allows batches in which the Company Identification field
 	// in the batch header and control do not match.
 	BypassCompanyIdentificationMatch bool `json:"bypassCompanyIdentificationMatch"`
@@ -617,8 +623,10 @@ func (f *File) ValidateWith(opts *ValidateOpts) error {
 		opts = &ValidateOpts{}
 	}
 
-	if err := f.Header.ValidateWith(opts); err != nil {
-		return err
+	if !opts.AllowMissingFileHeader {
+		if err := f.Header.ValidateWith(opts); err != nil {
+			return err
+		}
 	}
 
 	if !f.IsADV() {
@@ -633,8 +641,10 @@ func (f *File) ValidateWith(opts *ValidateOpts) error {
 			}
 		}
 
-		if err := f.Control.Validate(); err != nil {
-			return err
+		if !opts.AllowMissingFileControl {
+			if err := f.Control.Validate(); err != nil {
+				return err
+			}
 		}
 		if err := f.isEntryAddendaCount(false); err != nil {
 			return err
@@ -654,8 +664,10 @@ func (f *File) ValidateWith(opts *ValidateOpts) error {
 	if f.ADVControl.BatchCount != len(f.Batches) {
 		return NewErrFileCalculatedControlEquality("BatchCount", len(f.Batches), f.ADVControl.BatchCount)
 	}
-	if err := f.ADVControl.Validate(); err != nil {
-		return err
+	if !opts.AllowMissingFileControl {
+		if err := f.ADVControl.Validate(); err != nil {
+			return err
+		}
 	}
 	if err := f.isEntryAddendaCount(true); err != nil {
 		return err

--- a/file.go
+++ b/file.go
@@ -410,9 +410,16 @@ func datetimeParse(v string) (time.Time, error) {
 //
 // To check if the File is Nacha compliant, call Validate or ValidateWith.
 func (f *File) Create() error {
+	opts := f.validateOpts
+	if opts == nil {
+		opts = &ValidateOpts{}
+	}
+
 	// Requires a valid FileHeader to build FileControl
-	if err := f.Header.Validate(); err != nil {
-		return err
+	if !opts.AllowMissingFileHeader {
+		if err := f.Header.Validate(); err != nil {
+			return err
+		}
 	}
 
 	// If AllowZeroBatches is false, require at least one Batch in the new file.

--- a/file.go
+++ b/file.go
@@ -188,7 +188,7 @@ func FileFromJSONWith(bs []byte, opts *ValidateOpts) (*File, error) {
 
 // UnmarshalJSON parses a JSON blob with ach.FileFromJSON
 func (f *File) UnmarshalJSON(p []byte) error {
-	file, err := FileFromJSON(p)
+	file, err := FileFromJSONWith(p, f.validateOpts)
 	if err != nil {
 		return err
 	}

--- a/server/files.go
+++ b/server/files.go
@@ -119,6 +119,8 @@ func decodeCreateFileRequest(_ context.Context, request *http.Request) (interfac
 		bypassDestination                = "bypassDestination"
 		customTraceNumbers               = "customTraceNumbers"
 		allowZeroBatches                 = "allowZeroBatches"
+		allowMissingFileHeader           = "allowMissingFileHeader"
+		allowMissingFileControl          = "allowMissingFileControl"
 		bypassCompanyIdentificationMatch = "bypassCompanyIdentificationMatch"
 		customReturnCodes                = "customReturnCodes"
 		unequalServiceClassCode          = "unequalServiceClassCode"
@@ -130,6 +132,8 @@ func decodeCreateFileRequest(_ context.Context, request *http.Request) (interfac
 		bypassDestination,
 		customTraceNumbers,
 		allowZeroBatches,
+		allowMissingFileHeader,
+		allowMissingFileControl,
 		bypassCompanyIdentificationMatch,
 		customReturnCodes,
 		unequalServiceClassCode,
@@ -160,6 +164,10 @@ func decodeCreateFileRequest(_ context.Context, request *http.Request) (interfac
 			req.validateOpts.CustomTraceNumbers = true
 		case allowZeroBatches:
 			req.validateOpts.AllowZeroBatches = true
+		case allowMissingFileHeader:
+			req.validateOpts.AllowMissingFileHeader = true
+		case allowMissingFileControl:
+			req.validateOpts.AllowMissingFileControl = true
 		case bypassCompanyIdentificationMatch:
 			req.validateOpts.BypassCompanyIdentificationMatch = true
 		case customReturnCodes:

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -185,6 +185,13 @@ func TestFiles__decodeCreateFileRequest__validateOpts(t *testing.T) {
 				CustomTraceNumbers: true,
 			},
 		},
+		{
+			query: "?allowMissingFileHeader=true&allowMissingFileControl=true",
+			expect: ach.ValidateOpts{
+				AllowMissingFileHeader:  true,
+				AllowMissingFileControl: true,
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Also 
- file: unmarshal with ValidateOpts if set
- file: during creation check ValidateOpts for allowing empty headers