### PR TITLE
Better wrap text output in textarea for webui

### DIFF
--- a/cmd/webui/assets/index.html
+++ b/cmd/webui/assets/index.html
@@ -53,6 +53,8 @@
         }
         [id="contentoutput"] {
             grid-area: output;
+            white-space: pre;
+            overflow: auto;
         }
         header {
             grid-area: header;


### PR DESCRIPTION
Enable better wrapping for the output textarea to ensure no auto-wrapping occurs, which makes the "human readable" output much harder to read without copy/pasting the text into another editor