### PR TITLE
Added Validation Flag Individual Name

### DIFF
--- a/entryDetail.go
+++ b/entryDetail.go
@@ -338,8 +338,10 @@ func (ed *EntryDetail) Validate() error {
 	if err := ed.isAlphanumeric(ed.IdentificationNumber); err != nil {
 		return fieldError("IdentificationNumber", err, ed.IdentificationNumber)
 	}
-	if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
-		return fieldError("IndividualName", err, ed.IndividualName)
+	if !ed.validateOpts.AllowNonAlphanumericIndividualName {
+		if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
+			return fieldError("IndividualName", err, ed.IndividualName)
+		}
 	}
 	if err := ed.isAlphanumeric(ed.DiscretionaryData); err != nil {
 		return fieldError("DiscretionaryData", err, ed.DiscretionaryData)

--- a/file.go
+++ b/file.go
@@ -750,6 +750,9 @@ type ValidateOpts struct {
 
 	// AllowZeroEntryAmount will skip enforcing the entry Amount to be non-zero
 	AllowZeroEntryAmount bool `json:"allowZeroEntryAmount"`
+
+	// AllowNonAlphanumericIndividualName will skip enforcing Individual Name in entry details to be Alphanumeric by Nacha standard
+	AllowNonAlphanumericIndividualName bool `json:"allowAllowNonAlphanumericIndividualName"`
 }
 
 // merge will combine two ValidateOpts structs and keep any non-zero field values.


### PR DESCRIPTION
Sometimes ODFI sends us entries with Individual Names that contain special characters outside of the alphanumeric range defined by Nacha. The new validation opt `AllowSpecialCharactersInIndividualName` will allow us to skip that check, and it's default to false for backward compatibility.

More discussion in https://github.com/moov-io/ach/issues/1564