### PR TITLE
feat: add options to MergeDir for use in achgateway

### DIFF
--- a/merge_bench_test.go
+++ b/merge_bench_test.go
@@ -211,7 +211,7 @@ func BenchmarkMergeFiles(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 
-		merged, err := MergeDir(dir, mergeConditions)
+		merged, err := MergeDir(dir, mergeConditions, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -229,7 +229,7 @@ func BenchmarkMergeFiles(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 
-		merged, err := MergeDir(dir, mergeConditions)
+		merged, err := MergeDir(dir, mergeConditions, nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/test/testdata/web-debit.json
+++ b/test/testdata/web-debit.json
@@ -1,0 +1,1 @@
+{"requireABAOrigin": true, "allowMissingFileHeader": true, "unequalServiceClassCode": true}


### PR DESCRIPTION
- Option to read `ValidateOpts` in MergeDir
- Accept/Skip files (and option to parse them as JSON) 
- Fixes for usage with achgateway (and others)