### PR TITLE
feat: use testify's `assert` package for `Valid` unit tests

### DIFF
--- a/internal/iso3166/validate_test.go
+++ b/internal/iso3166/validate_test.go
@@ -15,26 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package iso3166
+package iso3166_test
 
 import (
+	"github.com/moov-io/ach/internal/iso3166"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestValidate(t *testing.T) {
-	if !Valid("US") {
-		t.Error("expected valid")
-	}
-
-	if !Valid("SS") {
-		t.Error("expected valid")
-	}
-
-	if Valid("") {
-		t.Errorf("invalid")
-	}
-
-	if Valid("QZ") {
-		t.Errorf("invalid")
-	}
+	assert.True(t, iso3166.Valid("US"))
+	assert.True(t, iso3166.Valid("SS"))
+	assert.False(t, iso3166.Valid(""))
+	assert.False(t, iso3166.Valid("QZ"))
 }

--- a/internal/iso4217/validate_test.go
+++ b/internal/iso4217/validate_test.go
@@ -15,26 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package iso4217
+package iso4217_test
 
 import (
+	"github.com/moov-io/ach/internal/iso4217"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestValidate(t *testing.T) {
-	if !Valid("USD") {
-		t.Error("expected valid")
-	}
-
-	if !Valid("eur") {
-		t.Error("expected valid")
-	}
-
-	if Valid("") {
-		t.Errorf("invalid")
-	}
-
-	if Valid("QZA") {
-		t.Errorf("invalid")
-	}
+	assert.True(t, iso4217.Valid("USD"))
+	assert.True(t, iso4217.Valid("eur"))
+	assert.False(t, iso4217.Valid(""))
+	assert.False(t, iso4217.Valid("QZA"))
 }


### PR DESCRIPTION
* use `assert.True` and `assert.False` instead of `if !Valid` and `if Valid` as that seemed to be clearer.
* change packages to `iso4217_test` and `iso3166_test` to make sure only exported functions can be tested.

Let me know if these changes make sense. I saw the repo was already using testify's `require` package.