### PR TITLE
feat: improve performance of getTraceNumbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ _cgo_export.*
 
 _testmain.go
 
+*.out
 *.exe
 *.test
 *.prof

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -623,22 +623,24 @@ func sortEntriesByTraceNumber(entries []*EntryDetail) []*EntryDetail {
 	return entries
 }
 
-type traceNumbers map[string]struct{}
-
-var traceNumberValue = struct{}{}
+type traceNumbers []string
 
 func (nums traceNumbers) contains(num string) bool {
-	_, exists := nums[num]
-	return exists
+	for i := range nums {
+		if num == nums[i] {
+			return true
+		}
+	}
+	return false
 }
 
 func getTraceNumbers(f *File) traceNumbers {
-	out := make(traceNumbers)
+	var out []string
 	for i := range f.Batches {
 		entries := f.Batches[i].GetEntries()
 		for j := range entries {
-			out[entries[j].TraceNumber] = traceNumberValue
+			out = append(out, entries[j].TraceNumber)
 		}
 	}
-	return out
+	return traceNumbers(out)
 }

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 
 	"github.com/moov-io/base"
+
+	"github.com/stretchr/testify/require"
 )
 
 // mockEntryDetail creates an entry detail
@@ -771,4 +773,21 @@ func TestEntryDetail__LargeAmountStrings(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	}
+}
+
+func TestGetTraceNumbers(t *testing.T) {
+	file := mockFilePPD()
+	odfi := mockBatchHeader().ODFIIdentification
+
+	trials := 10000
+
+	for i := 1; i < trials; i++ {
+		ed := mockEntryDetail()
+		ed.SetTraceNumber(odfi, i)
+
+		file.Batches[0].AddEntry(ed)
+	}
+
+	numbers := getTraceNumbers(file)
+	require.Equal(t, trials, len(numbers))
 }

--- a/merge.go
+++ b/merge.go
@@ -175,7 +175,7 @@ func (fs *mergableFiles) findOutfile(f *File) *File {
 
 				// found a matching file, so verify the TraceNumber isn't alreay inside
 				outTraceNumbers := getTraceNumbers(fs.outfiles[i])
-				for trace := range inTraceNumbers {
+				for _, trace := range inTraceNumbers {
 					// If any of our incoming trace numbers match the existing merged file
 					// return the entire file as separate. This keeps partially overlapping
 					// batches self-contained.


### PR DESCRIPTION
We noticed some memory pressure under large merge operations. One
large user of memory was getTraceNumbers which builds up a map of
Trace Numbers. However, within a file Trace Numbers need to be unique
so a map isn't needed.

Before:
![Screen Shot 2022-05-09 at 9 40 19 AM](https://user-images.githubusercontent.com/120951/167435718-53ceb165-db5b-4b43-bbfb-28e58fa16d13.png)

After:
![Screen Shot 2022-05-09 at 9 40 24 AM](https://user-images.githubusercontent.com/120951/167435742-d22dfed6-e80b-4ca5-a687-e3785f4fdc8b.png)

