### PR TITLE
Add R62 to list of dishonored return codes

### DIFF
--- a/addenda99_dishonored_return.go
+++ b/addenda99_dishonored_return.go
@@ -157,7 +157,7 @@ func (Addenda99Dishonored *Addenda99Dishonored) SetValidation(opts *ValidateOpts
 
 func IsDishonoredReturnCode(code string) bool {
 	switch code {
-	case "R61", "R67", "R68", "R69", "R70":
+	case "R61", "R62", "R67", "R68", "R69", "R70":
 		return true
 	}
 	return false


### PR DESCRIPTION
In the NACHA rulebook Part 4.2: Table of Return Reason Codes, `R62` is included under "Codes to be Used by the ODFI for Dishonored Return Entries".