### PR TITLE
fix: allow "slashed zero" which some OCR software produces

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -76,7 +76,7 @@ func TestExtendedCharacters(t *testing.T) {
 		require.Equal(t, "456¦123", entries[0].Addenda18[0].ForeignCorrespondentBankIDNumber)
 	})
 
-	t.Run("MTE File", func(t *testing.T) {
+	t.Run("ACH File", func(t *testing.T) {
 		bh := mockBatchMTEHeader()
 		bh.CompanyName = "Merchant | ATM"
 
@@ -84,6 +84,7 @@ func TestExtendedCharacters(t *testing.T) {
 		ed := mockMTEEntryDetail()
 		ed.IndividualName = "My {Store}"
 		ed.Addenda02.ReferenceInformationOne = `RF1¦RF2`
+		ed.IdentificationNumber = `0 is not Ø` // X12 extended zeros
 		b.AddEntry(ed)
 		require.NoError(t, b.Create())
 
@@ -91,6 +92,7 @@ func TestExtendedCharacters(t *testing.T) {
 		file.SetHeader(mockFileHeader())
 		file.AddBatch(b)
 		require.NoError(t, file.Create())
+		require.NoError(t, file.Validate())
 
 		// Cycle file through write/read
 		var buf bytes.Buffer
@@ -109,6 +111,7 @@ func TestExtendedCharacters(t *testing.T) {
 
 		entries := b1.GetEntries()
 		require.Equal(t, `My {Store}            `, entries[0].IndividualName)
+		require.Equal(t, `0 is not Ø     `, entries[0].IdentificationNumber)
 		require.Equal(t, `RF1¦RF2`, entries[0].Addenda02.ReferenceInformationOne)
 	})
 

--- a/validators.go
+++ b/validators.go
@@ -33,6 +33,7 @@ var (
 	numericCharacters     = "0123456789"
 	asciiCharacters       = ` !"#$%&'()*+,-./:;<=>?@[\]^_{|}~` + "`"
 	ebcdicExtraCharacters = `¢¬¦±`
+	realWorldEncountered  = `Ø`
 
 	validAlphaNumericCharacters          map[rune]bool
 	validUppercaseAlphaNumericCharacters map[rune]bool
@@ -40,11 +41,13 @@ var (
 
 func init() {
 	validAlphaNumericCharacters = setupCharacterMap(
-		lowerAlphaCharacters, strings.ToUpper(lowerAlphaCharacters), numericCharacters, asciiCharacters, ebcdicExtraCharacters,
+		lowerAlphaCharacters, strings.ToUpper(lowerAlphaCharacters), numericCharacters, asciiCharacters,
+		ebcdicExtraCharacters, realWorldEncountered,
 	)
 
 	validUppercaseAlphaNumericCharacters = setupCharacterMap(
-		strings.ToUpper(lowerAlphaCharacters), numericCharacters, asciiCharacters, ebcdicExtraCharacters,
+		strings.ToUpper(lowerAlphaCharacters), numericCharacters, asciiCharacters,
+		ebcdicExtraCharacters, realWorldEncountered,
 	)
 }
 

--- a/validators_test.go
+++ b/validators_test.go
@@ -168,6 +168,9 @@ func TestValidators__isAlphanumeric(t *testing.T) {
 				switch chr {
 				case `¢`, `¦`, `¬`, `±`: // skip valid ASCII characters
 					continue
+
+				case `Ø`: // skip characters found in real world usage
+					continue
 				}
 
 				if shouldError && err == nil {


### PR DESCRIPTION
Observed in some X12 / CTX entries.

See: https://moov-io.slack.com/archives/CD9J8EJKX/p1711489128493279