### PR TITLE
fix: allow .Create() to skip validation when configured

### DIFF
--- a/file.go
+++ b/file.go
@@ -454,18 +454,18 @@ func (f *File) Create() error {
 	if opts == nil {
 		opts = &ValidateOpts{}
 	}
-
-	// Requires a valid FileHeader to build FileControl
-	if !opts.AllowMissingFileHeader {
-		if err := f.Header.Validate(); err != nil {
-			return err
+	if !opts.SkipAll {
+		// Requires a valid FileHeader to build FileControl
+		if !opts.AllowMissingFileHeader {
+			if err := f.Header.Validate(); err != nil {
+				return err
+			}
 		}
-	}
 
-	// If AllowZeroBatches is false, require at least one Batch in the new file.
-	if (f.validateOpts == nil || !f.validateOpts.AllowZeroBatches) &&
-		len(f.Batches) <= 0 && len(f.IATBatches) <= 0 {
-		return ErrFileNoBatches
+		// If AllowZeroBatches is false, require at least one Batch in the new file.
+		if !opts.AllowZeroBatches && (len(f.Batches) <= 0 && len(f.IATBatches) <= 0) {
+			return ErrFileNoBatches
+		}
 	}
 
 	if !f.IsADV() {

--- a/file_test.go
+++ b/file_test.go
@@ -77,6 +77,16 @@ func mockFileADV() *File {
 	return mockFile
 }
 
+func TestFile_CreateWithoutValidation(t *testing.T) {
+	file := NewFile()
+	require.ErrorContains(t, file.Create(), "ImmediateDestination")
+
+	file.SetValidation(&ValidateOpts{
+		SkipAll: true,
+	})
+	require.NoError(t, file.Validate())
+}
+
 // testFileError validates a file error
 func testFileError(t testing.TB) {
 	err := &FileError{FieldName: "mock", Msg: "test message"}


### PR DESCRIPTION
Needed for https://github.com/moov-io/achgateway/issues/182 