### PR TITLE
[line-ending] allow specifying line ending via API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -309,10 +309,11 @@ paths:
             type: string
         - name: X-Line-Ending
           in: header
-          description: Optional Line Ending allows application developer to alter line ending of the file data returned
-          example: "\r\n"
+          description: Optional Line Ending allows application developer to alter line ending of the file data returned. Supported choices are LF (Line Feed) and CRLF (Carriage Return Line Feed).
+          example: "CRLF"
           schema:
             type: string
+            enum: ["LF", "CRLF"]
         - name: fileID
           in: path
           description: File ID

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -307,6 +307,12 @@ paths:
           example: "rs4f9915"
           schema:
             type: string
+        - name: X-Line-Ending
+          in: header
+          description: Optional Line Ending allows application developer to alter line ending of the file data returned
+          example: "\r\n"
+          schema:
+            type: string
         - name: fileID
           in: path
           description: File ID

--- a/server/files.go
+++ b/server/files.go
@@ -351,6 +351,8 @@ type getFileContentsRequest struct {
 	ID string
 
 	requestID string
+
+	opts *ach.WriteOpts
 }
 
 type getFileContentsResponse struct {
@@ -366,7 +368,7 @@ func getFileContentsEndpoint(s Service, logger log.Logger) endpoint.Endpoint {
 			return getFileContentsResponse{Err: ErrFoundABug}, ErrFoundABug
 		}
 
-		r, err := s.GetFileContents(req.ID)
+		r, err := s.GetFileContents(req.ID, req.opts)
 
 		if logger != nil {
 			logger := logger.With(log.Fields{

--- a/server/files.go
+++ b/server/files.go
@@ -404,9 +404,14 @@ func decodeGetFileContentsRequest(_ context.Context, r *http.Request) (interface
 	}, nil
 }
 
-// GetLineEnding returns the header value for Line Endings
+// Inspects the `X-Line-Ending` header. If it is a valid value (CRLF | LF), returns the line ending associated
+// with the selected enum value. Otherwise, defaults to Unix-style newline characters.
 func GetLineEnding(r *http.Request) string {
-	return r.Header.Get("X-Line-Ending")
+	header := r.Header.Get("X-Line-Ending")
+	if header == "CRLF" {
+		return "\r\n"
+	}
+	return "\n"
 }
 
 type validateFileRequest struct {

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -1086,12 +1086,11 @@ func TestFileContentsByID__getFileContentsEndpoint_WindowsLineEndings(t *testing
 	file, _ := ach.FileFromJSON(bs)
 	repo.StoreFile(file)
 
-	lineEnding := "\r\n"
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", fmt.Sprintf("/files/%s/contents", file.ID), nil)
 	req.Header.Set("Origin", "https://moov.io")
 	req.Header.Set("X-Request-Id", "11113")
-	req.Header.Set("X-Line-Ending", lineEnding)
+	req.Header.Set("X-Line-Ending", "CRLF")
 
 	router.ServeHTTP(w, req)
 	w.Flush()
@@ -1099,7 +1098,7 @@ func TestFileContentsByID__getFileContentsEndpoint_WindowsLineEndings(t *testing
 	if w.Code != http.StatusOK {
 		t.Errorf("bogus HTTP status: %d", w.Code)
 	}
-	lines := strings.Split(w.Body.String(), lineEnding)
+	lines := strings.Split(w.Body.String(), "\r\n")
 	require.True(t, len(lines) >= 10)
 }
 
@@ -1119,12 +1118,11 @@ func TestFileContentsByID__getFileContentsEndpoint_UnixLineEndings(t *testing.T)
 	file, _ := ach.FileFromJSON(bs)
 	repo.StoreFile(file)
 
-	lineEnding := "\n"
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", fmt.Sprintf("/files/%s/contents", file.ID), nil)
 	req.Header.Set("Origin", "https://moov.io")
 	req.Header.Set("X-Request-Id", "11113")
-	req.Header.Set("X-Line-Ending", lineEnding)
+	req.Header.Set("X-Line-Ending", "LF")
 
 	router.ServeHTTP(w, req)
 	w.Flush()
@@ -1132,7 +1130,7 @@ func TestFileContentsByID__getFileContentsEndpoint_UnixLineEndings(t *testing.T)
 	if w.Code != http.StatusOK {
 		t.Errorf("bogus HTTP status: %d", w.Code)
 	}
-	lines := strings.Split(w.Body.String(), lineEnding)
+	lines := strings.Split(w.Body.String(), "\n")
 	require.True(t, len(lines) >= 10)
 	// Line terminator should be `\n` and NOT include a carriage return.
 	windowsLines := strings.Split(w.Body.String(), "\r\n")

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -1068,7 +1068,75 @@ func TestFileContentsByID__getFileContentsEndpoint(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Errorf("bogus HTTP status: %d", w.Code)
 	}
+}
 
+func TestFileContentsByID__getFileContentsEndpoint_WindowsLineEndings(t *testing.T) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(testTTLDuration, logger)
+	svc := NewService(repo)
+	router := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// write an ACH file into repository
+	fd, err := os.Open(filepath.Join("..", "test", "testdata", "ppd-mixedDebitCredit-valid.json"))
+	if fd == nil {
+		t.Fatalf("empty ACH file: %v", err)
+	}
+	defer fd.Close()
+	bs, _ := io.ReadAll(fd)
+	file, _ := ach.FileFromJSON(bs)
+	repo.StoreFile(file)
+
+	lineEnding := "\r\n"
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/files/%s/contents", file.ID), nil)
+	req.Header.Set("Origin", "https://moov.io")
+	req.Header.Set("X-Request-Id", "11113")
+	req.Header.Set("X-Line-Ending", lineEnding)
+
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", w.Code)
+	}
+	lines := strings.Split(w.Body.String(), lineEnding)
+	require.True(t, len(lines) >= 10)
+}
+
+func TestFileContentsByID__getFileContentsEndpoint_UnixLineEndings(t *testing.T) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(testTTLDuration, logger)
+	svc := NewService(repo)
+	router := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// write an ACH file into repository
+	fd, err := os.Open(filepath.Join("..", "test", "testdata", "ppd-mixedDebitCredit-valid.json"))
+	if fd == nil {
+		t.Fatalf("empty ACH file: %v", err)
+	}
+	defer fd.Close()
+	bs, _ := io.ReadAll(fd)
+	file, _ := ach.FileFromJSON(bs)
+	repo.StoreFile(file)
+
+	lineEnding := "\n"
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/files/%s/contents", file.ID), nil)
+	req.Header.Set("Origin", "https://moov.io")
+	req.Header.Set("X-Request-Id", "11113")
+	req.Header.Set("X-Line-Ending", lineEnding)
+
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", w.Code)
+	}
+	lines := strings.Split(w.Body.String(), lineEnding)
+	require.True(t, len(lines) >= 10)
+	// Line terminator should be `\n` and NOT include a carriage return.
+	windowsLines := strings.Split(w.Body.String(), "\r\n")
+	require.True(t, len(windowsLines) == 1)
 }
 
 // TestFilesByID__deleteFileEndpoint tests by File ID

--- a/server/service.go
+++ b/server/service.go
@@ -46,7 +46,7 @@ type Service interface {
 	// DeleteFile takes a file resource ID and deletes it from the store
 	DeleteFile(id string) error
 	// GetFileContents creates a valid plaintext file in memory assuming it has a FileHeader and at least one Batch record.
-	GetFileContents(id string) (io.Reader, error)
+	GetFileContents(id string, opts *ach.WriteOpts) (io.Reader, error)
 	// ValidateFile
 	ValidateFile(id string, opts *ach.ValidateOpts) error
 	// BalanceFile will apply a given offset record to the file
@@ -129,7 +129,7 @@ func (s *service) DeleteFile(id string) error {
 	return s.store.DeleteFile(id)
 }
 
-func (s *service) GetFileContents(id string) (io.Reader, error) {
+func (s *service) GetFileContents(id string, opts *ach.WriteOpts) (io.Reader, error) {
 	f, err := s.GetFile(id)
 	if err != nil {
 		return nil, fmt.Errorf("problem reading file %s: %v", id, err)
@@ -139,7 +139,7 @@ func (s *service) GetFileContents(id string) (io.Reader, error) {
 	}
 
 	var buf bytes.Buffer
-	w := ach.NewWriter(&buf)
+	w := ach.NewWriterWithOpts(&buf, opts)
 	if err := w.Write(f); err != nil {
 		return nil, fmt.Errorf("problem writing plaintext file %s: %v", id, err)
 	}

--- a/writer.go
+++ b/writer.go
@@ -35,11 +35,26 @@ type Writer struct {
 	BypassValidation bool
 }
 
+// WriteOpts defines options for writing a file.
+type WriteOpts struct {
+	// LineEnding sets a custom line ending character.
+	LineEnding string `json:"lineEnding"`
+}
+
 // NewWriter returns a new Writer that writes to w.
 func NewWriter(w io.Writer) *Writer {
+	return NewWriterWithOpts(w, nil)
+}
+
+// NewWriter returns a new Writer that writes to w.
+func NewWriterWithOpts(w io.Writer, opts *WriteOpts) *Writer {
+	lineEnding := "\n"
+	if opts != nil && opts.LineEnding != "" {
+		lineEnding = opts.LineEnding
+	}
 	return &Writer{
 		w:          bufio.NewWriter(w),
-		LineEnding: "\n", //set default line ending
+		LineEnding: lineEnding,
 	}
 }
 


### PR DESCRIPTION
Ability to specify line-ending is supported if accessing directly via Go. This change exposes ability to specify line-ending for API requests when formatting a file as plaintext.

This PR may require additional updates, opening to gain insight on the steps to move forward.