### PR TITLE
Achcli Custom Validation

### DIFF
--- a/cmd/achcli/describe.go
+++ b/cmd/achcli/describe.go
@@ -65,21 +65,17 @@ func dumpFiles(paths []string, validateOpts *ach.ValidateOpts) error {
 }
 
 func readACHFile(path string, validateOpts *ach.ValidateOpts) (*ach.File, error) {
-	fd, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("problem opening %s: %v", path, err)
+	fd, readErr := os.Open(path)
+	if readErr != nil {
+		return nil, fmt.Errorf("problem opening %s: %v", path, readErr)
 	}
 	defer fd.Close()
 
-	f, err := ach.NewReader(fd).Read()
+	r := ach.NewReader(fd)
+	r.SetValidation(validateOpts)
+	f, err := r.Read()
 	if err != nil {
 		return nil, err
-	}
-
-	if validateOpts != nil {
-		if validateErr := f.ValidateWith(validateOpts); validateErr != nil {
-			return nil, validateErr
-		}
 	}
 
 	return &f, err

--- a/cmd/achcli/describe.go
+++ b/cmd/achcli/describe.go
@@ -77,6 +77,5 @@ func readACHFile(path string, validateOpts *ach.ValidateOpts) (*ach.File, error)
 	if err != nil {
 		return nil, err
 	}
-
 	return &f, err
 }

--- a/cmd/achcli/diff.go
+++ b/cmd/achcli/diff.go
@@ -16,11 +16,11 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-func diffFiles(paths []string) error {
+func diffFiles(paths []string, validateOpts *ach.ValidateOpts) error {
 	if len(paths) != 2 {
 		return fmt.Errorf("expected 2 files, but got %d", len(paths))
 	}
-	f1, f2, err := readTwoFiles(paths)
+	f1, f2, err := readTwoFiles(paths, validateOpts)
 	if err != nil {
 		return err
 	}
@@ -46,12 +46,12 @@ func diffFiles(paths []string) error {
 	return nil
 }
 
-func readTwoFiles(paths []string) (*ach.File, *ach.File, error) {
-	f1, err := readACHFile(paths[0])
+func readTwoFiles(paths []string, validateOpts *ach.ValidateOpts) (*ach.File, *ach.File, error) {
+	f1, err := readACHFile(paths[0], validateOpts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("problem reading %s: %v", paths[0], err)
 	}
-	f2, err := readACHFile(paths[1])
+	f2, err := readACHFile(paths[1], validateOpts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("problem reading %s: %v", paths[1], err)
 	}

--- a/cmd/achcli/doc.go
+++ b/cmd/achcli/doc.go
@@ -5,8 +5,10 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/moov-io/ach"
@@ -30,4 +32,11 @@ FLAGS
 `), ach.Version)
 	fmt.Println("")
 	flag.PrintDefaults()
+}
+
+func validationHelp() {
+	fmt.Fprintf(os.Stdout, "\nSpecify validation config file in json foramt to enable valiation opts.\n\nEXAMPLE:\n")
+	sampleJson, _ := json.MarshalIndent(ach.ValidateOpts{}, "", "  ")
+	fmt.Fprintf(os.Stdout, "%s \n", string(sampleJson))
+	fmt.Fprintf(os.Stdout, "\n")
 }

--- a/cmd/achcli/doc.go
+++ b/cmd/achcli/doc.go
@@ -5,10 +5,8 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/moov-io/ach"
@@ -19,12 +17,13 @@ func help() {
 achcli is a tool for displaying Nacha formatted ACH files in a human readable format.
 
 USAGE
-   achcli [-mask] [-pretty] path/to/file.ach
+   achcli [-mask] [-pretty] [-validate opts.json] path/to/file.ach
 
 EXAMPLES
   achcli -diff first.ach second.ach    Show the difference between two ACH files
   achcli -mask file.ach                Print file details with personally identifiable information partially removed
   achcli -reformat=json first.ach      Convert an incoming ACH file into another format (options: ach, json)
+  achcli -validate opts.json file.ach  Read an ACH File with the provided ValidateOpts
   achcli -version                      Print the version of achcli (Example: %s)
   achcli 20060102.ach                  Summarize an ACH file for human readability
 
@@ -32,11 +31,4 @@ FLAGS
 `), ach.Version)
 	fmt.Println("")
 	flag.PrintDefaults()
-}
-
-func validationHelp() {
-	fmt.Fprintf(os.Stdout, "\nSpecify validation config file in json foramt to enable valiation opts.\n\nEXAMPLE:\n")
-	sampleJson, _ := json.MarshalIndent(ach.ValidateOpts{}, "", "  ")
-	fmt.Fprintf(os.Stdout, "%s \n", string(sampleJson))
-	fmt.Fprintf(os.Stdout, "\n")
 }

--- a/cmd/achcli/main.go
+++ b/cmd/achcli/main.go
@@ -44,7 +44,7 @@ var (
 	flagValidateAllowUnorderedBatchNumbers       = flag.Bool("validate.allowUnorderedBatchNumbers", false, "Allow a file to be read with unordered batch numbers")
 	flagValidateAllowInvalidCheckDigit           = flag.Bool("validate.allowInvalidCheckDigit", false, "Allow the CheckDigit field in EntryDetail to differ from the expected calculation")
 	flagValidateUnequalAddendaCounts             = flag.Bool("validate.unequalAddendaCounts", false, "Skip checking that Addenda Count fields match their expected and computed values")
-	flagValidateUnequalServiceClassCode          = flag.Bool("validate.unequalServiceClassCode", false, "Skips equality checks for the ServiceClassCode in each pair of BatchHeader\n")
+	flagValidateUnequalServiceClassCode          = flag.Bool("validate.unequalServiceClassCode", false, "Skip equality checks for the ServiceClassCode in each pair of BatchHeader\n")
 )
 
 func main() {

--- a/cmd/achcli/main.go
+++ b/cmd/achcli/main.go
@@ -15,23 +15,36 @@ import (
 )
 
 var (
-	flagVerbose = flag.Bool("v", false, "Print verbose details about each ACH file")
-	flagVersion = flag.Bool("version", false, "Print moov-io/ach cli version")
+	flagVerbose = flag.Bool("v", false, "Print verbose details about each ACH file\n")
+	flagVersion = flag.Bool("version", false, "Print moov-io/ach cli version\n")
 
-	flagDiff     = flag.Bool("diff", false, "Compare two files against each other")
-	flagFlatten  = flag.Bool("flatten", false, "Flatten batches in each file")
-	flagMerge    = flag.Bool("merge", false, "Merge files before describing")
-	flagReformat = flag.String("reformat", "", "Reformat an incoming ACH file to another format")
+	flagDiff     = flag.Bool("diff", false, "Compare two files against each other\n")
+	flagFlatten  = flag.Bool("flatten", false, "Flatten batches in each file\n")
+	flagMerge    = flag.Bool("merge", false, "Merge files before describing\n")
+	flagReformat = flag.String("reformat", "", "Reformat an incoming ACH file to another format\n")
 
 	flagMask              = flag.Bool("mask", false, "Mask/hide full account numbers and individual names")
 	flagMaskAccounts      = flag.Bool("mask.accounts", false, "Mask/hide full account numbers")
 	flagMaskCorrectedData = flag.Bool("mask.corrections", false, "Mask/Hide Corrected Data in Addenda98 records")
-	flagMaskNames         = flag.Bool("mask.names", false, "Mask/hide full individual names")
+	flagMaskNames         = flag.Bool("mask.names", false, "Mask/hide full individual names\n")
 
 	flagPretty        = flag.Bool("pretty", false, "Display all values in their human readable format")
-	flagPrettyAmounts = flag.Bool("pretty.amounts", false, "Display human readable amounts instead of exact values")
+	flagPrettyAmounts = flag.Bool("pretty.amounts", false, "Display human readable amounts instead of exact values\n")
 
-	flagConfigFileName = flag.String("allow-validate-opts", "", "Path to config file in json format to enable validation opts")
+	flagValidate                                 = flag.String("validate", "", "Path to config file in json format to enable validation opts")
+	flagValidateRequireABAOrigin                 = flag.Bool("validate.requireABAOrigin", false, "Enable routing number validation over the ImmediateOrigin file header field")
+	flagValidateBypassOriginValidation           = flag.Bool("validate.bypassOriginValidation", false, "Skip validation for the ImmediateOrigin file header field")
+	flagValidateBypassDestinationValidation      = flag.Bool("validate.bypassDestinationValidation", false, "Skip validation for the ImmediateDestination file header field")
+	flagValidateCustomTraceNumbers               = flag.Bool("validate.customTraceNumbers", false, "Disable Nacha specified checks of TraceNumbers")
+	flagValidateAllowZeroBatches                 = flag.Bool("validate.allowZeroBatches", false, "Allow the file to have zero batches")
+	flagValidateAllowMissingFileHeader           = flag.Bool("validate.allowMissingFileHeader", false, "Allow a file to be read without a FileHeader record")
+	flagValidateAllowMissingFileControl          = flag.Bool("validate.allowMissingFileControl", false, "Allow a file to be read without a FileControl record")
+	flagValidateBypassCompanyIdentificationMatch = flag.Bool("validate.bypassCompanyIdentificationMatch", false, "Allow batches in which the Company Identification field in the batch header and control do not match")
+	flagValidateCustomReturnCodes                = flag.Bool("validate.customReturnCodes", false, "Skip validation for the Return Code field in an Addenda99")
+	flagValidateAllowUnorderedBatchNumbers       = flag.Bool("validate.allowUnorderedBatchNumbers", false, "Allow a file to be read with unordered batch numbers")
+	flagValidateAllowInvalidCheckDigit           = flag.Bool("validate.allowInvalidCheckDigit", false, "Allow the CheckDigit field in EntryDetail to differ from the expected calculation")
+	flagValidateUnequalAddendaCounts             = flag.Bool("validate.unequalAddendaCounts", false, "Skip checking that Addenda Count fields match their expected and computed values")
+	flagValidateUnequalServiceClassCode          = flag.Bool("validate.unequalServiceClassCode", false, "Skips equality checks for the ServiceClassCode in each pair of BatchHeader\n")
 )
 
 func main() {
@@ -93,23 +106,83 @@ func main() {
 
 func getValidationOpts() (opts *ach.ValidateOpts) {
 
-	if *flagConfigFileName == "" {
-		return
-	}
+	var newOpts ach.ValidateOpts
+	var existFlg bool
 
-	// read config file
-	buf, readErr := os.ReadFile(*flagConfigFileName)
-	if readErr == nil {
-		newOpts := ach.ValidateOpts{}
-		if readErr = json.Unmarshal(buf, &newOpts); readErr == nil {
-			opts = &newOpts
+	if *flagValidate != "" {
+		// read config file
+		buf, readErr := os.ReadFile(*flagValidate)
+		if readErr == nil {
+			if readErr = json.Unmarshal(buf, &newOpts); readErr == nil {
+				opts = &newOpts
+				return
+			}
+		}
+
+		if readErr != nil {
+			validationHelp()
+			os.Exit(1)
 		}
 	}
 
-	if readErr != nil {
-		validationHelp()
-		os.Exit(1)
+	if *flagValidateRequireABAOrigin {
+		existFlg = true
+		newOpts.RequireABAOrigin = true
+	}
+	if *flagValidateBypassOriginValidation {
+		existFlg = true
+		newOpts.BypassOriginValidation = true
+	}
+	if *flagValidateBypassDestinationValidation {
+		existFlg = true
+		newOpts.BypassDestinationValidation = true
+	}
+	if *flagValidateCustomTraceNumbers {
+		existFlg = true
+		newOpts.CustomTraceNumbers = true
 	}
 
+	if *flagValidateAllowZeroBatches {
+		existFlg = true
+		newOpts.AllowZeroBatches = true
+	}
+	if *flagValidateAllowMissingFileHeader {
+		existFlg = true
+		newOpts.AllowMissingFileHeader = true
+	}
+	if *flagValidateAllowMissingFileControl {
+		existFlg = true
+		newOpts.AllowMissingFileControl = true
+	}
+	if *flagValidateBypassCompanyIdentificationMatch {
+		existFlg = true
+		newOpts.BypassCompanyIdentificationMatch = true
+	}
+	if *flagValidateCustomReturnCodes {
+		existFlg = true
+		newOpts.CustomReturnCodes = true
+	}
+	if *flagValidateUnequalServiceClassCode {
+		existFlg = true
+		newOpts.UnequalServiceClassCode = true
+	}
+	if *flagValidateAllowUnorderedBatchNumbers {
+		existFlg = true
+		newOpts.AllowUnorderedBatchNumbers = true
+	}
+	if *flagValidateAllowInvalidCheckDigit {
+		existFlg = true
+		newOpts.AllowInvalidCheckDigit = true
+	}
+	if *flagValidateUnequalAddendaCounts {
+		existFlg = true
+		newOpts.UnequalAddendaCounts = true
+	}
+
+	if !existFlg {
+		return
+	}
+
+	opts = &newOpts
 	return
 }

--- a/cmd/achcli/reformat.go
+++ b/cmd/achcli/reformat.go
@@ -65,14 +65,5 @@ func readJsonFile(path string, validateOpts *ach.ValidateOpts) (*ach.File, error
 		return nil, fmt.Errorf("problem reading %s: %v", path, err)
 	}
 
-	f, err := ach.FileFromJSON(bs)
-	if err != nil {
-		return nil, err
-	}
-
-	if validateErr := f.ValidateWith(validateOpts); validateErr != nil {
-		return nil, validateErr
-	}
-
-	return f, nil
+	return ach.FileFromJSONWith(bs, validateOpts)
 }

--- a/cmd/achcli/reformat.go
+++ b/cmd/achcli/reformat.go
@@ -13,12 +13,12 @@ import (
 	"github.com/moov-io/ach"
 )
 
-func reformat(as string, filepath string) error {
+func reformat(as string, filepath string, validateOpts *ach.ValidateOpts) error {
 	if _, err := os.Stat(filepath); err != nil {
 		return err
 	}
 
-	file, err := readIncomingFile(filepath)
+	file, err := readIncomingFile(filepath, validateOpts)
 	if err != nil {
 		return err
 	}
@@ -41,19 +41,19 @@ func reformat(as string, filepath string) error {
 	return nil
 }
 
-func readIncomingFile(path string) (*ach.File, error) {
-	file, err := readJsonFile(path)
+func readIncomingFile(path string, validateOpts *ach.ValidateOpts) (*ach.File, error) {
+	file, err := readJsonFile(path, validateOpts)
 	if file != nil && err == nil {
 		return file, nil
 	}
-	file, err = readACHFile(path)
+	file, err = readACHFile(path, validateOpts)
 	if file != nil && err == nil {
 		return file, nil
 	}
 	return nil, fmt.Errorf("unable to read %s:\n %v", path, err)
 }
 
-func readJsonFile(path string) (*ach.File, error) {
+func readJsonFile(path string, validateOpts *ach.ValidateOpts) (*ach.File, error) {
 	fd, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("problem opening %s: %v", path, err)
@@ -65,5 +65,14 @@ func readJsonFile(path string) (*ach.File, error) {
 		return nil, fmt.Errorf("problem reading %s: %v", path, err)
 	}
 
-	return ach.FileFromJSON(bs)
+	f, err := ach.FileFromJSON(bs)
+	if err != nil {
+		return nil, err
+	}
+
+	if validateErr := f.ValidateWith(validateOpts); validateErr != nil {
+		return nil, validateErr
+	}
+
+	return f, nil
 }

--- a/docs/usage-command-line.md
+++ b/docs/usage-command-line.md
@@ -10,6 +10,53 @@ menubar: docs-menu
 
 On each release there's an `achcli` utility released. This tool can display ACH files in a human-readable format which is easier to read than their plaintext format. It also allows masking `DFIAccountNumber` values with the `-mask` flag.
 
+## Options
+
+```
+$ achcli -help
+achcli is a tool for displaying Nacha formatted ACH files in a human readable format.
+
+USAGE
+   achcli [-mask] [-pretty] [-validate opts.json] path/to/file.ach
+
+EXAMPLES
+  achcli -diff first.ach second.ach    Show the difference between two ACH files
+  achcli -mask file.ach                Print file details with personally identifiable information partially removed
+  achcli -reformat=json first.ach      Convert an incoming ACH file into another format (options: ach, json)
+  achcli -validate opts.json file.ach  Read an ACH File with the provided ValidateOpts
+  achcli -version                      Print the version of achcli (Example: v1.26.4)
+  achcli 20060102.ach                  Summarize an ACH file for human readability
+
+FLAGS
+  -diff
+    	Compare two files against each other
+  -flatten
+    	Flatten batches in each file
+  -mask
+    	Mask/hide full account numbers and individual names
+  -mask.accounts
+    	Mask/hide full account numbers
+  -mask.corrections
+    	Mask/Hide Corrected Data in Addenda98 records
+  -mask.names
+    	Mask/hide full individual names
+  -merge
+    	Merge files before describing
+  -pretty
+    	Display all values in their human readable format
+  -pretty.amounts
+    	Display human readable amounts instead of exact values
+  -reformat string
+    	Reformat an incoming ACH file to another format
+  -v	Print verbose details about each ACH file
+  -validate string
+    	Path to config file in json format to enable validation opts
+  -version
+    	Print moov-io/ach cli version
+```
+
+## Install and Usage
+
 ```
 $ wget -O achcli https://github.com/moov-io/ach/releases/download/v1.6.1/achcli-darwin-amd64 && chmod +x achcli
 
@@ -20,10 +67,10 @@ Describing ACH file 'test/testdata/ppd-debit.ach'
   121042882  My Bank Name  231380104    Federal Reserve Bank  190624            0000
 
   BatchNumber  SECCode  ServiceClassCode  CompanyName      DiscretionaryData  Identification  EntryDescription  DescriptiveDate
-  1            PPD      225 (Debits Only)  Name on Account                     121042882       REG.SALARY        
+  1            PPD      225 (Debits Only)  Name on Account                     121042882       REG.SALARY
 
     TransactionCode   RDFIIdentification  AccountNumber      Amount     Name                    TraceNumber      Category
-    27 (Checking Debit)  23138010            12345678           100000000  Receiver Account Name   121042880000001  
+    27 (Checking Debit)  23138010            12345678           100000000  Receiver Account Name   121042880000001
 
   ServiceClassCode  EntryAddendaCount  EntryHash  TotalDebits  TotalCredits  MACCode  ODFIIdentification  BatchNumber
   225 (Debits Only)  1                  23138010   100000000    0                      12104288            1

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/common v0.38.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rickar/cal/v2 v2.1.9 // indirect
-	golang.org/x/net v0.3.0 // indirect
+	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.3.0 h1:VWL6FNY2bEEmsGVKabSlHu5Irp34xmMRoqb/9lF9lxk=
 golang.org/x/net v0.3.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
+golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
+golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/oauth2 v0.3.0 h1:6l90koy8/LaBLmLu8jpHeHexzMwEita0zFfYlggy2F8=
 golang.org/x/oauth2 v0.3.0/go.mod h1:rQrIauxkUhJ6CuwEXwymO2/eh4xz2ZWF1nBkcxS+tGk=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
ValidateOpts has a lot of options 
To add all of the options using cli flags is uncomfortable, because cli has a lot of flags

Added one flag that specify validation opts config file 

```
#achcli --help

achcli is a tool for displaying Nacha formatted ACH files in a human readable format.

USAGE
   achcli [-mask] [-pretty] path/to/file.ach

EXAMPLES
  achcli -diff first.ach second.ach    Show the difference between two ACH files
  achcli -mask file.ach                Print file details with personally identifiable information partially removed
  achcli -reformat=json first.ach      Convert an incoming ACH file into another format (options: ach, json)        
  achcli -version                      Print the version of achcli (Example: v1.26.4)
  achcli 20060102.ach                  Summarize an ACH file for human readability

FLAGS
  -diff
        Compare two files against each other

  -flatten
        Flatten batches in each file

  -mask
        Mask/hide full account numbers and individual names
  -mask.accounts
        Mask/hide full account numbers
  -mask.corrections
        Mask/Hide Corrected Data in Addenda98 records      
  -mask.names
        Mask/hide full individual names

  -merge
        Merge files before describing

  -pretty
        Display all values in their human readable format  
  -pretty.amounts
        Display human readable amounts instead of exact values

  -reformat string
        Reformat an incoming ACH file to another format

  -v    Print verbose details about each ACH file

  -validate string
        Path to config file in json format to enable validation opts
  -validate.allowInvalidCheckDigit
        Allow the CheckDigit field in EntryDetail to differ from the expected calculation
  -validate.allowMissingFileControl
        Allow a file to be read without a FileControl record
  -validate.allowMissingFileHeader
        Allow a file to be read without a FileHeader record
  -validate.allowUnorderedBatchNumbers
        Allow a file to be read with unordered batch numbers
  -validate.allowZeroBatches
        Allow the file to have zero batches
  -validate.bypassCompanyIdentificationMatch
        Allow batches in which the Company Identification field in the batch header and control do not match
  -validate.bypassDestinationValidation
        Skip validation for the ImmediateDestination file header field
  -validate.bypassOriginValidation
        Skip validation for the ImmediateOrigin file header field
  -validate.customReturnCodes
        Skip validation for the Return Code field in an Addenda99
  -validate.customTraceNumbers
        Disable Nacha specified checks of TraceNumbers
  -validate.requireABAOrigin
        Enable routing number validation over the ImmediateOrigin file header field
  -validate.unequalAddendaCounts
        Skip checking that Addenda Count fields match their expected and computed values
  -validate.unequalServiceClassCode
        Skip equality checks for the ServiceClassCode in each pair of BatchHeader

  -version
        Print moov-io/ach cli version

```

if use invalid config file, display example config file 

```
#achcli -validate=unknown sample.ach

Specify validation config file in json foramt to enable valiation opts.

EXAMPLE:
{
  "requireABAOrigin": false,
  "bypassOriginValidation": false,
  "bypassDestinationValidation": false,
  "customTraceNumbers": false,
  "allowZeroBatches": false,
  "allowMissingFileHeader": false,
  "allowMissingFileControl": false,
  "bypassCompanyIdentificationMatch": false,
  "customReturnCodes": false,
  "unequalServiceClassCode": false,
  "allowUnorderedBatchNumbers": false,
  "allowInvalidCheckDigit": false,
  "unequalAddendaCounts": false
}
```
