### PR TITLE
perf: 'mergefiles' improvements

### DIFF
--- a/cmd/achcli/describe.go
+++ b/cmd/achcli/describe.go
@@ -13,14 +13,14 @@ import (
 )
 
 func dumpFiles(paths []string, validateOpts *ach.ValidateOpts) error {
-	files := make([]*ach.File, len(paths))
+	files := make([]ach.File, len(paths))
 	for i := range paths {
 		f, err := readACHFile(paths[i], validateOpts)
 		if err != nil {
 			fmt.Printf("WARN: problem reading %s:\n %v\n\n", paths[i], err)
 		}
 		if f != nil {
-			files[i] = f
+			files[i] = *f
 		}
 	}
 
@@ -41,7 +41,7 @@ func dumpFiles(paths []string, validateOpts *ach.ValidateOpts) error {
 				fmt.Printf("ERROR: problem flattening file: %v\n", err)
 			}
 			if file != nil {
-				files[i] = file
+				files[i] = *file
 			}
 		}
 	}
@@ -53,7 +53,7 @@ func dumpFiles(paths []string, validateOpts *ach.ValidateOpts) error {
 		if !*flagMerge {
 			fmt.Printf("Describing ACH file '%s'\n\n", paths[i])
 		}
-		if files[i] != nil {
+		if &files[i] != nil {
 			describe.File(os.Stdout, files[i], &describe.Opts{
 				MaskAccountNumbers: *flagMask || *flagMaskAccounts,
 				MaskCorrectedData:  *flagMask || *flagMaskCorrectedData,

--- a/cmd/achcli/describe/file.go
+++ b/cmd/achcli/describe/file.go
@@ -27,8 +27,8 @@ type Opts struct {
 	PrettyAmounts bool
 }
 
-func File(ww io.Writer, file *ach.File, opts *Opts) {
-	if file == nil {
+func File(ww io.Writer, file ach.File, opts *Opts) {
+	if &file == nil {
 		return
 	}
 	if opts == nil {

--- a/cmd/achcli/describe/file_test.go
+++ b/cmd/achcli/describe/file_test.go
@@ -19,7 +19,7 @@ func TestDescribeFile(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	File(&buf, file, nil) // No Options
+	File(&buf, *file, nil) // No Options
 	if testing.Verbose() {
 		os.Stdout.Write(buf.Bytes())
 	}
@@ -31,7 +31,7 @@ func TestDescribeIAT(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	File(&buf, file, nil) // No Options
+	File(&buf, *file, nil) // No Options
 	if testing.Verbose() {
 		os.Stdout.Write(buf.Bytes())
 	}
@@ -43,7 +43,7 @@ func TestDescribeReturn(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	File(&buf, file, nil) // No Options
+	File(&buf, *file, nil) // No Options
 	if testing.Verbose() {
 		os.Stdout.Write(buf.Bytes())
 	}
@@ -55,7 +55,7 @@ func TestDescribeCorrection(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	File(&buf, file, nil) // No Options
+	File(&buf, *file, nil) // No Options
 	if testing.Verbose() {
 		os.Stdout.Write(buf.Bytes())
 	}

--- a/dir.go
+++ b/dir.go
@@ -25,7 +25,7 @@ import (
 
 // ReadDir will attempt to parse all ACH files in the given directory. Only files which
 // parse successfully will be returned.
-func ReadDir(dir string) ([]*File, error) {
+func ReadDir(dir string) ([]File, error) {
 	readACH := func(path string) (*File, error) {
 		fd, err := os.Open(path)
 		if err != nil {
@@ -53,7 +53,7 @@ func ReadDir(dir string) ([]*File, error) {
 		return nil, err
 	}
 
-	out := make([]*File, 0, len(infos))
+	out := make([]File, 0, len(infos))
 	for i := range infos {
 		path := filepath.Join(dir, infos[i].Name())
 
@@ -67,12 +67,12 @@ func ReadDir(dir string) ([]*File, error) {
 
 		f, err1 := readACH(path)
 		if f != nil {
-			out = append(out, f)
+			out = append(out, *f)
 			continue
 		}
 		f, err2 := readJSON(path)
 		if f != nil {
-			out = append(out, f)
+			out = append(out, *f)
 			continue
 		}
 

--- a/examples/micro-entries/main.go
+++ b/examples/micro-entries/main.go
@@ -74,5 +74,5 @@ func main() {
 		log.Fatalf("ERROR building file: %v", err)
 	}
 
-	describe.File(os.Stdout, file, nil)
+	describe.File(os.Stdout, *file, nil)
 }

--- a/examples/reversal/main.go
+++ b/examples/reversal/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 
 	fmt.Println("Original:")
-	describe.File(os.Stdout, file, nil)
+	describe.File(os.Stdout, *file, nil)
 	fmt.Printf("\n\n")
 
 	effectiveEntryDate := time.Now().In(time.UTC)
@@ -45,5 +45,5 @@ func main() {
 	}
 
 	fmt.Println("Reversal:")
-	describe.File(os.Stdout, file, nil)
+	describe.File(os.Stdout, *file, nil)
 }

--- a/file.go
+++ b/file.go
@@ -470,7 +470,7 @@ func (f *File) Create() error {
 
 		// If AllowZeroBatches is false, require at least one Batch in the new file.
 		if !opts.AllowZeroBatches && (len(f.Batches) <= 0 && len(f.IATBatches) <= 0) {
-			return ErrFileNoBatches
+
 		}
 	}
 

--- a/merge.go
+++ b/merge.go
@@ -35,7 +35,7 @@ const NACHAFileLineLimit = 10000
 // Per NACHA rules files must remain under 10,000 lines (when rendered in their ASCII encoding)
 //
 // File Batches can only be merged if they are unique and routed to and from the same ABA routing numbers.
-func MergeFiles(files []*File) ([]*File, error) {
+func MergeFiles(files []File) ([]File, error) {
 	return mergeFilesHelper(files, Conditions{
 		MaxLines: NACHAFileLineLimit,
 	})
@@ -48,14 +48,14 @@ func NewMerger(opts *ValidateOpts) Merger {
 
 // Merge can merge ACH files with custom ValidateOpts
 type Merger interface {
-	MergeWith(files []*File, conditions Conditions) ([]*File, error)
+	MergeWith(files []File, conditions Conditions) ([]File, error)
 }
 
 type merger struct {
 	opts *ValidateOpts
 }
 
-func (m *merger) MergeWith(files []*File, conditions Conditions) ([]*File, error) {
+func (m *merger) MergeWith(files []File, conditions Conditions) ([]File, error) {
 	if m.opts != nil {
 		for i := range files {
 			files[i].SetValidation(m.opts)
@@ -72,17 +72,17 @@ type Conditions struct {
 	MaxDollarAmount int64 `json:"maxDollarAmount"`
 }
 
-func MergeFilesWith(files []*File, conditions Conditions) ([]*File, error) {
+func MergeFilesWith(files []File, conditions Conditions) ([]File, error) {
 	return mergeFilesHelper(files, conditions)
 }
 
-func mergeFilesHelper(files []*File, conditions Conditions) ([]*File, error) {
+func mergeFilesHelper(files []File, conditions Conditions) ([]File, error) {
 	fs := &mergableFiles{infiles: files}
 	for i := range fs.infiles {
-		if fs.infiles[i] == nil {
+		if &fs.infiles[i] == nil {
 			continue // skip nil Files
 		}
-		outf := fs.findOutfile(fs.infiles[i])
+		outf := fs.findOutfile(&fs.infiles[i])
 		for j := range fs.infiles[i].Batches {
 			batchExistsInMerged := false
 			for k := range outf.Batches {
@@ -115,7 +115,7 @@ func mergeFilesHelper(files []*File, conditions Conditions) ([]*File, error) {
 							return nil, err
 						}
 						f := *outf
-						fs.locMaxed = append(fs.locMaxed, &f)
+						fs.locMaxed = append(fs.locMaxed, f)
 					}
 
 					outf = fs.swapLocMaxedFile(outf) // replace output file with the one we just created
@@ -151,9 +151,9 @@ func mergeFilesHelper(files []*File, conditions Conditions) ([]*File, error) {
 }
 
 type mergableFiles struct {
-	infiles  []*File
-	outfiles []*File
-	locMaxed []*File
+	infiles  []File
+	outfiles []File
+	locMaxed []File
 }
 
 // swapLocMaxedFile replaces an ACH file that is over the Nacha line limit with an empty file containing
@@ -177,7 +177,7 @@ next:
 	out.Header.FileCreationTime = now.Format("1504")   // HHmm
 	out.SetValidation(f.validateOpts)
 	out.Create()
-	fs.outfiles = append(fs.outfiles, out) // add the new outfile
+	fs.outfiles = append(fs.outfiles, *out) // add the new outfile
 
 	return out
 }
@@ -215,7 +215,7 @@ func (fs *mergableFiles) findOutfile(f *File) *File {
 				}
 
 				// No conflicting TraceNumber was found, so return current merge file
-				return fs.outfiles[i]
+				return &fs.outfiles[i]
 			}
 		}
 		// Record a newly mergable File/FileHeader we can use in future merge attempts
@@ -223,7 +223,7 @@ func (fs *mergableFiles) findOutfile(f *File) *File {
 		outf.Header = f.Header
 		outf.SetValidation(f.validateOpts)
 		outf.Control = f.Control
-		fs.outfiles = append(fs.outfiles, outf)
+		fs.outfiles = append(fs.outfiles, *outf)
 		return outf
 	}
 	return lookup(0)

--- a/merge_bench_test.go
+++ b/merge_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkMergeFiles(b *testing.B) {
 		}
 	)
 
-	randomFile := func(B *testing.B) *File {
+	randomFile := func(B *testing.B) File {
 		B.Helper()
 
 		file := NewFile()
@@ -61,10 +61,10 @@ func BenchmarkMergeFiles(b *testing.B) {
 			B.Error(err)
 		}
 
-		return file
+		return *file
 	}
 
-	randomFiles := func(b *testing.B) (out []*File) {
+	randomFiles := func(b *testing.B) (out []File) {
 		b.Helper()
 		for i := 0; i < b.N; i++ {
 			out = append(out, randomFile(b))
@@ -99,7 +99,7 @@ func BenchmarkMergeFiles(b *testing.B) {
 		b.Fatalf("unexpected indices: %#v", indices)
 	}
 
-	mergeInGroups := func(b *testing.B, groups int) []*File {
+	mergeInGroups := func(b *testing.B, groups int) []File {
 		b.Helper()
 
 		files := randomFiles(b)
@@ -109,10 +109,10 @@ func BenchmarkMergeFiles(b *testing.B) {
 		b.ResetTimer()
 		b.StopTimer()
 
-		var out []*File
+		var out []File
 		var err error
 		if len(indices) > 1 {
-			var temp []*File
+			var temp []File
 			for i := 0; i < len(indices)-1; i += 0 {
 				b.StartTimer()
 				fs, err := MergeFilesWith(files[indices[i]:indices[i+1]], mergeConditions)

--- a/merge_test.go
+++ b/merge_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func filesAreEqual(f1, f2 *File) error {
+func filesAreEqual(f1, f2 File) error {
 	// File Header
 	if f1.Header.ImmediateOrigin != f2.Header.ImmediateOrigin {
 		return fmt.Errorf("f1.Header.ImmediateOrigin=%s vs f2.Header.ImmediateOrigin=%s", f1.Header.ImmediateOrigin, f2.Header.ImmediateOrigin)
@@ -78,14 +78,14 @@ func TestMergeFiles__filesAreEqual(t *testing.T) {
 	}
 
 	// compare a file against itself
-	if err := filesAreEqual(file, file); err != nil {
+	if err := filesAreEqual(*file, *file); err != nil {
 		t.Fatalf("same file: %v", err)
 	}
 
 	// break the equality
 	f2 := *file
 	f2.Header.ImmediateOrigin = "12"
-	if err := filesAreEqual(file, &f2); err == nil {
+	if err := filesAreEqual(*file, f2); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -96,7 +96,7 @@ func TestMergeFiles__identity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := MergeFiles([]*File{file})
+	out, err := MergeFiles([]File{*file})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestMergeFiles__identity(t *testing.T) {
 		t.Errorf("got %d merged ACH files", len(out))
 	}
 
-	if err := filesAreEqual(file, out[0]); err != nil {
+	if err := filesAreEqual(*file, out[0]); err != nil {
 		t.Errorf("unequal files:%v", err)
 	}
 
@@ -132,7 +132,7 @@ func TestMergeFiles__together(t *testing.T) {
 		t.Errorf("did batch counts change? f1:%d f2:%d", len(f1.Batches), len(f2.Batches))
 	}
 
-	out, err := MergeFiles([]*File{f1, f2})
+	out, err := MergeFiles([]File{*f1, *f2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestMergeFiles__apart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := MergeFiles([]*File{f1, f2})
+	out, err := MergeFiles([]File{*f1, *f2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,9 +290,9 @@ func TestMergeFiles__splitFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	traceNumbersBefore := countTraceNumbers(file, f2, f3)
+	traceNumbersBefore := countTraceNumbers(*file, *f2, *f3)
 
-	out, err := MergeFiles([]*File{file, f2, f3})
+	out, err := MergeFiles([]File{*file, *f2, *f3})
 	if err != nil || len(out) != 1 {
 		t.Fatalf("got %d files, error=%v", len(out), err)
 	}
@@ -336,9 +336,9 @@ func TestMergeFiles__dollarAmount(t *testing.T) {
 	// Verify our file's contents
 	require.NoError(t, file.Create())
 	require.Equal(t, 305, lineCount(file))
-	require.Equal(t, 101, countTraceNumbers(file))
+	require.Equal(t, 101, countTraceNumbers(*file))
 
-	mergedFiles, err := MergeFilesWith([]*File{file}, Conditions{
+	mergedFiles, err := MergeFilesWith([]File{*file}, Conditions{
 		MaxDollarAmount: 1000000, // $10,000.00
 	})
 	require.NoError(t, err)
@@ -375,9 +375,9 @@ func TestMergeFiles__dollarAmount2(t *testing.T) {
 	// Verify our file's contents
 	require.NoError(t, file.Create())
 	require.Equal(t, 305, lineCount(file))
-	require.Equal(t, 101, countTraceNumbers(file))
+	require.Equal(t, 101, countTraceNumbers(*file))
 
-	mergedFiles, err := MergeFilesWith([]*File{file}, Conditions{
+	mergedFiles, err := MergeFilesWith([]File{*file}, Conditions{
 		MaxDollarAmount: 33_000_000_00,
 	})
 	require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestMergeFiles__dollarAmount2(t *testing.T) {
 	}
 }
 
-func countTraceNumbers(files ...*File) int {
+func countTraceNumbers(files ...File) int {
 	var total int
 	for f := range files {
 		for b := range files[f].Batches {
@@ -420,7 +420,7 @@ func TestMergeFiles__invalid(t *testing.T) {
 	}
 	f2.Header = f1.Header
 
-	out, err := MergeFiles([]*File{f1, f2})
+	out, err := MergeFiles([]File{*f1, *f2})
 	if len(out) != 0 || err == nil {
 		t.Errorf("expected error: len(out)=%d error=%v", len(out), err)
 	}

--- a/test/issues/issue1202_test.go
+++ b/test/issues/issue1202_test.go
@@ -15,7 +15,7 @@ func TestIssue1202(t *testing.T) {
 	require.ErrorContains(t, err, ach.ErrFileHeader.Error())
 
 	if testing.Verbose() {
-		describe.File(os.Stdout, file, nil)
+		describe.File(os.Stdout, *file, nil)
 	}
 
 	require.Len(t, file.Batches, 2)

--- a/test/issues/issue863_test.go
+++ b/test/issues/issue863_test.go
@@ -63,10 +63,10 @@ func TestIssue863(t *testing.T) {
 	}
 }
 
-func readFiles(t *testing.T, r io.Reader) ([]*ach.File, error) {
+func readFiles(t *testing.T, r io.Reader) ([]ach.File, error) {
 	t.Helper()
 
-	var out []*ach.File
+	var out []ach.File
 	rdr := tar.NewReader(r)
 	for {
 		header, err := rdr.Next()
@@ -85,7 +85,7 @@ func readFiles(t *testing.T, r io.Reader) ([]*ach.File, error) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		out = append(out, &f)
+		out = append(out, f)
 	}
 	return out, nil
 }


### PR DESCRIPTION
This commit gives a benchmark report on the use of `[]*ach.File` and `[]ach.File`. It intend to show the improvement in passing by values instead of passing by reference

My benchmark results when using `[]*ach.File`
```
go test . -bench BenchmarkMergeFiles -v -run BenchmarkMergeFiles --benchtime 10s goos:darwin
goos: linux
goarch: amd64
pkg: github.com/moov-io/ach
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
BenchmarkMergeFiles
BenchmarkMergeFiles/MergeFiles
    merge_bench_test.go:148: 1 files merged into 1 files
    merge_bench_test.go:148: 100 files merged into 40 files
    merge_bench_test.go:148: 10000 files merged into 4000 files
    merge_bench_test.go:148: 180822 files merged into 72330 files
BenchmarkMergeFiles/MergeFiles-16                 180822             68727 ns/op            3184 B/op         88 allocs/op
BenchmarkMergeFiles/MergeFiles_3Groups
    merge_bench_test.go:152: 1 files merged into 1 files
    merge_bench_test.go:152: 100 files merged into 55 files
    merge_bench_test.go:152: 10000 files merged into 6005 files
    merge_bench_test.go:152: 76762 files merged into 57046 files
BenchmarkMergeFiles/MergeFiles_3Groups-16          76762            173807 ns/op            8804 B/op        245 allocs/op
BenchmarkMergeFiles/MergeFiles_5Groups
    merge_bench_test.go:155: 1 files merged into 1 files
    merge_bench_test.go:155: 100 files merged into 61 files
    merge_bench_test.go:155: 10000 files merged into 6096 files
    merge_bench_test.go:155: 73902 files merged into 45783 files
BenchmarkMergeFiles/MergeFiles_5Groups-16          73902            159337 ns/op            7928 B/op        220 allocs/op
BenchmarkMergeFiles/MergeFiles_10Groups
    merge_bench_test.go:158: 1 files merged into 1 files
    merge_bench_test.go:158: 100 files merged into 61 files
    merge_bench_test.go:158: 10000 files merged into 6039 files
    merge_bench_test.go:158: 75115 files merged into 51119 files
BenchmarkMergeFiles/MergeFiles_10Groups-16                 75115            165668 ns/op            8356 B/op        232 allocs/op
BenchmarkMergeFiles/MergeFiles_100Groups
    merge_bench_test.go:161: 1 files merged into 1 files
    merge_bench_test.go:161: 100 files merged into 40 files
    merge_bench_test.go:161: 10000 files merged into 6972 files
    merge_bench_test.go:161: 71922 files merged into 43097 files
BenchmarkMergeFiles/MergeFiles_100Groups-16                71922            156825 ns/op            7780 B/op        216 allocs/op
PASS
ok      github.com/moov-io/ach  83.807s
```

Also here are the results when using the `[]ach.File` (without the pointer)
```
go test . -bench BenchmarkMergeFiles -v -run BenchmarkMergeFiles --benchtime 10s goos:darwin
goos: linux
goarch: amd64
pkg: github.com/moov-io/ach
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
BenchmarkMergeFiles
BenchmarkMergeFiles/MergeFiles
    merge_bench_test.go:148: 1 files merged into 1 files
    merge_bench_test.go:148: 100 files merged into 34 files
    merge_bench_test.go:148: 10000 files merged into 3334 files
    merge_bench_test.go:148: 200274 files merged into 66759 files
BenchmarkMergeFiles/MergeFiles-16                 200274             63268 ns/op            3414 B/op         76 allocs/op
BenchmarkMergeFiles/MergeFiles_3Groups
    merge_bench_test.go:152: 1 files merged into 1 files
    merge_bench_test.go:152: 100 files merged into 31 files
    merge_bench_test.go:152: 10000 files merged into 3331 files
    merge_bench_test.go:152: 101288 files merged into 33760 files
BenchmarkMergeFiles/MergeFiles_3Groups-16         101288            121395 ns/op            6574 B/op        150 allocs/op
BenchmarkMergeFiles/MergeFiles_5Groups
    merge_bench_test.go:155: 1 files merged into 1 files
    merge_bench_test.go:155: 100 files merged into 31 files
    merge_bench_test.go:155: 10000 files merged into 3331 files
    merge_bench_test.go:155: 99624 files merged into 33206 files
BenchmarkMergeFiles/MergeFiles_5Groups-16          99624            125300 ns/op            6568 B/op        150 allocs/op
BenchmarkMergeFiles/MergeFiles_10Groups
    merge_bench_test.go:158: 1 files merged into 1 files
    merge_bench_test.go:158: 100 files merged into 31 files
    merge_bench_test.go:158: 10000 files merged into 3329 files
    merge_bench_test.go:158: 93589 files merged into 31191 files
BenchmarkMergeFiles/MergeFiles_10Groups-16                 93589            124098 ns/op            6505 B/op        150 allocs/op
BenchmarkMergeFiles/MergeFiles_100Groups
    merge_bench_test.go:161: 1 files merged into 1 files
    merge_bench_test.go:161: 100 files merged into 34 files
    merge_bench_test.go:161: 10000 files merged into 3301 files
    merge_bench_test.go:161: 96330 files merged into 32010 files
BenchmarkMergeFiles/MergeFiles_100Groups-16                96330            130157 ns/op            6454 B/op        150 allocs/op
PASS
ok      github.com/moov-io/ach  85.414s
```