### PR TITLE
Updated reference in comment to mixed credits and debits value. Adjusted small typo, capitlization.

### DIFF
--- a/batchControl.go
+++ b/batchControl.go
@@ -31,7 +31,7 @@ type BatchControl struct {
 	// ServiceClassCode ACH Mixed Debits and Credits '200'
 	// ACH Credits Only '220'
 	// ACH Debits Only '225'
-	// Constants: MixedCreditsAnDebits (220), CReditsOnly 9220), DebitsOnly (225)
+	// Constants: MixedCreditsAnDebits (220), CreditsOnly (220), DebitsOnly (225)
 	// Same as 'ServiceClassCode' in BatchHeaderRecord
 	ServiceClassCode int `json:"serviceClassCode"`
 	// EntryAddendaCount is a tally of each Entry Detail Record and each Addenda

--- a/batchControl.go
+++ b/batchControl.go
@@ -31,7 +31,7 @@ type BatchControl struct {
 	// ServiceClassCode ACH Mixed Debits and Credits '200'
 	// ACH Credits Only '220'
 	// ACH Debits Only '225'
-	// Constants: MixedCreditsAnDebits (220), CreditsOnly (220), DebitsOnly (225)
+	// Constants: MixedCreditsAnDebits (200), CreditsOnly (220), DebitsOnly (225)
 	// Same as 'ServiceClassCode' in BatchHeaderRecord
 	ServiceClassCode int `json:"serviceClassCode"`
 	// EntryAddendaCount is a tally of each Entry Detail Record and each Addenda


### PR DESCRIPTION
I've updated one of the comments for Service Class Code value for mixed credits and debits. It's correctly labeled on the comment preceeding it, so I'm just changing it to reflect the 200 value above.