### PR TITLE
New Validation Flag for Individual Name

### DIFF
--- a/entryDetail.go
+++ b/entryDetail.go
@@ -338,8 +338,10 @@ func (ed *EntryDetail) Validate() error {
 	if err := ed.isAlphanumeric(ed.IdentificationNumber); err != nil {
 		return fieldError("IdentificationNumber", err, ed.IdentificationNumber)
 	}
-	if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
-		return fieldError("IndividualName", err, ed.IndividualName)
+	if !ed.validateOpts.AllowNonAlphanumericIndividualName {
+		if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
+			return fieldError("IndividualName", err, ed.IndividualName)
+		}
 	}
 	if err := ed.isAlphanumeric(ed.DiscretionaryData); err != nil {
 		return fieldError("DiscretionaryData", err, ed.DiscretionaryData)

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -338,7 +338,7 @@ func (ed *EntryDetail) Validate() error {
 	if err := ed.isAlphanumeric(ed.IdentificationNumber); err != nil {
 		return fieldError("IdentificationNumber", err, ed.IdentificationNumber)
 	}
-	if !ed.validateOpts.AllowNonAlphanumericIndividualName {
+	if ed.validateOpts == nil || !ed.validateOpts.AllowSpecialCharactersInIndividualName {
 		if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
 			return fieldError("IndividualName", err, ed.IndividualName)
 		}

--- a/entryDetail_test.go
+++ b/entryDetail_test.go
@@ -305,9 +305,21 @@ func testEDIndividualNameAlphaNumeric(t testing.TB) {
 	}
 }
 
+// testEDIndividualNameAllowSpecialCharacters validates individual name can contain special characters
+func testEDIndividualNameAllowSpecialCharacters(t testing.TB) {
+	ed := mockEntryDetail()
+	ed.IndividualName = "Ĵóĥñ Đøë"
+	ed.SetValidation(&ValidateOpts{
+		AllowSpecialCharactersInIndividualName: true,
+	})
+	err := ed.Validate()
+	require.NoError(t, err)
+}
+
 // TestEDIndividualNameAlphaNumeric tests validating individual name is alpha numeric
 func TestEDIndividualNameAlphaNumeric(t *testing.T) {
 	testEDIndividualNameAlphaNumeric(t)
+	testEDIndividualNameAllowSpecialCharacters(t)
 }
 
 // BenchmarkEDIndividualNameAlphaNumeric benchmarks validating individual name is alpha numeric

--- a/file.go
+++ b/file.go
@@ -751,8 +751,8 @@ type ValidateOpts struct {
 	// AllowZeroEntryAmount will skip enforcing the entry Amount to be non-zero
 	AllowZeroEntryAmount bool `json:"allowZeroEntryAmount"`
 
-	// AllowNonAlphanumericIndividualName will skip enforcing Individual Name in entry details to be Alphanumeric by Nacha standard
-	AllowNonAlphanumericIndividualName bool `json:"allowAllowNonAlphanumericIndividualName"`
+	// AllowSpecialCharactersInIndividualName will skip enforcing Individual Name in entry details to be Alphanumeric
+	AllowSpecialCharactersInIndividualName bool `json:"allowSpecialCharactersInIndividualName"`
 }
 
 // merge will combine two ValidateOpts structs and keep any non-zero field values.

--- a/file.go
+++ b/file.go
@@ -750,6 +750,9 @@ type ValidateOpts struct {
 
 	// AllowZeroEntryAmount will skip enforcing the entry Amount to be non-zero
 	AllowZeroEntryAmount bool `json:"allowZeroEntryAmount"`
+
+	// AllowNonAlphanumericIndividualName will skip enforcing Individual Name in entry details to be Alphanumeric by Nacha standard
+	AllowNonAlphanumericIndividualName bool `json:"allowAllowNonAlphanumericIndividualName"`
 }
 
 // merge will combine two ValidateOpts structs and keep any non-zero field values.

--- a/file_test.go
+++ b/file_test.go
@@ -2241,17 +2241,3 @@ func TestFile_FlattenBatches_PreservesFileIDModifier(t *testing.T) {
 		t.Errorf("FileIDModifier not preserved: want 'B' got %s", flattened.Header.FileIDModifier)
 	}
 }
-
-func TestFile_AllowNonAlphanumericIndividualName(t *testing.T) {
-	/*
-		file := NewFile().SetHeader(mockFileHeader())
-		batch := NewBatchPPD(mockBatchPPDHeader())
-
-		ed := mockEntryDetail()
-		ed.IndividualName = "Ĵóĥñ Đøë"
-		ed.SetTraceNumber(mockBatchHeader().ODFIIdentification, 1)
-		batch.AddEntry(ed)
-		require.NotNil(t, ed.Validate())
-	*/
-
-}

--- a/file_test.go
+++ b/file_test.go
@@ -2241,3 +2241,17 @@ func TestFile_FlattenBatches_PreservesFileIDModifier(t *testing.T) {
 		t.Errorf("FileIDModifier not preserved: want 'B' got %s", flattened.Header.FileIDModifier)
 	}
 }
+
+func TestFile_AllowNonAlphanumericIndividualName(t *testing.T) {
+	/*
+		file := NewFile().SetHeader(mockFileHeader())
+		batch := NewBatchPPD(mockBatchPPDHeader())
+
+		ed := mockEntryDetail()
+		ed.IndividualName = "Ĵóĥñ Đøë"
+		ed.SetTraceNumber(mockBatchHeader().ODFIIdentification, 1)
+		batch.AddEntry(ed)
+		require.NotNil(t, ed.Validate())
+	*/
+
+}


### PR DESCRIPTION
Sometimes ODFI sends us entries with Individual Names that contain special characters outside of the alphanumeric range defined by Nacha. The new validation opt AllowSpecialCharactersInIndividualName will allow us to skip that check, and it's default to false for backward compatibility.

More discussion in https://github.com/moov-io/ach/issues/1564