### PR TITLE
Fix bug in Addenda02: Corrected ReferenceInformationTwoField to use ReferenceInformationTwo

### DIFF
--- a/addenda02.go
+++ b/addenda02.go
@@ -250,7 +250,7 @@ func (addenda02 *Addenda02) ReferenceInformationOneField() string {
 
 // ReferenceInformationTwoField returns a space padded ReferenceInformationTwo string
 func (addenda02 *Addenda02) ReferenceInformationTwoField() string {
-	return addenda02.alphaField(addenda02.ReferenceInformationOne, 3)
+	return addenda02.alphaField(addenda02.ReferenceInformationTwo, 3)
 }
 
 // TerminalIdentificationCodeField returns a space padded TerminalIdentificationCode string


### PR DESCRIPTION
Fix bug in Addenda02: Corrected ReferenceInformationTwoField to use ReferenceInformationTwo

In the **Addenda02** struct, **the ReferenceInformationTwoField method was incorrectly referencing ReferenceInformationOne instead of ReferenceInformationTwo**. This commit fixes the method to properly reference the correct field (ReferenceInformationTwo). This ensures that the correct data is returned and resolves any issues caused by the incorrect reference.
