### PR TITLE
Update CONTRIBUTING.md (fixed bad links, minor spelling and grammar fixes)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,22 @@
 # Contributing
 
-Wow, we really appreciate that you even looked at this section! We are trying to make the worlds best atomic building blocks for financial services that accelerate innovation in banking and we need your help!
+Wow, we really appreciate that you even looked at this section! We are trying to make the world's best atomic building blocks for financial services that accelerate innovation in banking and we need your help!
 
 You only have a fresh set of eyes once! The easiest way to contribute is to give feedback on the documentation that you are reading right now. This can be as simple as sending a message to our Google Group with your feedback or updating the markdown in this documentation and issuing a pull request.
 
 Stability is the hallmark of any good software. If you find an edge case that isn't handled please open an GitHub issue with the example data so that we can make our software more robust for everyone. We also welcome pull requests if you want to get your hands dirty.
 
-Have a use case that we don't handle; or handle well! Start the discussion on our Google Group or open a GitHub Issue. We want to make the project meet the needs of the community and keeps you using our code.
+Have a use case that we don't handle, or handle well? Start the discussion on our Google Group or open a GitHub Issue. We want to make the project meet the needs of the community and keeps you using our code.
 
 Please review our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure you agree with the values of this project.
 
 We use GitHub to manage reviews of pull requests.
 
-* If you have a trivial fix or improvement, go ahead and create a pull request, addressing (with `@...`) one or more of the maintainers (see [AUTHORS.md](AUTHORS.md)) in the description of the pull request.
+* If you have a trivial fix or improvement, go ahead and create a pull request, addressing (with `@...`) one or more of the maintainers (see [AUTHORS](AUTHORS)) in the description of the pull request.
 
 * If you plan to do something more involved, first propose your ideas in a Github issue. This will avoid unnecessary work and surely give you and us a good deal of inspiration.
 
-* Relevant coding style guidelines are the [Go Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments) and the _Formatting and style_ section of Peter Bourgon's [Go: Best Practices for Production Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).
+* Relevant coding style guidelines are the [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) and the _Formatting and style_ section of Peter Bourgon's [Go: Best Practices for Production Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).
 
 * When in doubt follow the [Go Proverbs](https://go-proverbs.github.io/)
 
@@ -63,12 +63,12 @@ Our Build pipeline utilizes [Travis-CI](https://travis-ci.org/moov-io/ach) to en
 
 ## Additional SEC (Standard Entry Class) code batch types.
 
-SEC type's in the Batch Header record define the payment type of the following Entry Details and Addenda. The format of the records in the batch is the same between all payment types but NACHA defines different rules for the values that are held in each record field. To add support for an additional SEC type you will need to implement NACHA rules for that type. The vast majority of rules are implemented in ach.batch and then composed into Batch(SEC) for reuse. All Batch(SEC) types must be a ach.Batcher.
+SEC types in the Batch Header record define the payment type of the following Entry Details and Addenda. The format of the records in the batch is the same between all payment types but NACHA defines different rules for the values that are held in each record field. To add support for an additional SEC type you will need to implement NACHA rules for that type. The vast majority of rules are implemented in ach.batch and then composed into Batch(SEC) for reuse. All Batch(SEC) types must be an ach.Batcher.
 
-2. Create an issue with the NACHA rules and record layout for the batch type.
-3. Create a new struct of the batch type. In the following example we will use MTE (Machine Transfer Entry) as our example.
-4. The following code would be place in a new file batchMTE.go next to the existing batch types.
-5. The code is stub code and the MTE type is not implemented. For concrete examples review the existing batch types in the source.
+1. Create an issue with the NACHA rules and record layout for the batch type.
+2. Create a new struct of the batch type. In the following example we will use MTE (Machine Transfer Entry) as our example.
+3. The following code would be place in a new file batchMTE.go next to the existing batch types.
+4. The code is stub code and the MTE type is not implemented. For concrete examples review the existing batch types in the source.
 
 Create a new struct and compose ach.batch
 
@@ -94,7 +94,7 @@ To support the Batcher interface you must add the following functions that are n
 - `Validate() error`
 - `Create() error`
 
-Validate is designed to enforce the NACHA rules for the MTE payment type. Validate is run after a batch of this type is read from a file. If you are creating a batch from code call validate afterwards.
+Validate is designed to enforce the NACHA rules for the MTE payment type. Validate is run after a batch of this type is read from a file. If you are creating a batch from code, call validate afterwards.
 
 ```go
 // Validate checks properties of the ACH batch to ensure they match NACHA guidelines.
@@ -113,7 +113,7 @@ func (batch *BatchMTE) Validate() error {
 	return nil
 }
 ```
-Create takes the Batch Header and Entry details and creates the proper sequence number and batch control. If additional logic specific to the SEC type is required it building a batch file it should be added here.
+Create takes the Batch Header and Entry details and creates the proper sequence number and batch control. If additional logic specific to the SEC type is required for building a batch file it should be added here.
 
 ```go
 // Create will tabulate and assemble an ACH batch into a valid state. This includes
@@ -149,7 +149,7 @@ In order for the code to be merged with a Pull requests we require a `batchMTE_t
 
 ## Command Line tools
 
-We have written two command line tools ([`readACH`](github.com/moov-io/ach/cmd/readACH) and [`writeACH`](github.com/moov-io/ach/cmd/writeACH)) that work with ACH files.
+We have written two command line tools ([`readACH`](github.com/moov-io/ach/tree/master/cmd/readACH) and [`writeACH`](github.com/moov-io/ach/tree/master/cmd/writeACH)) that work with ACH files.
 
 #### readACH
 
@@ -174,7 +174,7 @@ $ readACH -fPath test/testdata/ppd-debit.ach -json  | jq .
 
 ## Benchmarks
 
-Running benchmarks can be ran with `go test`. Typically machines running benchmarks are idle except for the benchmarked code. Please report all machine hardware specs and OS/Go versions when reporting benchmarks. Please refer to Dave Cheny's [benchmarking buide](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go).
+Running benchmarks can be ran with `go test`. Typically machines running benchmarks are idle except for the benchmarked code. Please report all machine hardware specs and OS/Go versions when reporting benchmarks. Please refer to Dave Cheney's [benchmarking guide](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go).
 
 Example:
 
@@ -187,18 +187,18 @@ $ go test ./cmd/readACH -bench=BenchmarkTestFileRead -count=10000 > BenchmarkTes
 
 ## References
 
-* [Wikipeda: Automated Clearing House](http://en.wikipedia.org/wiki/Automated_Clearing_House)
+* [Wikipedia: Automated Clearing House](http://en.wikipedia.org/wiki/Automated_Clearing_House)
 * [Nacha ACH Network: How it Works](https://www.nacha.org/ach-network)
 * [Federal ACH Directory](https://www.frbservices.org/EPaymentsDirectory/search.html)
 
 ## Format Specification
 
-* [NACHA ACH File Formatting](https://www.nacha.org/system/files/resources/AAP201%20-%20ACH%20File%20Formatting.pdf)
+* [NACHA ACH File Details](https://achdevguide.nacha.org/ach-file-details)
 * [PNC ACH File Specification](http://content.pncmc.com/live/pnc/corporate/treasury-management/ach-conversion/ACH-File-Specifications.pdf)
-* [Thomson Reuters ACH FIle Structure](http://cs.thomsonreuters.com/ua/acct_pr/acs/cs_us_en/pr/dd/ach_file_structure_and_content.htm)
-* [Gusto: How ACH Works: A developer perspective](http://engineering.gusto.com/how-ach-works-a-developer-perspective-part-4/)
+* [Thomson Reuters ACH FIle Structure](https://www.thomsonreuters.com/en-us/help/accounting-cs/direct-deposit/ach-structure-and-contents.html)
+* [Gusto: How ACH Works: A developer perspective](https://medium.com/gusto-engineering/how-ach-works-a-developer-perspective-part-5-1d998bbcd82c)
 
-![ACH File Layout](https://github.com/moov-io/ach/blob/master/documentation/ach_file_structure_shg.gif)
+![ACH File Layout](https://github.com/moov-io/ach/blob/master/docs/ach_file_structure_shg.gif)
 
 ## Inspiration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,15 +187,15 @@ $ go test ./cmd/readACH -bench=BenchmarkTestFileRead -count=10000 > BenchmarkTes
 
 ## References
 
-* [Wikipedia: Automated Clearing House](http://en.wikipedia.org/wiki/Automated_Clearing_House)
-* [Nacha ACH Network: How it Works](https://www.nacha.org/ach-network)
+* [Wikipedia: Automated Clearing House](https://en.wikipedia.org/wiki/Automated_Clearing_House)
+* [NACHA ACH Network: How it Works](https://www.nacha.org/ach-network)
 * [Federal ACH Directory](https://www.frbservices.org/EPaymentsDirectory/search.html)
 
 ## Format Specification
 
 * [NACHA ACH File Details](https://achdevguide.nacha.org/ach-file-details)
 * [PNC ACH File Specification](http://content.pncmc.com/live/pnc/corporate/treasury-management/ach-conversion/ACH-File-Specifications.pdf)
-* [Thomson Reuters ACH FIle Structure](https://www.thomsonreuters.com/en-us/help/accounting-cs/direct-deposit/ach-structure-and-contents.html)
+* [Thomson Reuters ACH File Structure](https://www.thomsonreuters.com/en-us/help/accounting-cs/direct-deposit/ach-structure-and-contents.html)
 * [Gusto: How ACH Works: A developer perspective](https://medium.com/gusto-engineering/how-ach-works-a-developer-perspective-part-5-1d998bbcd82c)
 
 ![ACH File Layout](https://github.com/moov-io/ach/blob/master/docs/ach_file_structure_shg.gif)


### PR DESCRIPTION
Made some small changes to ACH's CONTRIBUTING.md file, including fixing broken links:

- Fixed the “AUTHORS” link. The current link results in a 404 since the file is called “AUTHORS”, not “AUTHORS.md”.

- Updated the old “Go Code Review Comments” link so that the user isn’t required to manually redirect their browser.

- Fixed the numbering of instructions for adding SEC types (it should start with the number "1").

- Updated the "readACH" link, which currently gives a 404.

- Updated the "writeACH" link, which currently gives a 404.

- Updated several "Format Specification" links.

- Fixed some misspellings (for example, Cheny->Cheney, buide->guide, Wikipeda->Wikipedia)

- Changed the “I” in the word “FIle” from uppercase to lowercase.

- Changed one instance of “Nacha” to “NACHA” for consistency and correctness.

- Changed the scheme in the Wikipedia link from “http” to “https” in order to avoid an automatic redirect.


While the aforementioned changes should be good, there are still some questions that I have:
- The CONTRIBUTING.md file mentions a google group. Does that group still exist?
- It doesn’t look like anything has happened with the "Travis-CI" pipeline in quite some time (latest run was 4 years ago). Should references to it be removed?
- I couldn't find an updated PNC ACH File Specification. What link should be used?