### PR TITLE
all: reduce string allocations

### DIFF
--- a/batchControl.go
+++ b/batchControl.go
@@ -20,7 +20,6 @@ package ach
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"unicode/utf8"
 )
 
@@ -132,8 +131,9 @@ func NewBatchControl() *BatchControl {
 
 // String writes the BatchControl struct to a 94 character string.
 func (bc *BatchControl) String() string {
-	var buf strings.Builder
-	buf.Grow(94)
+	buf := getBuffer()
+	defer saveBuffer(buf)
+
 	buf.WriteString(batchControlPos)
 	buf.WriteString(fmt.Sprintf("%v", bc.ServiceClassCode))
 	buf.WriteString(bc.EntryAddendaCountField())

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -226,10 +226,11 @@ func (bh *BatchHeader) Parse(record string) {
 
 // String writes the BatchHeader struct to a 94 character string.
 func (bh *BatchHeader) String() string {
-	var buf strings.Builder
-	buf.Grow(94)
+	buf := getBuffer()
+	defer saveBuffer(buf)
+
 	buf.WriteString(batchHeaderPos)
-	buf.WriteString(fmt.Sprintf("%v", bh.ServiceClassCode))
+	buf.WriteString(strconv.Itoa(bh.ServiceClassCode))
 	buf.WriteString(bh.CompanyNameField())
 	buf.WriteString(bh.CompanyDiscretionaryDataField())
 	buf.WriteString(bh.CompanyIdentificationField())

--- a/cmd/achcli/describe.go
+++ b/cmd/achcli/describe.go
@@ -35,7 +35,6 @@ func dumpFiles(paths []string, validateOpts *ach.ValidateOpts) error {
 
 	if *flagFlatten {
 		for i := range files {
-			fmt.Printf("attempting flattening %d\n", i)
 			file, err := files[i].FlattenBatches()
 			if err != nil {
 				fmt.Printf("ERROR: problem flattening file: %v\n", err)

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -379,14 +379,14 @@ func (ed *EntryDetail) fieldInclusion() error {
 	return nil
 }
 
+var (
+	// Amount is a 10 digit field
+	maxAmount = 9_999_999_999
+)
+
 func (ed *EntryDetail) amountOverflowsField() error {
-	intstr := strconv.Itoa(ed.Amount)
-	strstr := ed.AmountField()
-	if intstr == "0" && strstr == "0000000000" {
-		return nil // both are empty values
-	}
-	if len(intstr) > len(strstr) {
-		return fmt.Errorf("does not match formatted value %s", strstr)
+	if ed.Amount > maxAmount {
+		return fmt.Errorf("does not match formatted value %s", ed.AmountField())
 	}
 	return nil
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -426,7 +426,7 @@ func TestMergeFiles__invalid(t *testing.T) {
 	}
 }
 
-func populateFileWithMockBatches(t *testing.T, numBatches int, file *File) {
+func populateFileWithMockBatches(t testing.TB, numBatches int, file *File) {
 	lastBatchIdx := len(file.Batches) - 1
 	var startSeq = file.Batches[lastBatchIdx].GetHeader().BatchNumber + 1
 	var entryDetail = file.Batches[0].GetEntries()[0]

--- a/validators.go
+++ b/validators.go
@@ -513,10 +513,11 @@ func CheckRoutingNumber(routingNumber string) error {
 		return fmt.Errorf("invalid routing number length of %d", n)
 	}
 
-	check := fmt.Sprintf("%d", CalculateCheckDigit(routingNumber))
-	last := string(routingNumber[len(routingNumber)-1])
+	check := CalculateCheckDigit(routingNumber)
+	last := int(routingNumber[len(routingNumber)-1]) - 48 // ASCII 0 is 48 decimal
+
 	if check != last {
-		return fmt.Errorf("routing number checksum mismatch: expected %s but got %s", check, last)
+		return fmt.Errorf("routing number checksum mismatch: expected %d but got %d", check, last)
 	}
 	return nil
 }


### PR DESCRIPTION
Before:
```
BenchmarkLargeWEBWrite-16    	    1886	    612136 ns/op	   89070 B/op	    2659 allocs/op
PASS
ok  	github.com/moov-io/ach	3.844s
```

After: 
```
BenchmarkLargeWEBWrite-16    	    2000	    566199 ns/op	   54180 B/op	    2041 allocs/op
PASS
ok  	github.com/moov-io/ach	3.210s
```