### PR TITLE
feat: add AllowInvalidAmounts validation option

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1016,6 +1016,9 @@ func (batch *Batch) IsADV() bool {
 }
 
 func (batch *Batch) ValidAmountForCodes(entry *EntryDetail) error {
+	if batch.validateOpts != nil && batch.validateOpts.AllowInvalidAmounts {
+		return nil
+	}
 	if entry != nil && entry.Addenda98 != nil {
 		// NOC entries will have a zero'd amount value
 		if entry.Amount != 0 {

--- a/docs/create-file.md
+++ b/docs/create-file.md
@@ -44,6 +44,7 @@ Example: `POST /files/create?requireABAOrigin=true&bypassDestination=true`
 
 | Query Param                        | Validation Option                  |
 |------------------------------------|------------------------------------|
+| `allowInvalidAmounts`              | `AllowInvalidAmounts`              |
 | `allowInvalidCheckDigit`           | `AllowInvalidCheckDigit`           |
 | `allowMissingFileControl`          | `AllowMissingFileControl`          |
 | `allowMissingFileHeader`           | `AllowMissingFileHeader`           |

--- a/docs/custom-validation.md
+++ b/docs/custom-validation.md
@@ -87,6 +87,13 @@ AllowUnorderedBatchNumbers bool `json:"allowUnorderedBatchNumbers"`
 UnequalAddendaCounts bool `json:"unequalAddendaCounts"`
 ```
 
+### Entries
+
+```
+// AllowInvalidAmounts will skip verifying the Amount is valid for the TransactionCode and entry type.
+AllowInvalidAmounts bool `json:"allowInvalidAmounts"`
+```
+
 ### File Header
 
 ```
@@ -107,6 +114,13 @@ AllowMissingFileControl bool `json:"allowMissingFileControl"`
 // CustomReturnCodes can be set to skip validation for the Return Code field in an Addenda99
 // This allows for non-standard/deprecated return codes (e.g. R97)
 CustomReturnCodes bool `json:"customReturnCodes"`
+```
+
+### Parsing
+
+```
+// PreserveSpaces keeps the spacing before and after values that normally have spaces trimmed during parsing.
+PreserveSpaces bool `json:"preserveSpaces"`
 ```
 
 ## Reader

--- a/file.go
+++ b/file.go
@@ -683,6 +683,9 @@ type ValidateOpts struct {
 
 	// PreserveSpaces keeps the spacing before and after values that normally have spaces trimmed during parsing.
 	PreserveSpaces bool `json:"preserveSpaces"`
+
+	// AllowInvalidAmounts will skip verifying the Amount is valid for the TransactionCode and entry type.
+	AllowInvalidAmounts bool `json:"allowInvalidAmounts"`
 }
 
 // ValidateWith performs checks on each record according to Nacha guidelines.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -149,6 +149,11 @@ paths:
           description: Optional parameter to save all padding spaces
           schema:
             type: boolean
+        - name: allowInvalidAmounts
+          in: query
+          description: Optional parameter to save all padding spaces
+          schema:
+            type: boolean
       requestBody:
         description: Content of the ACH file (in json or raw text)
         required: true

--- a/server/files.go
+++ b/server/files.go
@@ -138,6 +138,7 @@ func decodeCreateFileRequest(_ context.Context, request *http.Request) (interfac
 		allowInvalidCheckDigit           = "allowInvalidCheckDigit"
 		unequalAddendaCounts             = "unequalAddendaCounts"
 		preserveSpaces                   = "preserveSpaces"
+		allowInvalidAmounts              = "allowInvalidAmounts"
 	)
 
 	validationNames := []string{
@@ -156,6 +157,7 @@ func decodeCreateFileRequest(_ context.Context, request *http.Request) (interfac
 		allowInvalidCheckDigit,
 		unequalAddendaCounts,
 		preserveSpaces,
+		allowInvalidAmounts,
 	}
 
 	for _, name := range validationNames {
@@ -203,6 +205,8 @@ func decodeCreateFileRequest(_ context.Context, request *http.Request) (interfac
 			req.validateOpts.UnequalAddendaCounts = true
 		case preserveSpaces:
 			req.validateOpts.PreserveSpaces = true
+		case allowInvalidAmounts:
+			req.validateOpts.AllowInvalidAmounts = true
 		}
 	}
 

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -291,6 +291,12 @@ func TestFiles__decodeCreateFileRequest__validateOpts(t *testing.T) {
 				PreserveSpaces: true,
 			},
 		},
+		{
+			query: "?allowInvalidAmounts=true",
+			expect: ach.ValidateOpts{
+				AllowInvalidAmounts: true,
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
We are seeing prenote returns with incorrect amounts/transaction codes. 

```
// AllowInvalidAmounts will skip verifying the Amount is valid for the TransactionCode and entry type.
AllowInvalidAmounts bool `json:"allowInvalidAmounts"`
```