### PR TITLE
fix: Update required fields for CreateFile schema object in openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -632,6 +632,7 @@ paths:
 components:
   schemas:
     CreateFile:
+      description: \`batches\` OR `IATBatches` is required
       properties:
         id:
           type: string
@@ -643,10 +644,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Batch'
+          minItems: 1
         IATBatches:
           type: array
           items:
             $ref: '#/components/schemas/IATBatch'
+          minItems: 1
         fileControl:
           $ref: '#/components/schemas/FileControl'
         advEntryDetails:
@@ -657,6 +660,8 @@ components:
           $ref: '#/components/schemas/ADVBatchControl'
       required:
         - fileHeader
+        - batches
+        - IATBatches
     CreateFileResponse:
       properties:
         id:
@@ -762,10 +767,7 @@ components:
           description: Reserved field for information pertinent to the Originator.
       required:
         - immediateOrigin
-        - immediateOriginName
         - immediateDestination
-        - immediateDestinationName
-        - fileCreationTime
         - fileCreationDate
     FileControl:
       properties:
@@ -826,7 +828,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EntryDetail'
-          minLength: 1
+          minItems: 1
         batchControl:
           $ref: '#/components/schemas/BatchControl'
         advEntryDetails:
@@ -840,15 +842,14 @@ components:
       required:
         - batchHeader
         - entryDetails
-        - batchControl
     BatchHeader:
       required:
         - serviceClassCode
         - standardEntryClassCode
         - companyName
         - companyIdentification
+        - companyEntryDescription
         - ODFIIdentification
-        - batchNumber
       properties:
         id:
           type: string
@@ -981,7 +982,6 @@ components:
         $ref: '#/components/schemas/Batch'
     EntryDetail:
       required:
-        - id
         - amount
         - DFIAccountNumber
         - RDFIIdentification


### PR DESCRIPTION
Issue: #1050 

Updates the required fields for the CreateFile schema object in the Open API specification.

Minimal request body to create a new file:
```
{
    "fileHeader": {
        "immediateDestination": "226071004",
        "immediateOrigin": "0462723539",
        "fileCreationDate": "220716"
    },
    "batches": [
        {
            "batchHeader": {
                "serviceClassCode": 220,
                "companyName": "HMBradley",
                "companyIdentification": "0462723539",
                "standardEntryClassCode": "WEB",
                "companyEntryDescription": "HMBWEB",
                "ODFIIdentification": "22607100"
            },
            "entryDetails": [
                {
                    "transactionCode": 22,
                    "RDFIIdentification": "06540013",
                    "checkDigit": "7",
                    "DFIAccountNumber": "264236473264",
                    "amount": 121598,
                    "individualName": "Zach Test"
                }
            ]
        }
    ]
}
```