### PR TITLE
Allow NBSP (U+00A0) in PPD Addenda Payment Related Information

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -420,6 +420,7 @@ func (v *validator) isAlphanumeric(s string) error {
 		// Specific characters that are accepted
 		switch r {
 		case
+			0xA0, //   - Non-breaking Space
 			0xA2, // ¢ - Cent Sign
 			0xAC, // ¬ - Negation
 			0xA6, // ¦ - Pipe

--- a/validators_test.go
+++ b/validators_test.go
@@ -167,7 +167,7 @@ func TestValidators__isAlphanumeric(t *testing.T) {
 				shouldError := tt.shouldErr(i)
 
 				switch chr {
-				case `¢`, `¦`, `¬`, `±`: // skip valid ASCII characters
+				case ` `, `¢`, `¦`, `¬`, `±`: // skip valid ASCII characters
 					continue
 
 				case `Ø`: // skip characters found in real world usage


### PR DESCRIPTION
Not sure how lax you this project would like to get with what's been seen in the wild, but this is has been a minor inconvenience for us the last couple of months. We've been manually correcting these by replacing the NBSP with a regular space.

We've seen this in the wild recently:
(after the 50.00 and before the **\ in the line below):

```
705RMR*EE*11111111***                         50.00 **\                            00014444444
```

So this PR added the Unicode U+00A0 to the list of valid alpha numeric characters.