### PR TITLE
fix: read ValidateOpts from JSON before data

### DIFF
--- a/test/issues/issue1539_test.go
+++ b/test/issues/issue1539_test.go
@@ -1,0 +1,75 @@
+package issues
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/ach/cmd/achcli/describe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1539(t *testing.T) {
+	checkFile := func(t *testing.T, file *ach.File) {
+		t.Helper()
+
+		for _, b := range file.Batches {
+			for _, e := range b.GetEntries() {
+				// Check common fields
+				require.Contains(t, e.TraceNumber, "29147102")
+
+				switch e.TransactionCode {
+				case ach.CheckingCredit:
+					require.Equal(t, "27397636", e.RDFIIdentification)
+					require.Equal(t, "0123456789", e.DFIAccountNumber)
+
+				case ach.CheckingDebit:
+					require.Equal(t, "43219876", e.RDFIIdentification)
+					require.Equal(t, "3323523523", e.DFIAccountNumber)
+				}
+			}
+		}
+	}
+
+	t.Run("json.Unmarshal", func(t *testing.T) {
+		fd, err := os.Open(filepath.Join("testdata", "issue1539.json"))
+		require.NoError(t, err)
+		defer fd.Close()
+
+		var file ach.File
+		err = json.NewDecoder(fd).Decode(&file)
+		require.NoError(t, err)
+
+		// TraceNumbers should persist through Create()
+		require.NoError(t, file.Create())
+		for idx := range file.Batches {
+			require.NoError(t, file.Batches[idx].Create())
+		}
+
+		if testing.Verbose() {
+			describe.File(os.Stdout, &file, nil)
+		}
+
+		checkFile(t, &file)
+	})
+
+	t.Run("FileFromJSON", func(t *testing.T) {
+		file, err := ach.ReadJSONFile(filepath.Join("testdata", "issue1539.json"))
+		require.NoError(t, err)
+
+		// TraceNumbers should persist through Create()
+		require.NoError(t, file.Create())
+		for idx := range file.Batches {
+			require.NoError(t, file.Batches[idx].Create())
+		}
+
+		if testing.Verbose() {
+			describe.File(os.Stdout, file, nil)
+		}
+
+		checkFile(t, file)
+	})
+}

--- a/test/issues/testdata/issue1539.json
+++ b/test/issues/testdata/issue1539.json
@@ -1,0 +1,97 @@
+{
+    "id": "179837a5-ea10-46da-8777-53c4eed2258c",
+    "fileHeader": {
+        "id": "179837a5-ea10-46da-8777-53c4eed2258c",
+        "immediateDestination": "12345678",
+        "immediateOrigin": "987654321",
+        "fileCreationDate": "250127",
+        "fileCreationTime": "1452",
+        "fileIDModifier": "A",
+        "immediateDestinationName": "MyBANK",
+        "immediateOriginName": "Moov Financial"
+    },
+    "batches": [
+        {
+            "batchHeader": {
+                "id": "179837a5-ea10-46da-8777-53c4eed2258c",
+                "serviceClassCode": 200,
+                "companyName": "MOOV",
+                "companyIdentification": "987654",
+                "standardEntryClassCode": "CCD",
+                "companyEntryDescription": "MV",
+                "effectiveEntryDate": "250128",
+                "originatorStatusCode": 1,
+                "ODFIIdentification": "43219876",
+                "batchNumber": 1
+            },
+            "entryDetails": [
+                {
+                    "id": "179837a5-ea10-46da-8777-53c4eed2258c",
+                    "transactionCode": 22,
+                    "RDFIIdentification": "27397636",
+                    "checkDigit": "9",
+                    "DFIAccountNumber": "0123456789",
+                    "amount": 100,
+                    "individualName": "MOOV",
+                    "discretionaryData": "179837a5-ea10-46da-8777-53c4eed2258c",
+                    "traceNumber": "291471021010100",
+                    "category": "Forward"
+                },
+                {
+                    "id": "179837a5-ea10-46da-8777-53c4eed2258c",
+                    "transactionCode": 27,
+                    "RDFIIdentification": "43219876",
+                    "checkDigit": "8",
+                    "DFIAccountNumber": "3323523523",
+                    "amount": 100,
+                    "individualName": "MOOV",
+                    "discretionaryData": "OFFSET",
+                    "traceNumber": "291471023010100",
+                    "category": "Forward"
+                }
+            ],
+            "batchControl": {
+                "id": "",
+                "serviceClassCode": 200,
+                "entryAddendaCount": 2,
+                "entryHash": 54794647,
+                "totalDebit": 100,
+                "totalCredit": 100,
+                "companyIdentification": "987654",
+                "ODFIIdentification": "43219876",
+                "batchNumber": 1
+            },
+            "offset": null
+        }
+    ],
+    "fileControl": {
+        "id": "179837a5-ea10-46da-8777-53c4eed2258c",
+        "batchCount": 1,
+        "blockCount": 1,
+        "entryAddendaCount": 2,
+        "entryHash": 54794647,
+        "totalDebit": 100,
+        "totalCredit": 100
+    },
+    "NotificationOfChange": null,
+    "ReturnEntries": null,
+    "validateOpts": {
+        "skipAll": false,
+        "requireABAOrigin": false,
+        "bypassOriginValidation": true,
+        "bypassDestinationValidation": true,
+        "customTraceNumbers": true,
+        "allowZeroBatches": false,
+        "allowMissingFileHeader": false,
+        "allowMissingFileControl": false,
+        "bypassCompanyIdentificationMatch": false,
+        "customReturnCodes": false,
+        "unequalServiceClassCode": false,
+        "allowUnorderedBatchNumbers": false,
+        "allowInvalidCheckDigit": false,
+        "unequalAddendaCounts": false,
+        "preserveSpaces": false,
+        "allowInvalidAmounts": false,
+        "allowZeroEntryAmount": false
+    }
+}


### PR DESCRIPTION
Fields like TraceNumber can be retabulated / overwritten when ValidateOpts are configured to not allow this, but we aren't reading the ValidateOpts until after the value has been changed.

Fixes: https://github.com/moov-io/ach/issues/1539 