### PR TITLE
fix: preserve FileIDModifier when flattening files

### DIFF
--- a/file.go
+++ b/file.go
@@ -1271,6 +1271,7 @@ func (f *File) addFileHeaderData(file *File) *File {
 	file.Header.ImmediateDestination = f.Header.ImmediateDestination
 	file.Header.FileCreationDate = time.Now().Format("060102")
 	file.Header.FileCreationTime = time.Now().AddDate(0, 0, 1).Format("1504") // HHmm
+	file.Header.FileIDModifier = f.Header.FileIDModifier
 	file.Header.ImmediateDestinationName = f.Header.ImmediateDestinationName
 	file.Header.ImmediateOriginName = f.Header.ImmediateOriginName
 	return file

--- a/file_test.go
+++ b/file_test.go
@@ -2219,3 +2219,25 @@ func TestFileFromJSON_ValidateOpts(t *testing.T) {
 	require.NotNil(t, validateOpts)
 	require.True(t, validateOpts.PreserveSpaces)
 }
+
+func TestFile_FlattenBatches_PreservesFileIDModifier(t *testing.T) {
+	f := NewFile()
+	f.SetHeader(mockFileHeader())
+	f.Header.FileIDModifier = "B"
+	batch1 := mockBatchPPD(t)
+	f.AddBatch(batch1)
+
+	err := f.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	flattened, err := f.FlattenBatches()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if flattened.Header.FileIDModifier != "B" {
+		t.Errorf("FileIDModifier not preserved: want 'B' got %s", flattened.Header.FileIDModifier)
+	}
+}


### PR DESCRIPTION
When flattening a file using the `/files/{fileID}/flatten` endpoint, the FileIDModifier value from the original file header was not being copied to the new flattened file, causing it to default back to "A". This fix preserves the original FileIDModifier when flattening files.