### PR TITLE
Add DeleteEntry and DeleteADVEntry to Batcher

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -528,10 +529,32 @@ func (batch *Batch) AddEntry(entry *EntryDetail) {
 	batch.Entries = append(batch.Entries, entry)
 }
 
+// DeleteEntry deletes an EntryDetail from the Batch
+func (batch *Batch) DeleteEntry(entry *EntryDetail) {
+	if entry == nil {
+		return
+	}
+
+	batch.Entries = slices.DeleteFunc(batch.Entries, func(e *EntryDetail) bool {
+		return e == entry
+	})
+}
+
 // AddADVEntry appends an ADV EntryDetail to the Batch
 func (batch *Batch) AddADVEntry(entry *ADVEntryDetail) {
 	batch.category = entry.Category
 	batch.ADVEntries = append(batch.ADVEntries, entry)
+}
+
+// DeleteADVEntry deletes an ADV EntryDetail from the Batch
+func (batch *Batch) DeleteADVEntry(entry *ADVEntryDetail) {
+	if entry == nil {
+		return
+	}
+
+	batch.ADVEntries = slices.DeleteFunc(batch.ADVEntries, func(e *ADVEntryDetail) bool {
+		return e == entry
+	})
 }
 
 // GetADVEntries returns a slice of entry details for the batch

--- a/batch.go
+++ b/batch.go
@@ -529,15 +529,9 @@ func (batch *Batch) AddEntry(entry *EntryDetail) {
 	batch.Entries = append(batch.Entries, entry)
 }
 
-// DeleteEntry deletes an EntryDetail from the Batch
-func (batch *Batch) DeleteEntry(entry *EntryDetail) {
-	if entry == nil {
-		return
-	}
-
-	batch.Entries = slices.DeleteFunc(batch.Entries, func(e *EntryDetail) bool {
-		return e == entry
-	})
+// DeleteEntries deletes all Entries from the Batch where del() == true
+func (batch *Batch) DeleteEntries(del func(e *EntryDetail) bool) {
+	batch.Entries = slices.DeleteFunc(batch.Entries, del)
 }
 
 // AddADVEntry appends an ADV EntryDetail to the Batch
@@ -546,15 +540,9 @@ func (batch *Batch) AddADVEntry(entry *ADVEntryDetail) {
 	batch.ADVEntries = append(batch.ADVEntries, entry)
 }
 
-// DeleteADVEntry deletes an ADV EntryDetail from the Batch
-func (batch *Batch) DeleteADVEntry(entry *ADVEntryDetail) {
-	if entry == nil {
-		return
-	}
-
-	batch.ADVEntries = slices.DeleteFunc(batch.ADVEntries, func(e *ADVEntryDetail) bool {
-		return e == entry
-	})
+// DeleteADVEntries deletes all ADV Entries from the Batch where del() == true
+func (batch *Batch) DeleteADVEntries(del func(e *ADVEntryDetail) bool) {
+	batch.ADVEntries = slices.DeleteFunc(batch.ADVEntries, del)
 }
 
 // GetADVEntries returns a slice of entry details for the batch

--- a/batch_test.go
+++ b/batch_test.go
@@ -1697,3 +1697,55 @@ func TestBatch_calculateEntryHash(t *testing.T) {
 	hash := b.calculateEntryHash()
 	require.Equal(t, 22140797, hash)
 }
+
+func TestBatch_DeleteEntry(t *testing.T) {
+	b := &Batch{}
+	b.SetHeader(mockBatchHeader())
+
+	ed1 := mockEntryDetail()
+	ed1.TraceNumber = "1"
+	b.AddEntry(ed1)
+
+	ed2 := mockEntryDetail()
+	ed2.TraceNumber = "2"
+	b.AddEntry(ed2)
+
+	ed3 := mockEntryDetail()
+	ed3.TraceNumber = "3"
+	b.AddEntry(ed3)
+
+	require.Equal(t, 3, len(b.Entries))
+
+	b.DeleteEntry(ed2)
+	require.Equal(t, 2, len(b.Entries))
+	require.Equal(t, "1", b.Entries[0].TraceNumber)
+	require.Equal(t, "3", b.Entries[1].TraceNumber)
+	b.DeleteEntry(ed2)
+	require.Equal(t, 2, len(b.Entries))
+}
+
+func TestBatch_DeleteADVEntry(t *testing.T) {
+	b := &Batch{}
+	b.SetHeader(mockBatchADVHeader())
+
+	ed1 := NewADVEntryDetail()
+	ed1.ID = "1"
+	b.AddADVEntry(ed1)
+
+	ed2 := NewADVEntryDetail()
+	ed2.ID = "2"
+	b.AddADVEntry(ed2)
+
+	ed3 := NewADVEntryDetail()
+	ed3.ID = "3"
+	b.AddADVEntry(ed3)
+
+	require.Equal(t, 3, len(b.ADVEntries))
+
+	b.DeleteADVEntry(ed2)
+	require.Equal(t, 2, len(b.ADVEntries))
+	require.Equal(t, "1", b.ADVEntries[0].ID)
+	require.Equal(t, "3", b.ADVEntries[1].ID)
+	b.DeleteADVEntry(ed2)
+	require.Equal(t, 2, len(b.ADVEntries))
+}

--- a/batch_test.go
+++ b/batch_test.go
@@ -1698,54 +1698,76 @@ func TestBatch_calculateEntryHash(t *testing.T) {
 	require.Equal(t, 22140797, hash)
 }
 
-func TestBatch_DeleteEntry(t *testing.T) {
+func TestBatch_DeleteEntries(t *testing.T) {
 	b := &Batch{}
 	b.SetHeader(mockBatchHeader())
 
 	ed1 := mockEntryDetail()
 	ed1.TraceNumber = "1"
-	b.AddEntry(ed1)
-
+	ed1.Amount = 20
 	ed2 := mockEntryDetail()
 	ed2.TraceNumber = "2"
-	b.AddEntry(ed2)
-
+	ed2.Amount = 60
 	ed3 := mockEntryDetail()
 	ed3.TraceNumber = "3"
+	ed3.Amount = 100
+
+	b.AddEntry(ed1)
+	b.AddEntry(ed2)
 	b.AddEntry(ed3)
 
 	require.Equal(t, 3, len(b.Entries))
 
-	b.DeleteEntry(ed2)
+	b.DeleteEntries(func(e *EntryDetail) bool {
+		return e.TraceNumber == "2"
+	})
+
 	require.Equal(t, 2, len(b.Entries))
 	require.Equal(t, "1", b.Entries[0].TraceNumber)
 	require.Equal(t, "3", b.Entries[1].TraceNumber)
-	b.DeleteEntry(ed2)
-	require.Equal(t, 2, len(b.Entries))
+
+	b.AddEntry(ed2)
+
+	b.DeleteEntries(func(e *EntryDetail) bool {
+		return e.Amount >= 50
+	})
+	require.Equal(t, 1, len(b.Entries))
+	require.Equal(t, "1", b.Entries[0].TraceNumber)
 }
 
-func TestBatch_DeleteADVEntry(t *testing.T) {
+func TestBatch_DeleteADVEntries(t *testing.T) {
 	b := &Batch{}
-	b.SetHeader(mockBatchADVHeader())
+	b.SetHeader(mockBatchHeader())
 
-	ed1 := NewADVEntryDetail()
+	ed1 := mockADVEntryDetail()
 	ed1.ID = "1"
-	b.AddADVEntry(ed1)
-
-	ed2 := NewADVEntryDetail()
+	ed1.Amount = 20
+	ed2 := mockADVEntryDetail()
 	ed2.ID = "2"
-	b.AddADVEntry(ed2)
-
-	ed3 := NewADVEntryDetail()
+	ed2.Amount = 60
+	ed3 := mockADVEntryDetail()
 	ed3.ID = "3"
+	ed3.Amount = 100
+
+	b.AddADVEntry(ed1)
+	b.AddADVEntry(ed2)
 	b.AddADVEntry(ed3)
 
 	require.Equal(t, 3, len(b.ADVEntries))
 
-	b.DeleteADVEntry(ed2)
+	b.DeleteADVEntries(func(e *ADVEntryDetail) bool {
+		return e.ID == "2"
+	})
+
 	require.Equal(t, 2, len(b.ADVEntries))
 	require.Equal(t, "1", b.ADVEntries[0].ID)
 	require.Equal(t, "3", b.ADVEntries[1].ID)
-	b.DeleteADVEntry(ed2)
-	require.Equal(t, 2, len(b.ADVEntries))
+
+	b.AddADVEntry(ed2)
+
+	b.DeleteADVEntries(func(e *ADVEntryDetail) bool {
+		return e.Amount >= 50
+	})
+	require.Equal(t, 1, len(b.ADVEntries))
+	require.Equal(t, "1", b.ADVEntries[0].ID)
 }

--- a/batcher.go
+++ b/batcher.go
@@ -38,10 +38,10 @@ type Batcher interface {
 	SetADVControl(*ADVBatchControl)
 	GetEntries() []*EntryDetail
 	AddEntry(*EntryDetail)
-	DeleteEntry(*EntryDetail)
+	DeleteEntries(func(*EntryDetail) bool)
 	GetADVEntries() []*ADVEntryDetail
 	AddADVEntry(*ADVEntryDetail)
-	DeleteADVEntry(*ADVEntryDetail)
+	DeleteADVEntries(func(*ADVEntryDetail) bool)
 	Create() error
 	Validate() error
 	SetID(string)

--- a/batcher.go
+++ b/batcher.go
@@ -38,8 +38,10 @@ type Batcher interface {
 	SetADVControl(*ADVBatchControl)
 	GetEntries() []*EntryDetail
 	AddEntry(*EntryDetail)
+	DeleteEntry(*EntryDetail)
 	GetADVEntries() []*ADVEntryDetail
 	AddADVEntry(*ADVEntryDetail)
+	DeleteADVEntry(*ADVEntryDetail)
 	Create() error
 	Validate() error
 	SetID(string)


### PR DESCRIPTION
closes #1509 

Was also contemplating if it would be more useful to implement a `DeleteFunc` as the `slices` library provides, then it's easier to delete from the `Entries` slice based on arbitrary criteria instead of by maintaining or retrieving the pointer you want to delete. If that's preferable I can implement that.