### PR TITLE
fix: reduce memory usage during MergeFiles

### DIFF
--- a/entryDetail.go
+++ b/entryDetail.go
@@ -634,25 +634,3 @@ func sortEntriesByTraceNumber(entries []*EntryDetail) []*EntryDetail {
 	})
 	return entries
 }
-
-type traceNumbers []string
-
-func (nums traceNumbers) contains(num string) bool {
-	for i := range nums {
-		if num == nums[i] {
-			return true
-		}
-	}
-	return false
-}
-
-func getTraceNumbers(f *File) traceNumbers {
-	var out []string
-	for i := range f.Batches {
-		entries := f.Batches[i].GetEntries()
-		for j := range entries {
-			out = append(out, entries[j].TraceNumber)
-		}
-	}
-	return traceNumbers(out)
-}

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -28,8 +28,6 @@ import (
 	"testing"
 
 	"github.com/moov-io/base"
-
-	"github.com/stretchr/testify/require"
 )
 
 // mockEntryDetail creates an entry detail
@@ -773,21 +771,4 @@ func TestEntryDetail__LargeAmountStrings(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	}
-}
-
-func TestGetTraceNumbers(t *testing.T) {
-	file := mockFilePPD()
-	odfi := mockBatchHeader().ODFIIdentification
-
-	trials := 10000
-
-	for i := 1; i < trials; i++ {
-		ed := mockEntryDetail()
-		ed.SetTraceNumber(odfi, i)
-
-		file.Batches[0].AddEntry(ed)
-	}
-
-	numbers := getTraceNumbers(file)
-	require.Equal(t, trials, len(numbers))
 }

--- a/go.sum
+++ b/go.sum
@@ -1552,6 +1552,7 @@ golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5 h1:bRb386wvrE+oBNdF1d/Xh9mQrfQ4ecYhW5qJ5GvTGT4=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2 h1:NWy5+hlRbC7HK+PmcXVUmW1IMyFce7to56IUvhUFm7Y=
 golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/merge_test.go
+++ b/merge_test.go
@@ -400,8 +400,10 @@ func TestMergeFiles__dollarAmount2(t *testing.T) {
 
 func countTraceNumbers(files ...*File) int {
 	var total int
-	for i := range files {
-		total += len(getTraceNumbers(files[i]))
+	for f := range files {
+		for b := range files[f].Batches {
+			total += len(files[f].Batches[b].GetEntries())
+		}
 	}
 	return total
 }

--- a/test/issues/issue927_test.go
+++ b/test/issues/issue927_test.go
@@ -35,7 +35,7 @@ func TestIssue927(t *testing.T) {
 	}
 
 	if len(after) != 2 {
-		t.Errorf("merged %d files into %d", len(before), len(after))
+		t.Fatalf("merged %d files into %d files", len(before), len(after))
 	}
 
 	if n := len(after[0].Batches); n != 5 {


### PR DESCRIPTION
We've been seeing getTraceNumbers use a ton of memory, which isn't surprising since it allocates (and then expands) an array of trace numbers. This can be bypassed with a mess of for loops instead.

Running achgateway's tests before:
![Screen Shot 2022-07-07 at 10 57 02 AM](https://user-images.githubusercontent.com/120951/177818772-6e3cb181-c13b-4e1d-bd08-b385e176f82f.png)
![Screen Shot 2022-07-07 at 10 57 12 AM](https://user-images.githubusercontent.com/120951/177818777-c6e246de-8e68-4ce8-896c-d670075dc404.png)

After: 
![Screen Shot 2022-07-07 at 10 57 26 AM](https://user-images.githubusercontent.com/120951/177818851-810dae35-241c-4b89-9ade-5fe72cdbc45d.png)
![Screen Shot 2022-07-07 at 11 02 16 AM](https://user-images.githubusercontent.com/120951/177819373-cfb25288-b85a-41a1-bdc5-70cc4f258206.png)
