### PR TITLE
make achcli -skip-validation flag not depend on -validate <filepath> being present

### DIFF
--- a/cmd/achcli/main.go
+++ b/cmd/achcli/main.go
@@ -93,6 +93,13 @@ func main() {
 }
 
 func readValidationOpts(path string) *ach.ValidateOpts {
+	var opts ach.ValidateOpts
+
+	if *flagSkipValidation {
+		opts.SkipAll = true
+		return &opts
+	}
+
 	if path != "" {
 		// read config file
 		bs, readErr := os.ReadFile(path)
@@ -101,13 +108,9 @@ func readValidationOpts(path string) *ach.ValidateOpts {
 			os.Exit(1)
 		}
 
-		var opts ach.ValidateOpts
 		if err := json.Unmarshal(bs, &opts); err != nil {
 			fmt.Printf("ERROR: unmarshal of validate opts failed: %v\n", err)
 			os.Exit(1)
-		}
-		if *flagSkipValidation {
-			opts.SkipAll = true
 		}
 		return &opts
 	}

--- a/docs/usage-command-line.md
+++ b/docs/usage-command-line.md
@@ -24,35 +24,37 @@ EXAMPLES
   achcli -mask file.ach                Print file details with personally identifiable information partially removed
   achcli -reformat=json first.ach      Convert an incoming ACH file into another format (options: ach, json)
   achcli -validate opts.json file.ach  Read an ACH File with the provided ValidateOpts
-  achcli -version                      Print the version of achcli (Example: v1.26.4)
+  achcli -version                      Print the version of achcli (Example: v1.38.0)
   achcli 20060102.ach                  Summarize an ACH file for human readability
 
 FLAGS
   -diff
-    	Compare two files against each other
+        Compare two files against each other
   -flatten
-    	Flatten batches in each file
+        Flatten batches in each file
   -mask
-    	Mask/hide full account numbers and individual names
+        Mask/hide full account numbers and individual names
   -mask.accounts
-    	Mask/hide full account numbers
+        Mask/hide full account numbers
   -mask.corrections
-    	Mask/Hide Corrected Data in Addenda98 records
+        Mask/Hide Corrected Data in Addenda98 records
   -mask.names
-    	Mask/hide full individual names
+        Mask/hide full individual names
   -merge
-    	Merge files before describing
+        Merge files before describing
   -pretty
-    	Display all values in their human readable format
+        Display all values in their human readable format
   -pretty.amounts
-    	Display human readable amounts instead of exact values
+        Display human readable amounts instead of exact values
   -reformat string
-    	Reformat an incoming ACH file to another format
-  -v	Print verbose details about each ACH file
+        Reformat an incoming ACH file to another format
+  -skip-validation
+        Skip all validation checks
+  -v    Print verbose details about each ACH file
   -validate string
-    	Path to config file in json format to enable validation opts
+        Path to config file in json format to enable validation opts
   -version
-    	Print moov-io/ach cli version
+        Print moov-io/ach cli version
 ```
 
 ## Install and Usage


### PR DESCRIPTION
Right now `-skip-validation` is only considered if the `-validate` flag is
present. The name of the flag implies it being a boolean flag and it is
unintuitive that it needs another flag to be present referencing a
config file that will be ignored. I am unsure if this was intended behaviour but it felt unintuitive and it lead me to have to debug where I call the `achcli` tool until I realised this was the behaviour.

fixes #1414 