### PR TITLE
fix: MergeFiles should keep ValidateOpts

### DIFF
--- a/file.go
+++ b/file.go
@@ -19,7 +19,6 @@ package ach
 
 import (
 	"bytes"
-	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -710,8 +709,11 @@ type ValidateOpts struct {
 // merge will combine two ValidateOpts structs and keep any non-zero field values.
 func (v *ValidateOpts) merge(other *ValidateOpts) *ValidateOpts {
 	// If either ValidateOpts is nil return the other
-	if v == nil || other == nil {
-		return cmp.Or(v, other)
+	if v == nil {
+		return other
+	}
+	if other == nil {
+		return v
 	}
 
 	out := &ValidateOpts{

--- a/file_test.go
+++ b/file_test.go
@@ -2134,7 +2134,7 @@ func TestFile_ValidateOpts_Merge(t *testing.T) {
 		PreserveSpaces:   true,
 	}
 
-	merged := first.Merge(second)
+	merged := first.merge(second)
 
 	require.False(t, merged.SkipAll)                 // keep false when both are false
 	require.True(t, merged.RequireABAOrigin)         // was true in first
@@ -2148,7 +2148,7 @@ func TestFile_ValidateOpts_Merge(t *testing.T) {
 		return fmt.Errorf("code %d is invalid", code)
 	}
 
-	merged = first.Merge(second)
+	merged = first.merge(second)
 	require.False(t, merged.SkipAll)               // keep false when both are false
 	require.True(t, merged.RequireABAOrigin)       // was true in first
 	require.NotNil(t, merged.CheckTransactionCode) // non-nil function
@@ -2162,8 +2162,8 @@ func TestFile_ValidateOpts_Merge(t *testing.T) {
 			CustomReturnCodes: true,
 		}
 
-		require.Nil(t, empty.Merge(empty))
-		require.NotNil(t, empty.Merge(full))
-		require.NotNil(t, full.Merge(empty))
+		require.Nil(t, empty.merge(empty))
+		require.NotNil(t, empty.merge(full))
+		require.NotNil(t, full.merge(empty))
 	})
 }

--- a/merge.go
+++ b/merge.go
@@ -107,7 +107,7 @@ func MergeFilesWith(incoming []*File, conditions Conditions) ([]*File, error) {
 		if outFile == nil {
 			return nil, fmt.Errorf("finding outfile from incoming[%d]: %w", i, ErrPleaseReportBug)
 		}
-		outFile.validateOpts = outFile.validateOpts.Merge(incoming[i].GetValidation())
+		outFile.validateOpts = outFile.validateOpts.merge(incoming[i].GetValidation())
 
 		for j := range incoming[i].Batches {
 			bh := incoming[i].Batches[j].GetHeader()

--- a/merge_test.go
+++ b/merge_test.go
@@ -513,6 +513,32 @@ func populateFileWithMockBatches(t testing.TB, numBatches int, file *File) {
 	}
 }
 
+func TestMergeFiles__ValidateOpts(t *testing.T) {
+	f1, err := readACHFilepath(filepath.Join("test", "testdata", "ppd-debit.ach"))
+	require.NoError(t, err)
+
+	f1.SetValidation(&ValidateOpts{
+		CustomReturnCodes: true,
+	})
+
+	f2, err := readACHFilepath(filepath.Join("test", "testdata", "web-debit.ach"))
+	require.NoError(t, err)
+
+	f2.Header = f1.Header
+	f2.SetValidation(&ValidateOpts{
+		AllowInvalidAmounts: true,
+	})
+
+	merged, err := MergeFiles([]*File{f1, f2})
+	require.NoError(t, err)
+	require.Len(t, merged, 1)
+
+	opts := merged[0].GetValidation()
+	require.False(t, opts.SkipAll)
+	require.True(t, opts.CustomReturnCodes)
+	require.True(t, opts.AllowInvalidAmounts)
+}
+
 func TestMergeFilesHelpers(t *testing.T) {
 	t.Run("pickOutFile", func(t *testing.T) {
 		fh := mockFileHeader()


### PR DESCRIPTION
In fact we should merge them together rather than take the first `ValidateOpts` 