### PR TITLE
feat: support reading paymentTypeCode from JSON

### DIFF
--- a/entryDetail.go
+++ b/entryDetail.go
@@ -18,6 +18,7 @@
 package ach
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -340,6 +341,32 @@ func (ed *EntryDetail) amountOverflowsField() error {
 	if len(intstr) > len(strstr) {
 		return fmt.Errorf("does not match formatted value %s", strstr)
 	}
+	return nil
+}
+
+func (ed *EntryDetail) UnmarshalJSON(data []byte) error {
+	type Aux EntryDetail
+	var entry Aux
+	err := json.Unmarshal(data, &entry)
+	if err != nil {
+		return err
+	}
+
+	type Aux2 struct {
+		PaymentTypeCode string `json:"paymentTypeCode"`
+	}
+	var aux Aux2
+
+	err = json.Unmarshal(data, &aux)
+	if err != nil {
+		return err
+	}
+
+	if aux.PaymentTypeCode != "" {
+		entry.DiscretionaryData = aux.PaymentTypeCode
+	}
+
+	*ed = EntryDetail(entry)
 	return nil
 }
 

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 
 	"github.com/moov-io/base"
+
+	"github.com/stretchr/testify/require"
 )
 
 // mockEntryDetail creates an entry detail
@@ -771,4 +773,34 @@ func TestEntryDetail__LargeAmountStrings(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	}
+}
+
+func TestEntryDetail_UnmarshalPaymentTypeCode(t *testing.T) {
+	orig := mockEntryDetail()
+	orig.recordType = ""
+
+	// Convert the EntryDetail to a map[string]interface{} so we can
+	// add paymentTypeCode and read that back in DiscretionaryData.
+	bs, err := json.Marshal(orig)
+	require.NoError(t, err)
+
+	fields := make(map[string]interface{})
+	err = json.Unmarshal(bs, &fields)
+	require.NoError(t, err)
+
+	fields["paymentTypeCode"] = "S" // set Payment Type Code
+
+	// Convert map into json bytes
+	bs, err = json.Marshal(fields)
+	require.NoError(t, err)
+
+	var after EntryDetail
+	err = json.Unmarshal(bs, &after)
+	require.NoError(t, err)
+
+	require.Equal(t, "S", after.PaymentTypeField())
+	require.Equal(t, "S ", after.DiscretionaryDataField())
+
+	orig.DiscretionaryData = "S"
+	require.Equal(t, after, *orig)
 }


### PR DESCRIPTION
It came up that TEL/WEB entry detail records have a "payment type code" field (size 1) that overlaps with the the `DiscretionaryData` field (size 2). This causes a bit of confusion because the JSON representation doesn't error when you provide `paymentTypeCode` but also doesn't populate `DiscretionaryData`. 

This PR is an experiment to support `paymentTypeCode` only in the JSON level. 

@atonks2 can I get your thoughts on this experiment? 