### PR TITLE
fix: populate ATX/CTX receiving company / addenda indicator from JSON

### DIFF
--- a/entryDetail.go
+++ b/entryDetail.go
@@ -557,6 +557,8 @@ func (ed *EntryDetail) SetOriginalTraceNumber(s string) {
 
 // SetCATXAddendaRecords setter for CTX and ATX AddendaRecords characters 1-4 of underlying IndividualName
 func (ed *EntryDetail) SetCATXAddendaRecords(i int) {
+	ed.AddendaRecordIndicator = i
+
 	count := ed.numericField(i, 4)
 	current := ed.IndividualName
 	if utf8.RuneCountInString(current) > 4 {

--- a/test/issues/issue1501_test.go
+++ b/test/issues/issue1501_test.go
@@ -1,0 +1,50 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package issues
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/ach/cmd/achcli/describe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1501(t *testing.T) {
+	file, err := ach.ReadJSONFile(filepath.Join("testdata", "issue1501.json"))
+	require.NoError(t, err)
+
+	if testing.Verbose() {
+		describe.File(os.Stdout, file, nil)
+	}
+
+	require.Len(t, file.Batches, 1)
+
+	entries := file.Batches[0].GetEntries()
+	require.Len(t, entries, 2)
+
+	e1 := entries[0]
+	require.Equal(t, "0001", e1.CATXAddendaRecordsField())
+	require.Equal(t, "Test              ", e1.CATXReceivingCompanyField())
+
+	e2 := entries[1]
+	require.Equal(t, "0001", e2.CATXAddendaRecordsField())
+	require.Equal(t, "Other", e2.CATXReceivingCompanyField())
+}

--- a/test/issues/testdata/issue1501.json
+++ b/test/issues/testdata/issue1501.json
@@ -1,0 +1,83 @@
+{
+    "fileControl": {
+        "totalDebit": 0,
+        "totalCredit": 6,
+        "id": "",
+        "entryHash": 8410676,
+        "entryAddendaCount": 2,
+        "blockCount": 1,
+        "batchCount": 1
+    },
+    "batches": [
+        {
+            "entryDetails": [
+                {
+                    "addenda99": {
+                        "traceNumber": "084106760000005",
+                        "originalTrace": "084106760000001",
+                        "originalDFI": "06200001",
+                        "addendaInformation": "No Account/Unable to Locate Account",
+                        "returnCode": "R06",
+                        "typeCode": "99"
+                    },
+                    "category": "Return",
+                    "identificationNumber": "ALEXA SMART",
+                    "individualName": "Test",
+                    "DFIAccountNumber": "000000012",
+                    "checkDigit": "9",
+                    "transactionCode": 22,
+                    "RDFIIdentification": "06200001",
+                    "traceNumber": "025405790000009",
+                    "amount": 1000,
+                    "id": "16857152524021c",
+                    "addendaRecordIndicator": 1
+                },
+                {
+                    "addenda99": {
+                        "traceNumber": "084106760000006",
+                        "originalTrace": "084106760000002",
+                        "originalDFI": "06200001",
+                        "addendaInformation": "No Account/Unable to Locate Account",
+                        "returnCode": "R06",
+                        "typeCode": "99"
+                    },
+                    "category": "Return",
+                    "identificationNumber": "ALEXA SMART",
+                    "individualName": "0001Other",
+                    "DFIAccountNumber": "000000012",
+                    "checkDigit": "9",
+                    "transactionCode": 22,
+                    "RDFIIdentification": "06200001",
+                    "traceNumber": "025405790000010",
+                    "amount": 1000,
+                    "id": "16857152524021c"
+                }
+            ],
+            "batchHeader": {
+                "serviceClassCode": 220,
+                "effectiveEntryDate": "230603",
+                "ODFIIdentification": "08410676",
+                "companyEntryDescription": "RETURN",
+                "standardEntryClassCode": "CTX",
+                "companyIdentification": "1113290945",
+                "companyName": "ben10"
+            }
+        }
+    ],
+    "fileADVControl": {
+        "totalDebit": 0,
+        "totalCredit": 0,
+        "id": "",
+        "entryHash": 0,
+        "entryAddendaCount": 0,
+        "batchCount": 0
+    },
+    "fileHeader": {
+        "fileCreationTime": "1614",
+        "fileCreationDate": "240602",
+        "immediateDestinationName": "FEDERAL RESERVE BANK",
+        "immediateDestination": "081000045",
+        "immediateOriginName": "EVOLVE BANK & TRUST",
+        "immediateOrigin": "084106768"
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/moov-io/ach/issues/1501