### PR TITLE
changed currency format

### DIFF
--- a/cmd/achcli/describe/file.go
+++ b/cmd/achcli/describe/file.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/moov-io/ach"
 
+	"golang.org/x/text/currency"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
-	"golang.org/x/text/number"
 )
 
 type Opts struct {
@@ -195,8 +195,8 @@ func formatAmount(prettyAmounts bool, amt int) string {
 	}
 
 	printer := message.NewPrinter(language.Und)
-	formatter := number.Decimal(float64(amt)/100.0, number.MinFractionDigits(2))
-	return printer.Sprint(formatter)
+	printedCurrency := printer.Sprint(currency.NarrowSymbol(currency.USD.Amount(float64(amt) / 100)))
+	return strings.ReplaceAll(printedCurrency, " ", "")
 }
 
 func dumpAddenda02(w *tabwriter.Writer, a *ach.Addenda02) {

--- a/cmd/achcli/describe/file_test.go
+++ b/cmd/achcli/describe/file_test.go
@@ -64,8 +64,8 @@ func TestDescribeCorrection(t *testing.T) {
 
 func TestFormatAmount(t *testing.T) {
 	require.Equal(t, "12345", formatAmount(false, 12345))
-	require.Equal(t, "123.45", formatAmount(true, 12345))
-	require.Equal(t, "1,234,567.89", formatAmount(true, 123456789))
+	require.Equal(t, "$123.45", formatAmount(true, 12345))
+	require.Equal(t, "$1,234,567.89", formatAmount(true, 123456789))
 }
 
 func TestMaskNumber(t *testing.T) {


### PR DESCRIPTION
human readable currency for amount implemented yet
- "12,345.68" instead of "1234568"

updated this function using https://pkg.go.dev/golang.org/x/text@v0.4.0/currency
- "$12,345.68" instead of "1234568"


Dump file example:
```
Describing ACH file 'examples/testdata/ack-read.ach'

  Origin      OriginName               Destination  DestinationName          FileCreationDate  FileCreationTime
   231380104  My Bank Name              031300012   Federal Reserve Bank     190816            1055

  BatchNumber  SECCode  ServiceClassCode    CompanyName       DiscretionaryData     Identification  EntryDescription  EffectiveEntryDate  DescriptiveDate
  0000001      ACK      220 (Credits Only)  Name on Account                         231380104       Vndr Pay          190816

    TransactionCode                              RDFIIdentification  AccountNumber      Amount  Name                    TraceNumber      Category        
    24 (Checking Zero Dollar Remittance Credit)  03130001            744-5678-99        $0.00   Best. #1                231380100000001  Forward

    TransactionCode                              RDFIIdentification  AccountNumber      Amount  Name                    TraceNumber      Category        
    24 (Checking Zero Dollar Remittance Credit)  03130001            744-5678-99        $0.00   Best. #1                231380100000002  Forward

  ServiceClassCode    EntryAddendaCount  EntryHash   TotalDebits  TotalCredits  MACCode              ODFIIdentification  BatchNumber
  220 (Credits Only)  000002             0006260002  $0.00        $0.00                              23138010            0000001

  BatchCount  BlockCount  EntryAddendaCount  TotalDebitAmount  TotalCreditAmount
  000001      000001      00000002           $0.00             $0.00

```
