### PR TITLE
feat: standardize validate opts query params, accept on GET/POST validate

### DIFF
--- a/docs/create-file.md
+++ b/docs/create-file.md
@@ -48,10 +48,11 @@ Example: `POST /files/create?requireABAOrigin=true&bypassDestination=true`
 | `allowInvalidCheckDigit`           | `AllowInvalidCheckDigit`           |
 | `allowMissingFileControl`          | `AllowMissingFileControl`          |
 | `allowMissingFileHeader`           | `AllowMissingFileHeader`           |
+| `allowUnorderedBatchNumbers`       | `AllowUnorderedBatchNumbers`       |
 | `allowZeroBatches`                 | `AllowZeroBatches`                 |
 | `bypassCompanyIdentificationMatch` | `BypassCompanyIdentificationMatch` |
-| `bypassDestination`                | `BypassDestinationValidation`      |
-| `bypassOrigin`                     | `BypassOriginValidation`           |
+| `bypassDestinationValidation`      | `BypassDestinationValidation`      |
+| `bypassOriginValidation`           | `BypassOriginValidation`           |
 | `customReturnCodes`                | `CustomReturnCodes`                |
 | `customTraceNumbers`               | `CustomTraceNumbers`               |
 | `preserveSpaces`                   | `PreserveSpaces`                   |
@@ -59,7 +60,8 @@ Example: `POST /files/create?requireABAOrigin=true&bypassDestination=true`
 | `skipAll`                          | `SkipAll`                          |
 | `unequalAddendaCounts`             | `UnequalAddendaCounts`             |
 | `unequalServiceClassCode`          | `UnequalServiceClassCode`          |
-| `unorderedBatchNumbers`            | `AllowUnorderedBatchNumbers`       |
+
+> Note: `bypassDestination`, `bypassOrigin`, and `unorderedBatchNumbers` are deprecated query parameters replace by identical named parameters.
 
 ## Upload a raw ACH file
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -89,7 +89,19 @@ paths:
           description: Optional parameter to configure ImmediateOrigin validation
           schema:
             type: boolean
+          deprecated: true
+        - name: bypassOriginValidation
+          in: query
+          description: Optional parameter to configure ImmediateOrigin validation
+          schema:
+            type: boolean
         - name: bypassDestination
+          in: query
+          description: Optional parameter to configure ImmediateDestination validation
+          schema:
+            type: boolean
+          deprecated: true
+        - name: bypassDestinationValidation
           in: query
           description: Optional parameter to configure ImmediateDestination validation
           schema:
@@ -130,6 +142,12 @@ paths:
           schema:
             type: boolean
         - name: unorderedBatchNumbers
+          in: query
+          description: Allow a file to be read with unordered batch numbers.
+          schema:
+            type: boolean
+          deprecated: true
+        - name: allowUnorderedBatchNumbers
           in: query
           description: Allow a file to be read with unordered batch numbers.
           schema:
@@ -304,6 +322,87 @@ paths:
               schema:
                 $ref: '#/components/schemas/RawFile'
   /files/{fileID}/validate:
+    parameters:
+      - name: skipAll
+        in: query
+        description: Optional parameter to disable all validation checks for a File
+        schema:
+          type: boolean
+      - name: requireABAOrigin
+        in: query
+        description: Optional parameter to configure ImmediateOrigin validation
+        schema:
+          type: boolean
+      - name: bypassOriginValidation
+        in: query
+        description: Optional parameter to configure ImmediateOrigin validation
+        schema:
+          type: boolean
+      - name: bypassDestinationValidation
+        in: query
+        description: Optional parameter to configure ImmediateDestination validation
+        schema:
+          type: boolean
+      - name: customTraceNumbers
+        in: query
+        description: Optional parameter to configure ImmediateDestination validation
+        schema:
+          type: boolean
+      - name: allowZeroBatches
+        in: query
+        description: Optional parameter to configure ImmediateDestination validation
+        schema:
+          type: boolean
+      - name: allowMissingFileHeader
+        in: query
+        description: Optional parameter to configure ImmediateDestination validation
+        schema:
+          type: boolean
+      - name: allowMissingFileControl
+        in: query
+        description: Optional parameter to configure ImmediateDestination validation
+        schema:
+          type: boolean
+      - name: bypassCompanyIdentificationMatch
+        in: query
+        description: Optional parameter to configure ImmediateDestination validation
+        schema:
+          type: boolean
+      - name: customReturnCodes
+        in: query
+        description: Optional parameter to configure ImmediateDestination validation
+        schema:
+          type: boolean
+      - name: unequalServiceClassCode
+        in: query
+        description: Optional parameter to configure ImmediateDestination validation
+        schema:
+          type: boolean
+      - name: allowUnorderedBatchNumbers
+        in: query
+        description: Allow a file to be read with unordered batch numbers.
+        schema:
+          type: boolean
+      - name: allowInvalidCheckDigit
+        in: query
+        description: Allow the CheckDigit field in EntryDetail to differ from the expected calculation
+        schema:
+          type: boolean
+      - name: unequalAddendaCounts
+        in: query
+        description: Optional parameter to configure UnequalAddendaCounts validation
+        schema:
+          type: boolean
+      - name: preserveSpaces
+        in: query
+        description: Optional parameter to save all padding spaces
+        schema:
+          type: boolean
+      - name: allowInvalidAmounts
+        in: query
+        description: Optional parameter to save all padding spaces
+        schema:
+          type: boolean
     get:
       tags: ['ACH Files']
       summary: Validate File

--- a/server/test/unordered_batches/unordered_batch_test.go
+++ b/server/test/unordered_batches/unordered_batch_test.go
@@ -51,6 +51,19 @@ func TestUnorderedBatches(t *testing.T) {
 	req = httptest.NewRequest("POST", fmt.Sprintf("/files/%s/validate", response.ID), &buf)
 	server.Handler.ServeHTTP(w, req)
 	w.Flush()
+	require.Equal(t, http.StatusOK, w.Code)
 
+	// Try POST /validate with ?unorderedBatchNumbers
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", fmt.Sprintf("/files/%s/validate?unorderedBatchNumbers=true", response.ID), nil)
+	server.Handler.ServeHTTP(w, req)
+	w.Flush()
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Try POST /validate with ?allowUnorderedBatchNumbers
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", fmt.Sprintf("/files/%s/validate?allowUnorderedBatchNumbers=true", response.ID), nil)
+	server.Handler.ServeHTTP(w, req)
+	w.Flush()
 	require.Equal(t, http.StatusOK, w.Code)
 }

--- a/server/validate.go
+++ b/server/validate.go
@@ -1,0 +1,137 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/moov-io/ach"
+)
+
+const (
+	skipAll                          = "skipAll"
+	requireABAOrigin                 = "requireABAOrigin"
+	bypassOrigin                     = "bypassOrigin"
+	bypassOriginValidation           = "bypassOriginValidation"
+	bypassDestination                = "bypassDestination"
+	bypassDestinationValidation      = "bypassDestinationValidation"
+	customTraceNumbers               = "customTraceNumbers"
+	allowZeroBatches                 = "allowZeroBatches"
+	allowMissingFileHeader           = "allowMissingFileHeader"
+	allowMissingFileControl          = "allowMissingFileControl"
+	bypassCompanyIdentificationMatch = "bypassCompanyIdentificationMatch"
+	customReturnCodes                = "customReturnCodes"
+	unequalServiceClassCode          = "unequalServiceClassCode"
+	unorderedBatchNumbers            = "unorderedBatchNumbers"
+	allowUnorderedBatchNumbers       = "allowUnorderedBatchNumbers"
+	allowInvalidCheckDigit           = "allowInvalidCheckDigit"
+	unequalAddendaCounts             = "unequalAddendaCounts"
+	preserveSpaces                   = "preserveSpaces"
+	allowInvalidAmounts              = "allowInvalidAmounts"
+)
+
+// readValidateOpts parses ValidateOpts from the URL query parameters and from the request body.
+// A copy of the request body is returned. Callers are responsible for closing the body.
+//
+// Query parameters override the JSON body
+func readValidateOpts(request *http.Request) (io.Reader, *ach.ValidateOpts, error) {
+	validationNames := []string{
+		skipAll,
+		requireABAOrigin,
+		bypassOrigin,
+		bypassOriginValidation,
+		bypassDestination,
+		bypassDestinationValidation,
+		customTraceNumbers,
+		allowZeroBatches,
+		allowMissingFileHeader,
+		allowMissingFileControl,
+		bypassCompanyIdentificationMatch,
+		customReturnCodes,
+		unequalServiceClassCode,
+		unorderedBatchNumbers,
+		allowUnorderedBatchNumbers,
+		allowInvalidCheckDigit,
+		unequalAddendaCounts,
+		preserveSpaces,
+		allowInvalidAmounts,
+	}
+
+	var buf bytes.Buffer
+	bs, _ := io.ReadAll(io.TeeReader(request.Body, &buf))
+
+	opts := &ach.ValidateOpts{}
+	json.Unmarshal(bs, opts)
+
+	for _, name := range validationNames {
+		q := request.URL.Query()
+		if q == nil {
+			continue
+		}
+		input := q.Get(name)
+		if input == "" {
+			continue
+		}
+
+		yes, err := strconv.ParseBool(input)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s is an invalid boolean: %v", name, err)
+		}
+		switch name {
+		case skipAll:
+			opts.SkipAll = yes
+		case requireABAOrigin:
+			opts.RequireABAOrigin = yes
+		case bypassOrigin, bypassOriginValidation:
+			opts.BypassOriginValidation = yes
+		case bypassDestination, bypassDestinationValidation:
+			opts.BypassDestinationValidation = yes
+		case customTraceNumbers:
+			opts.CustomTraceNumbers = yes
+		case allowZeroBatches:
+			opts.AllowZeroBatches = yes
+		case allowMissingFileHeader:
+			opts.AllowMissingFileHeader = yes
+		case allowMissingFileControl:
+			opts.AllowMissingFileControl = yes
+		case bypassCompanyIdentificationMatch:
+			opts.BypassCompanyIdentificationMatch = yes
+		case customReturnCodes:
+			opts.CustomReturnCodes = yes
+		case unequalServiceClassCode:
+			opts.UnequalServiceClassCode = yes
+		case unorderedBatchNumbers, allowUnorderedBatchNumbers:
+			opts.AllowUnorderedBatchNumbers = yes
+		case allowInvalidCheckDigit:
+			opts.AllowInvalidCheckDigit = yes
+		case unequalAddendaCounts:
+			opts.UnequalAddendaCounts = yes
+		case preserveSpaces:
+			opts.PreserveSpaces = yes
+		case allowInvalidAmounts:
+			opts.AllowInvalidAmounts = yes
+		}
+	}
+
+	return &buf, opts, nil
+}

--- a/server/validate_test.go
+++ b/server/validate_test.go
@@ -1,0 +1,44 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadValidateOpts(t *testing.T) {
+	body := strings.NewReader(`{
+ "bypassOriginValidation":true,
+ "bypassDestinationValidation":true,
+ "allowUnorderedBatchNumbers":true
+}`)
+	req, err := http.NewRequest("POST", "/files/f1/validate?bypassDestination=false&allowInvalidCheckDigit=true", body)
+	require.NoError(t, err)
+
+	_, opts, err := readValidateOpts(req)
+	require.NoError(t, err)
+
+	require.True(t, opts.BypassOriginValidation)
+	require.False(t, opts.BypassDestinationValidation) // query params override body
+	require.True(t, opts.AllowUnorderedBatchNumbers)
+	require.True(t, opts.AllowInvalidCheckDigit)
+}


### PR DESCRIPTION
There were a few query params whose names didn't match the JSON, so this PR standardizes on naming. The old names are supported, but deprecated. Also read validate opts query params on GET/POST `/files/{fileID}//validate`. 