### PR TITLE
test: add benchmark for MergeFiles

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -47,11 +47,28 @@ func NewMerger(opts *ValidateOpts) Merger {
 
 // Merge can merge ACH files with custom ValidateOpts
 type Merger interface {
+	Files() []*File
+	MergeFile(file *File, conditions Conditions) error
+
 	MergeWith(files []*File, conditions Conditions) ([]*File, error)
 }
 
 type merger struct {
-	opts *ValidateOpts
+	merged []*File
+	opts   *ValidateOpts
+}
+
+func (m *merger) Files() []*File {
+	return m.merged
+}
+
+func (m *merger) MergeFile(file *File, conditions Conditions) error {
+	result, err := m.MergeWith(append(m.merged, file), conditions)
+	if err != nil {
+		return err
+	}
+	m.merged = result
+	return nil
 }
 
 func (m *merger) MergeWith(files []*File, conditions Conditions) ([]*File, error) {

--- a/merge.go
+++ b/merge.go
@@ -47,28 +47,11 @@ func NewMerger(opts *ValidateOpts) Merger {
 
 // Merge can merge ACH files with custom ValidateOpts
 type Merger interface {
-	Files() []*File
-	MergeFile(file *File, conditions Conditions) error
-
 	MergeWith(files []*File, conditions Conditions) ([]*File, error)
 }
 
 type merger struct {
-	merged []*File
-	opts   *ValidateOpts
-}
-
-func (m *merger) Files() []*File {
-	return m.merged
-}
-
-func (m *merger) MergeFile(file *File, conditions Conditions) error {
-	result, err := m.MergeWith(append(m.merged, file), conditions)
-	if err != nil {
-		return err
-	}
-	m.merged = result
-	return nil
+	opts *ValidateOpts
 }
 
 func (m *merger) MergeWith(files []*File, conditions Conditions) ([]*File, error) {

--- a/merge_bench_test.go
+++ b/merge_bench_test.go
@@ -1,0 +1,102 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ach
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func BenchmarkMergeFiles(b *testing.B) {
+	randomFile := func(B *testing.B) *File {
+		B.Helper()
+
+		file := NewFile()
+		file.SetHeader(mockFileHeader())
+		file.Control = mockFileControl()
+
+		base := fmt.Sprintf("%d", time.Now().UnixMilli())[:8]
+
+		for b := 0; b < 10; b++ {
+			batch := mockBatchPPD()
+			for e := 1; e < 20; e++ {
+				entry := mockPPDEntryDetail()
+
+				traceNumber, err := strconv.ParseInt(fmt.Sprintf("%s%d%d", base, b, e), 10, 64)
+				if err != nil {
+					B.Error(err)
+				}
+				entry.SetTraceNumber(batch.GetHeader().ODFIIdentification, int(traceNumber))
+
+				batch.AddEntry(entry)
+			}
+			file.AddBatch(batch)
+		}
+		if err := file.Create(); err != nil {
+			B.Error(err)
+		}
+
+		return file
+	}
+
+	randomFiles := func(b *testing.B) (out []*File) {
+		b.Helper()
+		for i := 0; i < b.N; i++ {
+			out = append(out, randomFile(b))
+		}
+		return
+	}
+
+	b.Run("MergeFiles", func(b *testing.B) {
+		files := randomFiles(b)
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		out, err := MergeFiles(files)
+		b.StopTimer()
+
+		if err != nil {
+			b.Error(err)
+		}
+		if n := len(out); n == 0 {
+			b.Error("no files merged")
+		}
+	})
+
+	b.Run("Merger.MergeFile", func(b *testing.B) {
+		files := randomFiles(b)
+		m := NewMerger(nil)
+		var cond Conditions
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := range files {
+			err := m.MergeFile(files[i], cond)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+		b.StopTimer()
+
+		if n := len(m.Files()); n == 0 {
+			b.Error("no files merged")
+		}
+	})
+}

--- a/merge_bench_test.go
+++ b/merge_bench_test.go
@@ -79,24 +79,4 @@ func BenchmarkMergeFiles(b *testing.B) {
 			b.Error("no files merged")
 		}
 	})
-
-	b.Run("Merger.MergeFile", func(b *testing.B) {
-		files := randomFiles(b)
-		m := NewMerger(nil)
-		var cond Conditions
-		b.ReportAllocs()
-		b.ResetTimer()
-
-		for i := range files {
-			err := m.MergeFile(files[i], cond)
-			if err != nil {
-				b.Error(err)
-			}
-		}
-		b.StopTimer()
-
-		if n := len(m.Files()); n == 0 {
-			b.Error("no files merged")
-		}
-	})
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -459,38 +459,3 @@ func populateFileWithMockBatches(t *testing.T, numBatches int, file *File) {
 		file.AddBatch(batch)
 	}
 }
-
-func TestMerger__MergeFile(t *testing.T) {
-	f1, err := readACHFilepath(filepath.Join("test", "testdata", "ppd-debit.ach"))
-	require.NoError(t, err)
-
-	f2, err := readACHFilepath(filepath.Join("test", "testdata", "web-debit.ach"))
-	require.NoError(t, err)
-	f2.Header = f1.Header // replace Header so they're merged into one file
-
-	f3, err := readACHFilepath(filepath.Join("test", "testdata", "20110805A.ach"))
-	require.NoError(t, err)
-	f3.Header = f1.Header
-
-	require.Len(t, f1.Batches, 1)
-	require.Len(t, f2.Batches, 3)
-	require.Len(t, f3.Batches, 2)
-
-	var cond Conditions
-
-	m := NewMerger(nil)
-	err = m.MergeFile(f1, cond)
-	require.NoError(t, err)
-	err = m.MergeFile(f2, cond)
-	require.NoError(t, err)
-	err = m.MergeFile(f3, cond)
-	require.NoError(t, err)
-
-	out := m.Files()
-	require.Len(t, out, 1)
-	require.Len(t, out[0].Batches, 6)
-
-	for i := range out {
-		require.NoError(t, out[i].Validate(), fmt.Sprintf("batch[%d] is invalid", i))
-	}
-}


### PR DESCRIPTION
I was trying out a different pattern (and to merge files one-by-one) but ran into some serious performance penalty. 

```
gotest . -bench BenchmarkMergeFiles -v -run BenchmarkMergeFiles 
goos: darwin
goarch: amd64
pkg: github.com/moov-io/ach
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkMergeFiles
BenchmarkMergeFiles/MergeFiles
BenchmarkMergeFiles/MergeFiles-16         	    2160	    610758 ns/op	   18685 B/op	    2315 allocs/op
BenchmarkMergeFiles/Merger.MergeFile
BenchmarkMergeFiles/Merger.MergeFile-16   	     100	  26960290 ns/op	  943819 B/op	  116916 allocs/op
PASS
ok  	github.com/moov-io/ach	5.637s
```