### PR TITLE
perf: isTraceNumberODFI

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -819,10 +819,14 @@ func (batch *Batch) isTraceNumberODFI() error {
 	if batch.validateOpts != nil && batch.validateOpts.BypassOriginValidation {
 		return nil
 	}
+	bhODFI := batch.Header.ODFIIdentificationField()
 	for _, entry := range batch.Entries {
-		if batch.Header.ODFIIdentificationField() != entry.TraceNumberField()[:8] {
-			return batch.Error("ODFIIdentificationField",
-				NewErrBatchTraceNumberNotODFI(batch.Header.ODFIIdentificationField(), entry.TraceNumberField()[:8]))
+		var entryODFI string
+		if len(entry.TraceNumber) >= 8 {
+			entryODFI = entry.TraceNumber[:8]
+		}
+		if bhODFI != entryODFI {
+			return batch.Error("ODFIIdentificationField", NewErrBatchTraceNumberNotODFI(bhODFI, entryODFI))
 		}
 	}
 	return nil


### PR DESCRIPTION
```
MergeFiles/MergeFiles-16                    505.5µ ± ∞ ¹   501.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
MergeFiles/MergeFiles_ValidateOpts-16       503.0µ ± ∞ ¹   502.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                     535.8µ         528.3µ        -1.38%

MergeFiles/MergeFiles-16                   55.60Ki ± ∞ ¹   55.62Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
MergeFiles/MergeFiles_ValidateOpts-16      55.62Ki ± ∞ ¹   55.65Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                    57.43Ki         57.43Ki        +0.02%

MergeFiles/MergeFiles-16                     637.0 ± ∞ ¹   637.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
MergeFiles/MergeFiles_ValidateOpts-16        637.0 ± ∞ ¹   637.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                      656.4         656.4        +0.00%
```