### PR TITLE
Use constructor to create IATEntryDetails when parsing IAT batches

### DIFF
--- a/cmd/achcli/describe/file_test.go
+++ b/cmd/achcli/describe/file_test.go
@@ -35,7 +35,7 @@ func TestDescribeIAT(t *testing.T) {
 	if testing.Verbose() {
 		os.Stdout.Write(buf.Bytes())
 	}
-	require.Equal(t, 5255, buf.Len())
+	require.Equal(t, 5262, buf.Len())
 }
 
 func TestDescribeReturn(t *testing.T) {

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -192,7 +192,7 @@ func (iatEd *IATEntryDetail) Parse(record string) {
 			iatEd.Amount = iatEd.parseNumField(reset())
 		case 74:
 			// 40-74 The foreign receiver's account number you are crediting/debiting
-			iatEd.DFIAccountNumber = string(reset())
+			iatEd.DFIAccountNumber = iatEd.parseStringFieldWithOpts(reset(), iatEd.validateOpts)
 		case 76:
 			// 75-76 reserved Leave blank
 			reset()

--- a/iatEntryDetail_test.go
+++ b/iatEntryDetail_test.go
@@ -92,7 +92,7 @@ func BenchmarkIATMockEntryDetail(b *testing.B) {
 
 // testParseIATEntryDetail parses a known IATEntryDetail record string.
 func testParseIATEntryDetail(t testing.TB) {
-	var line = "6221210428820007             000010000012345678901234567890123456789012345    1231380100000001"
+	var line = "6221210428820007             0000100000123456789012345678901234567890         1231380100000001"
 	r := NewReader(strings.NewReader(line))
 	r.addIATCurrentBatch(NewIATBatch(mockIATBatchHeaderFF()))
 	r.IATCurrentBatch.SetHeader(mockIATBatchHeaderFF())
@@ -118,8 +118,11 @@ func testParseIATEntryDetail(t testing.TB) {
 	if record.AmountField() != "0000100000" {
 		t.Errorf("Amount Expected '0000100000' got: %v", record.AmountField())
 	}
-	if record.DFIAccountNumberField() != "12345678901234567890123456789012345" {
-		t.Errorf("DfiAccountNumber Expected '12345678901234567890123456789012345' got: %v", record.DFIAccountNumberField())
+	if record.DFIAccountNumberField() != "123456789012345678901234567890     " {
+		t.Errorf("DfiAccountNumber Expected '123456789012345678901234567890     ' got: %v", record.DFIAccountNumberField())
+	}
+	if record.DFIAccountNumber != "123456789012345678901234567890" {
+		t.Errorf("DfiAccountNumber Expected '123456789012345678901234567890' got: %v", record.DFIAccountNumber)
 	}
 	if record.AddendaRecordIndicator != 1 {
 		t.Errorf("AddendaRecordIndicator Expected '0' got: %v", record.AddendaRecordIndicator)

--- a/reader.go
+++ b/reader.go
@@ -678,7 +678,7 @@ func (r *Reader) parseIATEntryDetail() error {
 		return ErrFileEntryOutsideBatch
 	}
 
-	ed := new(IATEntryDetail)
+	ed := NewIATEntryDetail()
 	ed.Parse(r.line)
 	if err := maybeValidate(ed, r.File.validateOpts); err != nil {
 		return r.parseError(err)


### PR DESCRIPTION
- Use `NewIATEntryDetail()` (rather than `new(IATEntryDetail)`) to create IAT entry details when parsing a file; this sets a couple important defaults including `Category`, which is currently blank for all parsed IAT forwards.
- Strip extra whitespace by default when parsing account numbers of IAT entries, to match the behavior of parsed account numbers for other entry details (we can leave this change off if it feels potentially disruptive.)