### PR TITLE
feat: add build file endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -218,6 +218,34 @@ paths:
           description: Permanently deleted File.
         '404':
           description: A File with the specified ID was not found.
+  /files/{fileID}/build:
+    get:
+      tags: ['ACH Files']
+      summary: Build File
+      description: |
+        Assembles the existing File (batches and controls) records, computes sequence numbers and totals. Returns JSON formatted file.
+      operationId: buildFile
+      parameters:
+        - name: X-Request-ID
+          in: header
+          description: Optional Request ID allows application developer to trace requests through the system's logs
+          example: "rs4f9915"
+          schema:
+            type: string
+        - name: fileID
+          in: path
+          description: File ID
+          required: true
+          schema:
+            type: string
+            example: "3f2d23ee214"
+      responses:
+        '200':
+          description: File built successfully without errors.
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/File'
   /files/{fileID}/contents:
     get:
       tags: ['ACH Files']

--- a/server/routing.go
+++ b/server/routing.go
@@ -121,6 +121,12 @@ func MakeHTTPHandler(s Service, repo Repository, kitlog gokitlog.Logger) http.Ha
 		encodeResponse,
 		options...,
 	))
+	r.Methods("GET").Path("/files/{id}/build").Handler(httptransport.NewServer(
+		buildFileEndpoint(s, repo, logger),
+		decodeBuildFileRequest,
+		encodeResponse,
+		options...,
+	))
 	r.Methods("POST").Path("/files/create").Handler(httptransport.NewServer(
 		createFileEndpoint(s, repo, logger),
 		decodeCreateFileRequest,

--- a/server/service.go
+++ b/server/service.go
@@ -41,6 +41,8 @@ type Service interface {
 	GetFile(id string) (*ach.File, error)
 	// GetFiles retrieves all files accessible from the client.
 	GetFiles() []*ach.File
+	// BuildFile tabulates file values according to the Nacha spec
+	BuildFile(id string) (*ach.File, error)
 	// DeleteFile takes a file resource ID and deletes it from the store
 	DeleteFile(id string) error
 	// GetFileContents creates a valid plaintext file in memory assuming it has a FileHeader and at least one Batch record.
@@ -109,6 +111,16 @@ func (s *service) GetFile(id string) (*ach.File, error) {
 
 func (s *service) GetFiles() []*ach.File {
 	return s.store.FindAllFiles()
+}
+
+// BuildFile tabulates file values according to the Nacha spec
+func (s *service) BuildFile(id string) (*ach.File, error) {
+	file, err := s.GetFile(id)
+	if err != nil {
+		return nil, fmt.Errorf("build file: error reading file %s: %v", id, err)
+	}
+	err = file.Create()
+	return file, err
 }
 
 func (s *service) DeleteFile(id string) error {


### PR DESCRIPTION
There's been a longstanding issue where the HTTP server has no endpoint for building and returning a JSON formatted file. Callers have had to use `GET /files/{fileID}/contents` and then `GET /files/{fileID}` to get the JSON formatted response. 

Issue: https://github.com/moov-io/ach/issues/1024