### PR TITLE
perf: reduce allocations in some formatting and validation functions

### DIFF
--- a/converters.go
+++ b/converters.go
@@ -65,6 +65,9 @@ var (
 	stringZeros map[int]string = populateMap(94, "0")
 )
 
+// populateMap will allocate strings for padding ACH fields.
+//
+// In Go strings are immutable so they can be reused across objects without needing to allocate new objects.
 func populateMap(max int, zero string) map[int]string {
 	out := make(map[int]string, max)
 	for i := 0; i < max; i++ {

--- a/validators.go
+++ b/validators.go
@@ -471,29 +471,30 @@ func CalculateCheckDigit(routingNumber string) int {
 		return -1
 	}
 
-	var routeIndex [8]string
-	for i := 0; i < 8; i++ {
-		if routingNumber[i] < '0' || routingNumber[i] > '9' {
+	var sum int
+	for i, r := range routingNumber {
+		// Don't process check digit of routing number
+		if i >= 8 {
+			break
+		}
+
+		// Reject anything that's not a digit
+		if r < '0' || r > '9' {
 			return -1 // only digits are allowed
 		}
-		routeIndex[i] = string(routingNumber[i])
+
+		// Calculate the check digit
+		var n int32 = (r - '0')
+
+		switch i {
+		case 0, 3, 6:
+			sum += int(n * 3)
+		case 1, 4, 7:
+			sum += int(n * 7)
+		case 2, 5:
+			sum += int(n)
+		}
 	}
-	n, _ := strconv.Atoi(routeIndex[0])
-	sum := n * 3
-	n, _ = strconv.Atoi(routeIndex[1])
-	sum = sum + (n * 7)
-	n, _ = strconv.Atoi(routeIndex[2])
-	sum = sum + n // multiply by 1
-	n, _ = strconv.Atoi(routeIndex[3])
-	sum = sum + (n * 3)
-	n, _ = strconv.Atoi(routeIndex[4])
-	sum = sum + (n * 7)
-	n, _ = strconv.Atoi(routeIndex[5])
-	sum = sum + n // multiply by 1
-	n, _ = strconv.Atoi(routeIndex[6])
-	sum = sum + (n * 3)
-	n, _ = strconv.Atoi(routeIndex[7])
-	sum = sum + (n * 7)
 
 	return roundUp10(sum) - sum
 }

--- a/validators_bench_test.go
+++ b/validators_bench_test.go
@@ -31,7 +31,7 @@ func BenchmarkCalculateCheckDigit(b *testing.B) {
 	}
 
 	aba := func(b *testing.B) string {
-		idx := rand.Int() % len(routingNumbers)
+		idx := rand.Int() % len(routingNumbers) //nolint:gosec
 		out := routingNumbers[idx]
 		return out
 	}

--- a/validators_bench_test.go
+++ b/validators_bench_test.go
@@ -1,0 +1,52 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ach
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkCalculateCheckDigit(b *testing.B) {
+	var routingNumbers = []string{
+		"053902197", "067014822", "273976369", "026009593", "071101307", "322271627",
+		"121000358", "028000121", "054001725", "011401533", "322271724", "121042882",
+		"021000021", "063100277", "071000013", "314074269", "063107513", "111000025",
+		"031201360", "031176110", "991221943", "994489520", "724524972", "726286823",
+	}
+
+	aba := func(b *testing.B) string {
+		idx := rand.Int() % len(routingNumbers)
+		out := routingNumbers[idx]
+		return out
+	}
+
+	b.Run("valid", func(b *testing.B) {
+		num := aba(b)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			got := CalculateCheckDigit(num)
+
+			last := int(num[8] - '0')
+			if last != got {
+				b.Errorf("ABA=%v got=%v expected=%v", num, got, last)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Two nice performance / memory improvements. 

<details>
<summary>numericField</summary>

```
goos: darwin
goarch: amd64
pkg: github.com/moov-io/ach
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkNumericFieldShort
BenchmarkNumericFieldShort-16    	97991214	       118.7 ns/op	      24 B/op	       3 allocs/op
BenchmarkNumericFieldLong
BenchmarkNumericFieldLong-16     	338344930	        36.13 ns/op	       8 B/op	       1 allocs/op
PASS
ok  	github.com/moov-io/ach	28.253s
```

```
goos: darwin
goarch: amd64
pkg: github.com/moov-io/ach
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkNumericFieldShort
BenchmarkNumericFieldShort-16    	186805923	        64.67 ns/op	      16 B/op	       2 allocs/op
BenchmarkNumericFieldLong
BenchmarkNumericFieldLong-16     	398885554	        30.35 ns/op	       8 B/op	       1 allocs/op
PASS
ok  	github.com/moov-io/ach	34.381s
```

</details>


<details>
<summary>CalculateCheckDigit</summary>

```
goos: darwin
goarch: amd64
pkg: github.com/moov-io/ach
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkCalculateCheckDigit
BenchmarkCalculateCheckDigit/valid
BenchmarkCalculateCheckDigit/valid-16         	85632897	       139.3 ns/op	      32 B/op	       8 allocs/op
PASS
ok  	github.com/moov-io/ach	12.267s
```

```
goos: darwin
goarch: amd64
pkg: github.com/moov-io/ach
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkCalculateCheckDigit
BenchmarkCalculateCheckDigit/valid
BenchmarkCalculateCheckDigit/valid-16         	437170713	        27.36 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/moov-io/ach	15.385s
```