### PR TITLE
fix: COR batches should allow NOC/Prenote Transaction Codes

### DIFF
--- a/batchCOR.go
+++ b/batchCOR.go
@@ -59,21 +59,14 @@ func (batch *BatchCOR) Validate() error {
 	}
 
 	for _, entry := range batch.Entries {
-		/* COR TransactionCode must be a Return or NOC transaction Code
-		   Return/NOC
-		   Credit:  21, 31, 41, 51
-		   Debit: 26, 36, 46, 56
-		*/
+		// COR TransactionCode must be a Return or NOC transaction Code
 		switch entry.TransactionCode {
-		case
-			CheckingCredit, CheckingDebit, CheckingPrenoteCredit, CheckingPrenoteDebit,
-			CheckingZeroDollarRemittanceCredit, CheckingZeroDollarRemittanceDebit,
-			SavingsCredit, SavingsDebit, SavingsPrenoteCredit, SavingsPrenoteDebit,
-			SavingsZeroDollarRemittanceCredit, SavingsZeroDollarRemittanceDebit,
-			GLCredit, GLDebit, GLPrenoteCredit, GLPrenoteDebit, GLZeroDollarRemittanceCredit,
-			GLZeroDollarRemittanceDebit, LoanCredit, LoanDebit, LoanPrenoteCredit,
-			LoanZeroDollarRemittanceCredit:
+		case CheckingCredit, CheckingZeroDollarRemittanceCredit, CheckingDebit, CheckingZeroDollarRemittanceDebit,
+			SavingsCredit, SavingsZeroDollarRemittanceCredit, SavingsDebit, SavingsZeroDollarRemittanceDebit,
+			GLCredit, GLZeroDollarRemittanceCredit, GLDebit, GLZeroDollarRemittanceDebit,
+			LoanCredit, LoanZeroDollarRemittanceCredit, LoanDebit:
 			return batch.Error("TransactionCode", ErrBatchTransactionCode, entry.TransactionCode)
+
 		}
 		// Verify the Amount is valid for SEC code and TransactionCode
 		if err := batch.ValidAmountForCodes(entry); err != nil {

--- a/batchCOR_test.go
+++ b/batchCOR_test.go
@@ -358,7 +358,7 @@ func TestBatchCORCategoryNOCAddenda02(t *testing.T) {
 	}
 }
 
-// TestBatchCORCategoryNOCAddenda98 validates that no error is returned if Addenda098 is defined for CategoryNOC
+// TestBatchCORCategoryNOCAddenda98 validates that no error is returned if Addenda98 is defined for CategoryNOC
 func TestBatchCORCategoryNOCAddenda98(t *testing.T) {
 	mockBatch := NewBatchCOR(mockBatchCORHeader())
 	mockBatch.AddEntry(mockCOREntryDetail())


### PR DESCRIPTION
Found this when working on handling prenotes in ach-test-harness. 