### PR TITLE
server: return file on ACH file creation

### DIFF
--- a/server/files.go
+++ b/server/files.go
@@ -60,8 +60,9 @@ type createFileRequest struct {
 }
 
 type createFileResponse struct {
-	ID  string `json:"id"`
-	Err error  `json:"error"`
+	ID   string    `json:"id"`
+	File *ach.File `json:"file"`
+	Err  error     `json:"error"`
 }
 
 func (r createFileResponse) error() error { return r.Err }
@@ -100,9 +101,11 @@ func createFileEndpoint(s Service, r Repository, logger log.Logger) endpoint.End
 			}
 		}
 
+		f, _ := r.FindFile(req.File.ID)
 		resp := createFileResponse{
-			ID:  req.File.ID,
-			Err: err,
+			ID:   req.File.ID,
+			File: f,
+			Err:  err,
 		}
 		if req.parseError != nil {
 			resp.Err = req.parseError

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -127,6 +127,7 @@ func TestFiles__CustomJsonValidation(t *testing.T) {
 	var resp createFileResponse
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 	require.Equal(t, "adam-01", resp.ID)
+	require.NotNil(t, resp.File)
 	require.Equal(t, nil, resp.Err)
 }
 

--- a/test/testdata/json-bypass-origin-and-destination.json
+++ b/test/testdata/json-bypass-origin-and-destination.json
@@ -2,7 +2,7 @@
     "id": "adam-01",
     "fileHeader": {
         "id": "adam-01",
-        "immediateDestination": "000000000",
+        "immediateDestination": "123456780",
         "immediateOrigin": "000000000",
         "fileCreationDate": "181008",
         "fileCreationTime": "",


### PR DESCRIPTION
We were talking about how it would be nice to get the JSON representation of the file back on file creation in slack the other day, since no data is persisted this seems like it would be a worthwhile add.

If accepted I'd like do the same to the segment endpoints so it returns both files