### PR TITLE
fix: BatchHeaders are different with mismatching CompanyEntryDescription values

### DIFF
--- a/batchHeader.go
+++ b/batchHeader.go
@@ -78,6 +78,7 @@ type BatchHeader struct {
 	// This field must contain the word "NONSETTLED" (left justified) when the
 	// batch contains entries which could not settle.
 	CompanyEntryDescription string `json:"companyEntryDescription,omitempty"`
+
 	// CompanyDescriptiveDate currently, the Rules provide that the “Originator establishes this field as the date it
 	// would like to see displayed to the Receiver for descriptive purposes.” NACHA recommends that, as desired,
 	// the content of this field be formatted using the convention “SDHHMM”, where the “SD” in positions 64- 65 denotes
@@ -221,6 +222,9 @@ func (bh *BatchHeader) Equal(other *BatchHeader) bool {
 		return false
 	}
 	if bh.StandardEntryClassCode != other.StandardEntryClassCode {
+		return false
+	}
+	if bh.CompanyEntryDescription != other.CompanyEntryDescription {
 		return false
 	}
 	if bh.EffectiveEntryDate != other.EffectiveEntryDate {

--- a/batchHeader_test.go
+++ b/batchHeader_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/moov-io/base"
+
+	"github.com/stretchr/testify/require"
 )
 
 // mockBatchHeader creates a batch header
@@ -162,6 +164,16 @@ func BenchmarkBHString(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		testBHString(b)
 	}
+}
+
+func TestBatchHeader_Equal(t *testing.T) {
+	bh1 := mockBatchHeader()
+	bh2 := mockBatchHeader()
+	require.True(t, bh1.Equal(bh2))
+
+	bh1.CompanyEntryDescription = "9697"
+	bh2.CompanyEntryDescription = "9669"
+	require.False(t, bh1.Equal(bh2))
 }
 
 // testInvalidServiceCode validates error if service code is not valid


### PR DESCRIPTION

This comes up sometimes where customers put invoice numbers in this field and they see incorrect values in OLB memos.