### PR TITLE
Add DeleteEntries to IATBatch

### DIFF
--- a/iatBatch.go
+++ b/iatBatch.go
@@ -19,6 +19,7 @@ package ach
 
 import (
 	"encoding/json"
+	"slices"
 	"strconv"
 )
 
@@ -274,6 +275,11 @@ func (iatBatch *IATBatch) GetEntries() []*IATEntryDetail {
 func (iatBatch *IATBatch) AddEntry(entry *IATEntryDetail) {
 	iatBatch.category = entry.Category
 	iatBatch.Entries = append(iatBatch.Entries, entry)
+}
+
+// DeleteEntries deletes all Entries from the Batch where del() == true
+func (iatBatch *IATBatch) DeleteEntries(del func(e *IATEntryDetail) bool) {
+	iatBatch.Entries = slices.DeleteFunc(iatBatch.Entries, del)
 }
 
 // Category returns IATBatch Category

--- a/iatBatch_test.go
+++ b/iatBatch_test.go
@@ -2095,3 +2095,40 @@ func TestIATBatchInvalidServiceClassCode(t *testing.T) {
 	err = iatBatch.verify()
 	require.NoError(t, err)
 }
+
+func TestIATBatch_DeleteEntries(t *testing.T) {
+	mockBatch := IATBatch{}
+	mockBatch.SetHeader(mockIATBatchHeaderFF())
+
+	ed1 := mockIATEntryDetail()
+	ed1.TraceNumber = "1"
+	ed1.Amount = 20
+	ed2 := mockIATEntryDetail()
+	ed2.TraceNumber = "2"
+	ed2.Amount = 60
+	ed3 := mockIATEntryDetail()
+	ed3.TraceNumber = "3"
+	ed3.Amount = 100
+
+	mockBatch.AddEntry(ed1)
+	mockBatch.AddEntry(ed2)
+	mockBatch.AddEntry(ed3)
+
+	require.Len(t, mockBatch.Entries, 3)
+
+	mockBatch.DeleteEntries(func(e *IATEntryDetail) bool {
+		return e.TraceNumber == "2"
+	})
+
+	require.Len(t, mockBatch.Entries, 2)
+	require.Equal(t, "1", mockBatch.Entries[0].TraceNumber)
+	require.Equal(t, "3", mockBatch.Entries[1].TraceNumber)
+
+	mockBatch.AddEntry(ed2)
+
+	mockBatch.DeleteEntries(func(e *IATEntryDetail) bool {
+		return e.Amount >= 50
+	})
+	require.Len(t, mockBatch.Entries, 1)
+	require.Equal(t, "1", mockBatch.Entries[0].TraceNumber)
+}


### PR DESCRIPTION
Fixes https://github.com/moov-io/ach/issues/1525

Noticed that we missed to add DeleteEntries for IAT [here](https://github.com/moov-io/ach/pull/1511) and I'm looking to use that same functionality for IAT batches as well. 

Please review TY!