### PR TITLE
Add AllowSpecialCharacters as a validation option

### DIFF
--- a/addenda02.go
+++ b/addenda02.go
@@ -65,6 +65,8 @@ type Addenda02 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda02 returns a new Addenda02 with default values for none exported fields
@@ -142,6 +144,12 @@ func (addenda02 *Addenda02) Parse(record string) {
 	}
 }
 
+func (a *Addenda02) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda02 struct to a 94 character string.
 func (addenda02 *Addenda02) String() string {
 	if addenda02 == nil {
@@ -180,17 +188,31 @@ func (addenda02 *Addenda02) Validate() error {
 	if addenda02.TypeCode != "02" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda02.TypeCode)
 	}
-	if err := addenda02.isAlphanumeric(addenda02.ReferenceInformationOne); err != nil {
-		return fieldError("ReferenceInformationOne", err, addenda02.ReferenceInformationOne)
-	}
-	if err := addenda02.isAlphanumeric(addenda02.ReferenceInformationTwo); err != nil {
-		return fieldError("ReferenceInformationTwo", err, addenda02.ReferenceInformationTwo)
-	}
-	if err := addenda02.isAlphanumeric(addenda02.TerminalIdentificationCode); err != nil {
-		return fieldError("TerminalIdentificationCode", err, addenda02.TerminalIdentificationCode)
-	}
-	if err := addenda02.isAlphanumeric(addenda02.TransactionSerialNumber); err != nil {
-		return fieldError("TransactionSerialNumber", err, addenda02.TransactionSerialNumber)
+	if addenda02.validateOpts == nil || !addenda02.validateOpts.AllowSpecialCharacters {
+		if err := addenda02.isAlphanumeric(addenda02.ReferenceInformationOne); err != nil {
+			return fieldError("ReferenceInformationOne", err, addenda02.ReferenceInformationOne)
+		}
+		if err := addenda02.isAlphanumeric(addenda02.ReferenceInformationTwo); err != nil {
+			return fieldError("ReferenceInformationTwo", err, addenda02.ReferenceInformationTwo)
+		}
+		if err := addenda02.isAlphanumeric(addenda02.TerminalIdentificationCode); err != nil {
+			return fieldError("TerminalIdentificationCode", err, addenda02.TerminalIdentificationCode)
+		}
+		if err := addenda02.isAlphanumeric(addenda02.TransactionSerialNumber); err != nil {
+			return fieldError("TransactionSerialNumber", err, addenda02.TransactionSerialNumber)
+		}
+		if err := addenda02.isAlphanumeric(addenda02.AuthorizationCodeOrExpireDate); err != nil {
+			return fieldError("AuthorizationCodeOrExpireDate", err, addenda02.AuthorizationCodeOrExpireDate)
+		}
+		if err := addenda02.isAlphanumeric(addenda02.TerminalLocation); err != nil {
+			return fieldError("TerminalLocation", err, addenda02.TerminalLocation)
+		}
+		if err := addenda02.isAlphanumeric(addenda02.TerminalCity); err != nil {
+			return fieldError("TerminalCity", err, addenda02.TerminalCity)
+		}
+		if err := addenda02.isAlphanumeric(addenda02.TerminalState); err != nil {
+			return fieldError("TerminalState", err, addenda02.TerminalState)
+		}
 	}
 
 	// TransactionDate Addenda02 ACH File format is MMDD. Validate MM is 01-12 and day for the
@@ -204,18 +226,6 @@ func (addenda02 *Addenda02) Validate() error {
 		return fieldError("TransactionDate", ErrValidDay, mm)
 	}
 
-	if err := addenda02.isAlphanumeric(addenda02.AuthorizationCodeOrExpireDate); err != nil {
-		return fieldError("AuthorizationCodeOrExpireDate", err, addenda02.AuthorizationCodeOrExpireDate)
-	}
-	if err := addenda02.isAlphanumeric(addenda02.TerminalLocation); err != nil {
-		return fieldError("TerminalLocation", err, addenda02.TerminalLocation)
-	}
-	if err := addenda02.isAlphanumeric(addenda02.TerminalCity); err != nil {
-		return fieldError("TerminalCity", err, addenda02.TerminalCity)
-	}
-	if err := addenda02.isAlphanumeric(addenda02.TerminalState); err != nil {
-		return fieldError("TerminalState", err, addenda02.TerminalState)
-	}
 	return nil
 }
 

--- a/addenda02_test.go
+++ b/addenda02_test.go
@@ -57,6 +57,21 @@ func testAddenda02ValidTypeCode(t testing.TB) {
 	}
 }
 
+func TestAddenda02SpecialCharacter(t *testing.T) {
+	record := mockAddenda02()
+	record.TerminalCity = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}
+
 // TestAddenda02ValidTypeCode tests validating Addenda02 TypeCode
 func TestAddenda02ValidTypeCode(t *testing.T) {
 	testAddenda02ValidTypeCode(t)

--- a/addenda05.go
+++ b/addenda05.go
@@ -47,6 +47,8 @@ type Addenda05 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda05 returns a new Addenda05 with default values for none exported fields
@@ -104,6 +106,12 @@ func (addenda05 *Addenda05) Parse(record string) {
 	}
 }
 
+func (a *Addenda05) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda05 struct to a 94 character string.
 func (addenda05 *Addenda05) String() string {
 	if addenda05 == nil {
@@ -136,8 +144,11 @@ func (addenda05 *Addenda05) Validate() error {
 	if addenda05.TypeCode != "05" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda05.TypeCode)
 	}
-	if err := addenda05.isAlphanumeric(addenda05.PaymentRelatedInformation); err != nil {
-		return fieldError("PaymentRelatedInformation", err, addenda05.PaymentRelatedInformation)
+
+	if addenda05.validateOpts == nil || !addenda05.validateOpts.AllowSpecialCharacters {
+		if err := addenda05.isAlphanumeric(addenda05.PaymentRelatedInformation); err != nil {
+			return fieldError("PaymentRelatedInformation", err, addenda05.PaymentRelatedInformation)
+		}
 	}
 
 	return nil

--- a/addenda05_test.go
+++ b/addenda05_test.go
@@ -124,6 +124,21 @@ func TestAddenda05FieldInclusion(t *testing.T) {
 	}
 }
 
+func TestAddenda05SpecialCharacter(t *testing.T) {
+	record := mockAddenda05()
+	record.PaymentRelatedInformation = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}
+
 func TestAddenda05FieldInclusionSequenceNumber(t *testing.T) {
 	addenda05 := mockAddenda05()
 	addenda05.SequenceNumber = 0

--- a/addenda10.go
+++ b/addenda10.go
@@ -58,6 +58,8 @@ type Addenda10 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda10 returns a new Addenda10 with default values for none exported fields
@@ -123,6 +125,12 @@ func (addenda10 *Addenda10) Parse(record string) {
 	}
 }
 
+func (a *Addenda10) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda10 struct to a 94 character string.
 func (addenda10 *Addenda10) String() string {
 	if addenda10 == nil {
@@ -165,12 +173,14 @@ func (addenda10 *Addenda10) Validate() error {
 	if err := addenda10.isTransactionTypeCode(addenda10.TransactionTypeCode); err != nil {
 		return fieldError("TransactionTypeCode", err, addenda10.TransactionTypeCode)
 	}
-	// ToDo: Foreign Payment Amount blank ?
-	if err := addenda10.isAlphanumeric(addenda10.ForeignTraceNumber); err != nil {
-		return fieldError("ForeignTraceNumber", err, addenda10.ForeignTraceNumber)
-	}
-	if err := addenda10.isAlphanumeric(addenda10.Name); err != nil {
-		return fieldError("Name", err, addenda10.Name)
+	if addenda10.validateOpts == nil || !addenda10.validateOpts.AllowSpecialCharacters {
+		// ToDo: Foreign Payment Amount blank ?
+		if err := addenda10.isAlphanumeric(addenda10.ForeignTraceNumber); err != nil {
+			return fieldError("ForeignTraceNumber", err, addenda10.ForeignTraceNumber)
+		}
+		if err := addenda10.isAlphanumeric(addenda10.Name); err != nil {
+			return fieldError("Name", err, addenda10.Name)
+		}
 	}
 	return nil
 }

--- a/addenda10_test.go
+++ b/addenda10_test.go
@@ -127,6 +127,21 @@ func BenchmarkAddenda10TypeCode10(b *testing.B) {
 	}
 }
 
+func TestAddenda10SpecialCharacter(t *testing.T) {
+	record := mockAddenda10()
+	record.Name = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}
+
 // testAddenda10TransactionTypeCode validates TransactionTypeCode
 func testAddenda10TransactionTypeCode(t testing.TB) {
 	addenda10 := mockAddenda10()

--- a/addenda11.go
+++ b/addenda11.go
@@ -49,6 +49,8 @@ type Addenda11 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda11 returns a new Addenda11 with default values for none exported fields
@@ -108,6 +110,12 @@ func (addenda11 *Addenda11) Parse(record string) {
 	}
 }
 
+func (a *Addenda11) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda11 struct to a 94 character string.
 func (addenda11 *Addenda11) String() string {
 	if addenda11 == nil {
@@ -144,11 +152,13 @@ func (addenda11 *Addenda11) Validate() error {
 	if addenda11.TypeCode != "11" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda11.TypeCode)
 	}
-	if err := addenda11.isAlphanumeric(addenda11.OriginatorName); err != nil {
-		return fieldError("OriginatorName", err, addenda11.OriginatorName)
-	}
-	if err := addenda11.isAlphanumeric(addenda11.OriginatorStreetAddress); err != nil {
-		return fieldError("OriginatorStreetAddress", err, addenda11.OriginatorStreetAddress)
+	if addenda11.validateOpts == nil || !addenda11.validateOpts.AllowSpecialCharacters {
+		if err := addenda11.isAlphanumeric(addenda11.OriginatorName); err != nil {
+			return fieldError("OriginatorName", err, addenda11.OriginatorName)
+		}
+		if err := addenda11.isAlphanumeric(addenda11.OriginatorStreetAddress); err != nil {
+			return fieldError("OriginatorStreetAddress", err, addenda11.OriginatorStreetAddress)
+		}
 	}
 	return nil
 }

--- a/addenda11_test.go
+++ b/addenda11_test.go
@@ -134,6 +134,21 @@ func TestOriginatorNameAlphaNumeric(t *testing.T) {
 	testOriginatorNameAlphaNumeric(t)
 }
 
+func TestAddenda11SpecialCharacter(t *testing.T) {
+	record := mockAddenda11()
+	record.OriginatorName = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}
+
 // BenchmarkOriginatorNameAlphaNumeric benchmarks validating OriginatorName is alphanumeric
 func BenchmarkOriginatorNameAlphaNumeric(b *testing.B) {
 	b.ReportAllocs()

--- a/addenda12.go
+++ b/addenda12.go
@@ -54,6 +54,8 @@ type Addenda12 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda12 returns a new Addenda12 with default values for none exported fields
@@ -113,6 +115,12 @@ func (addenda12 *Addenda12) Parse(record string) {
 	}
 }
 
+func (a *Addenda12) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda12 struct to a 94 character string.
 func (addenda12 *Addenda12) String() string {
 	if addenda12 == nil {
@@ -150,11 +158,13 @@ func (addenda12 *Addenda12) Validate() error {
 	if addenda12.TypeCode != "12" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda12.TypeCode)
 	}
-	if err := addenda12.isAlphanumeric(addenda12.OriginatorCityStateProvince); err != nil {
-		return fieldError("OriginatorCityStateProvince", err, addenda12.OriginatorCityStateProvince)
-	}
-	if err := addenda12.isAlphanumeric(addenda12.OriginatorCountryPostalCode); err != nil {
-		return fieldError("OriginatorCountryPostalCode", err, addenda12.OriginatorCountryPostalCode)
+	if addenda12.validateOpts == nil || !addenda12.validateOpts.AllowSpecialCharacters {
+		if err := addenda12.isAlphanumeric(addenda12.OriginatorCityStateProvince); err != nil {
+			return fieldError("OriginatorCityStateProvince", err, addenda12.OriginatorCityStateProvince)
+		}
+		if err := addenda12.isAlphanumeric(addenda12.OriginatorCountryPostalCode); err != nil {
+			return fieldError("OriginatorCountryPostalCode", err, addenda12.OriginatorCountryPostalCode)
+		}
 	}
 	return nil
 }

--- a/addenda12_test.go
+++ b/addenda12_test.go
@@ -129,6 +129,21 @@ func testOriginatorCityStateProvinceAlphaNumeric(t testing.TB) {
 	}
 }
 
+func TestAddenda12SpecialCharacter(t *testing.T) {
+	record := mockAddenda12()
+	record.OriginatorCityStateProvince = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}
+
 // TestOriginatorCityStateProvinceAlphaNumeric tests validating OriginatorCityStateProvince is alphanumeric
 func TestOriginatorCityStateProvinceAlphaNumeric(t *testing.T) {
 	testOriginatorCityStateProvinceAlphaNumeric(t)

--- a/addenda13.go
+++ b/addenda13.go
@@ -70,6 +70,8 @@ type Addenda13 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda13 returns a new Addenda13 with default values for none exported fields
@@ -135,6 +137,12 @@ func (addenda13 *Addenda13) Parse(record string) {
 	}
 }
 
+func (a *Addenda13) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda13 struct to a 94 character string.
 func (addenda13 *Addenda13) String() string {
 	if addenda13 == nil {
@@ -173,18 +181,20 @@ func (addenda13 *Addenda13) Validate() error {
 	if addenda13.TypeCode != "13" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda13.TypeCode)
 	}
-	if err := addenda13.isAlphanumeric(addenda13.ODFIName); err != nil {
-		return fieldError("ODFIName", err, addenda13.ODFIName)
-	}
 	// Valid ODFI Identification Number Qualifier
 	if err := addenda13.isIDNumberQualifier(addenda13.ODFIIDNumberQualifier); err != nil {
 		return fieldError("ODFIIDNumberQualifier", err, addenda13.ODFIIDNumberQualifier)
 	}
-	if err := addenda13.isAlphanumeric(addenda13.ODFIIdentification); err != nil {
-		return fieldError("ODFIIdentification", err, addenda13.ODFIIdentification)
-	}
-	if err := addenda13.isAlphanumeric(addenda13.ODFIBranchCountryCode); err != nil {
-		return fieldError("ODFIBranchCountryCode", err, addenda13.ODFIBranchCountryCode)
+	if addenda13.validateOpts == nil || !addenda13.validateOpts.AllowSpecialCharacters {
+		if err := addenda13.isAlphanumeric(addenda13.ODFIName); err != nil {
+			return fieldError("ODFIName", err, addenda13.ODFIName)
+		}
+		if err := addenda13.isAlphanumeric(addenda13.ODFIIdentification); err != nil {
+			return fieldError("ODFIIdentification", err, addenda13.ODFIIdentification)
+		}
+		if err := addenda13.isAlphanumeric(addenda13.ODFIBranchCountryCode); err != nil {
+			return fieldError("ODFIBranchCountryCode", err, addenda13.ODFIBranchCountryCode)
+		}
 	}
 	return nil
 }

--- a/addenda13_test.go
+++ b/addenda13_test.go
@@ -165,6 +165,21 @@ func TestODFIIDNumberQualifierValid(t *testing.T) {
 	testODFIIDNumberQualifierValid(t)
 }
 
+func TestAddenda13SpecialCharacter(t *testing.T) {
+	record := mockAddenda13()
+	record.ODFIName = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}
+
 // BenchmarkODFIIDNumberQualifierValid benchmarks validating ODFIIDNumberQualifier is valid
 func BenchmarkODFIIDNumberQualifierValid(b *testing.B) {
 	b.ReportAllocs()

--- a/addenda14.go
+++ b/addenda14.go
@@ -65,6 +65,8 @@ type Addenda14 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda14 returns a new Addenda14 with default values for none exported fields
@@ -130,6 +132,12 @@ func (addenda14 *Addenda14) Parse(record string) {
 	}
 }
 
+func (a *Addenda14) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda14 struct to a 94 character string.
 func (addenda14 *Addenda14) String() string {
 	if addenda14 == nil {
@@ -168,18 +176,20 @@ func (addenda14 *Addenda14) Validate() error {
 	if addenda14.TypeCode != "14" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda14.TypeCode)
 	}
-	if err := addenda14.isAlphanumeric(addenda14.RDFIName); err != nil {
-		return fieldError("RDFIName", err, addenda14.RDFIName)
-	}
 	// Valid RDFI Identification Number Qualifier
 	if err := addenda14.isIDNumberQualifier(addenda14.RDFIIDNumberQualifier); err != nil {
 		return fieldError("RDFIIDNumberQualifier", ErrIDNumberQualifier, addenda14.RDFIIDNumberQualifier)
 	}
-	if err := addenda14.isAlphanumeric(addenda14.RDFIIdentification); err != nil {
-		return fieldError("RDFIIdentification", err, addenda14.RDFIIdentification)
-	}
-	if err := addenda14.isAlphanumeric(addenda14.RDFIBranchCountryCode); err != nil {
-		return fieldError("RDFIBranchCountryCode", err, addenda14.RDFIBranchCountryCode)
+	if addenda14.validateOpts == nil || !addenda14.validateOpts.AllowSpecialCharacters {
+		if err := addenda14.isAlphanumeric(addenda14.RDFIName); err != nil {
+			return fieldError("RDFIName", err, addenda14.RDFIName)
+		}
+		if err := addenda14.isAlphanumeric(addenda14.RDFIIdentification); err != nil {
+			return fieldError("RDFIIdentification", err, addenda14.RDFIIdentification)
+		}
+		if err := addenda14.isAlphanumeric(addenda14.RDFIBranchCountryCode); err != nil {
+			return fieldError("RDFIBranchCountryCode", err, addenda14.RDFIBranchCountryCode)
+		}
 	}
 	return nil
 }

--- a/addenda14_test.go
+++ b/addenda14_test.go
@@ -397,3 +397,18 @@ func TestAddenda14RuneCountInString(t *testing.T) {
 		t.Error("Parsed with an invalid RuneCountInString not equal to 94")
 	}
 }
+
+func TestAddenda14SpecialCharacter(t *testing.T) {
+	record := mockAddenda14()
+	record.RDFIName = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/addenda15.go
+++ b/addenda15.go
@@ -50,6 +50,8 @@ type Addenda15 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda15 returns a new Addenda15 with default values for none exported fields
@@ -109,6 +111,12 @@ func (addenda15 *Addenda15) Parse(record string) {
 	}
 }
 
+func (a *Addenda15) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda15 struct to a 94 character string.
 func (addenda15 *Addenda15) String() string {
 	if addenda15 == nil {
@@ -145,11 +153,13 @@ func (addenda15 *Addenda15) Validate() error {
 	if addenda15.TypeCode != "15" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda15.TypeCode)
 	}
-	if err := addenda15.isAlphanumeric(addenda15.ReceiverIDNumber); err != nil {
-		return fieldError("ReceiverIDNumber", err, addenda15.ReceiverIDNumber)
-	}
-	if err := addenda15.isAlphanumeric(addenda15.ReceiverStreetAddress); err != nil {
-		return fieldError("ReceiverStreetAddress", err, addenda15.ReceiverStreetAddress)
+	if addenda15.validateOpts == nil || !addenda15.validateOpts.AllowSpecialCharacters {
+		if err := addenda15.isAlphanumeric(addenda15.ReceiverIDNumber); err != nil {
+			return fieldError("ReceiverIDNumber", err, addenda15.ReceiverIDNumber)
+		}
+		if err := addenda15.isAlphanumeric(addenda15.ReceiverStreetAddress); err != nil {
+			return fieldError("ReceiverStreetAddress", err, addenda15.ReceiverStreetAddress)
+		}
 	}
 	return nil
 }

--- a/addenda15_test.go
+++ b/addenda15_test.go
@@ -273,3 +273,18 @@ func TestAddenda15RuneCountInString(t *testing.T) {
 		t.Error("Parsed with an invalid RuneCountInString not equal to 94")
 	}
 }
+
+func TestAddenda15SpecialCharacter(t *testing.T) {
+	record := mockAddenda15()
+	record.ReceiverStreetAddress = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/addenda16.go
+++ b/addenda16.go
@@ -53,6 +53,8 @@ type Addenda16 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda16 returns a new Addenda16 with default values for none exported fields
@@ -112,6 +114,12 @@ func (addenda16 *Addenda16) Parse(record string) {
 	}
 }
 
+func (a *Addenda16) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda16 struct to a 94 character string.
 func (addenda16 *Addenda16) String() string {
 	if addenda16 == nil {
@@ -148,11 +156,13 @@ func (addenda16 *Addenda16) Validate() error {
 	if addenda16.TypeCode != "16" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda16.TypeCode)
 	}
-	if err := addenda16.isAlphanumeric(addenda16.ReceiverCityStateProvince); err != nil {
-		return fieldError("ReceiverCityStateProvince", err, addenda16.ReceiverCityStateProvince)
-	}
-	if err := addenda16.isAlphanumeric(addenda16.ReceiverCountryPostalCode); err != nil {
-		return fieldError("ReceiverCountryPostalCode", err, addenda16.ReceiverCountryPostalCode)
+	if addenda16.validateOpts == nil || !addenda16.validateOpts.AllowSpecialCharacters {
+		if err := addenda16.isAlphanumeric(addenda16.ReceiverCityStateProvince); err != nil {
+			return fieldError("ReceiverCityStateProvince", err, addenda16.ReceiverCityStateProvince)
+		}
+		if err := addenda16.isAlphanumeric(addenda16.ReceiverCountryPostalCode); err != nil {
+			return fieldError("ReceiverCountryPostalCode", err, addenda16.ReceiverCountryPostalCode)
+		}
 	}
 	return nil
 }

--- a/addenda16_test.go
+++ b/addenda16_test.go
@@ -302,3 +302,18 @@ func TestAddenda16RuneCountInString(t *testing.T) {
 		t.Error("Parsed with an invalid RuneCountInString not equal to 94")
 	}
 }
+
+func TestAddenda16SpecialCharacter(t *testing.T) {
+	record := mockAddenda16()
+	record.ReceiverCityStateProvince = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/addenda17.go
+++ b/addenda17.go
@@ -51,6 +51,8 @@ type Addenda17 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda17 returns a new Addenda17 with default values for none exported fields
@@ -107,6 +109,12 @@ func (addenda17 *Addenda17) Parse(record string) {
 	}
 }
 
+func (a *Addenda17) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda17 struct to a 94 character string.
 func (addenda17 *Addenda17) String() string {
 	if addenda17 == nil {
@@ -138,8 +146,10 @@ func (addenda17 *Addenda17) Validate() error {
 	if addenda17.TypeCode != "17" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda17.TypeCode)
 	}
-	if err := addenda17.isAlphanumeric(addenda17.PaymentRelatedInformation); err != nil {
-		return fieldError("PaymentRelatedInformation", err, addenda17.PaymentRelatedInformation)
+	if addenda17.validateOpts == nil || !addenda17.validateOpts.AllowSpecialCharacters {
+		if err := addenda17.isAlphanumeric(addenda17.PaymentRelatedInformation); err != nil {
+			return fieldError("PaymentRelatedInformation", err, addenda17.PaymentRelatedInformation)
+		}
 	}
 
 	return nil

--- a/addenda17_test.go
+++ b/addenda17_test.go
@@ -216,3 +216,18 @@ func TestAddenda17RuneCountInString(t *testing.T) {
 		t.Error("Parsed with an invalid RuneCountInString not equal to 94")
 	}
 }
+
+func TestAddenda17SpecialCharacter(t *testing.T) {
+	record := mockAddenda17()
+	record.PaymentRelatedInformation = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/addenda18.go
+++ b/addenda18.go
@@ -67,6 +67,8 @@ type Addenda18 struct {
 	validator
 	// converters is composed for ACH to GoLang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // NewAddenda18 returns a new Addenda18 with default values for none exported fields
@@ -138,6 +140,12 @@ func (addenda18 *Addenda18) Parse(record string) {
 	}
 }
 
+func (a *Addenda18) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the Addenda18 struct to a 94 character string.
 func (addenda18 *Addenda18) String() string {
 	if addenda18 == nil {
@@ -173,17 +181,19 @@ func (addenda18 *Addenda18) Validate() error {
 	if addenda18.TypeCode != "18" {
 		return fieldError("TypeCode", ErrAddendaTypeCode, addenda18.TypeCode)
 	}
-	if err := addenda18.isAlphanumeric(addenda18.ForeignCorrespondentBankName); err != nil {
-		return fieldError("ForeignCorrespondentBankName", err, addenda18.ForeignCorrespondentBankName)
-	}
-	if err := addenda18.isAlphanumeric(addenda18.ForeignCorrespondentBankIDNumberQualifier); err != nil {
-		return fieldError("ForeignCorrespondentBankIDNumberQualifier", err, addenda18.ForeignCorrespondentBankIDNumberQualifier)
-	}
-	if err := addenda18.isAlphanumeric(addenda18.ForeignCorrespondentBankIDNumber); err != nil {
-		return fieldError("ForeignCorrespondentBankIDNumber", err, addenda18.ForeignCorrespondentBankIDNumber)
-	}
-	if err := addenda18.isAlphanumeric(addenda18.ForeignCorrespondentBankBranchCountryCode); err != nil {
-		return fieldError("ForeignCorrespondentBankBranchCountryCode", err, addenda18.ForeignCorrespondentBankBranchCountryCode)
+	if addenda18.validateOpts == nil || !addenda18.validateOpts.AllowSpecialCharacters {
+		if err := addenda18.isAlphanumeric(addenda18.ForeignCorrespondentBankName); err != nil {
+			return fieldError("ForeignCorrespondentBankName", err, addenda18.ForeignCorrespondentBankName)
+		}
+		if err := addenda18.isAlphanumeric(addenda18.ForeignCorrespondentBankIDNumberQualifier); err != nil {
+			return fieldError("ForeignCorrespondentBankIDNumberQualifier", err, addenda18.ForeignCorrespondentBankIDNumberQualifier)
+		}
+		if err := addenda18.isAlphanumeric(addenda18.ForeignCorrespondentBankIDNumber); err != nil {
+			return fieldError("ForeignCorrespondentBankIDNumber", err, addenda18.ForeignCorrespondentBankIDNumber)
+		}
+		if err := addenda18.isAlphanumeric(addenda18.ForeignCorrespondentBankBranchCountryCode); err != nil {
+			return fieldError("ForeignCorrespondentBankBranchCountryCode", err, addenda18.ForeignCorrespondentBankBranchCountryCode)
+		}
 	}
 	return nil
 }

--- a/addenda18_test.go
+++ b/addenda18_test.go
@@ -388,3 +388,18 @@ func TestAddenda18RuneCountInString(t *testing.T) {
 		t.Error("Parsed with an invalid RuneCountInString not equal to 94")
 	}
 }
+
+func TestAddenda18SpecialCharacter(t *testing.T) {
+	record := mockAddenda18()
+	record.ForeignCorrespondentBankName = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/advBatchControl.go
+++ b/advBatchControl.go
@@ -59,6 +59,8 @@ type ADVBatchControl struct {
 	validator
 	// converters is composed for ACH to golang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 // Parse takes the input record string and parses the EntryDetail values
@@ -119,6 +121,12 @@ func (bc *ADVBatchControl) Parse(record string) {
 	}
 }
 
+func (a *ADVBatchControl) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // NewADVBatchControl returns a new ADVBatchControl with default values for none exported fields
 func NewADVBatchControl() *ADVBatchControl {
 	return &ADVBatchControl{
@@ -156,8 +164,10 @@ func (bc *ADVBatchControl) Validate() error {
 		return fieldError("ServiceClassCode", err, strconv.Itoa(bc.ServiceClassCode))
 	}
 
-	if err := bc.isAlphanumeric(bc.ACHOperatorData); err != nil {
-		return fieldError("ACHOperatorData", err, bc.ACHOperatorData)
+	if bc.validateOpts == nil || !bc.validateOpts.AllowSpecialCharacters {
+		if err := bc.isAlphanumeric(bc.ACHOperatorData); err != nil {
+			return fieldError("ACHOperatorData", err, bc.ACHOperatorData)
+		}
 	}
 	return nil
 }

--- a/advBatchControl_test.go
+++ b/advBatchControl_test.go
@@ -291,3 +291,18 @@ func BenchmarkADVBatchControlLength(b *testing.B) {
 		testADVBatchControlLength(b)
 	}
 }
+
+func TestADVBatchControlSpecialCharacter(t *testing.T) {
+	record := mockADVBatchControl()
+	record.ACHOperatorData = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/advEntryDetail.go
+++ b/advEntryDetail.go
@@ -84,6 +84,8 @@ type ADVEntryDetail struct {
 	validator
 	// converters is composed for ACH to golang Converters
 	converters
+	// validateOpts defines optional overrides for record validation
+	validateOpts *ValidateOpts
 }
 
 const (
@@ -159,6 +161,12 @@ func (ed *ADVEntryDetail) Parse(record string) {
 	ed.SequenceNumber = ed.parseNumField(string(runes[90:94]))
 }
 
+func (a *ADVEntryDetail) SetValidation(opts *ValidateOpts) {
+	if a != nil {
+		a.validateOpts = opts
+	}
+}
+
 // String writes the ADVEntryDetail struct to a 94 character string.
 func (ed *ADVEntryDetail) String() string {
 	buf := getBuffer()
@@ -192,20 +200,22 @@ func (ed *ADVEntryDetail) Validate() error {
 	if err := ed.isTransactionCode(ed.TransactionCode); err != nil {
 		return fieldError("TransactionCode", err, strconv.Itoa(ed.TransactionCode))
 	}
-	if err := ed.isAlphanumeric(ed.DFIAccountNumber); err != nil {
-		return fieldError("DFIAccountNumber", err, ed.DFIAccountNumber)
-	}
-	if err := ed.isAlphanumeric(ed.AdviceRoutingNumber); err != nil {
-		return fieldError("AdviceRoutingNumber", err, ed.AdviceRoutingNumber)
-	}
-	if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
-		return fieldError("IndividualName", err, ed.IndividualName)
-	}
-	if err := ed.isAlphanumeric(ed.DiscretionaryData); err != nil {
-		return fieldError("DiscretionaryData", err, ed.DiscretionaryData)
-	}
-	if err := ed.isAlphanumeric(ed.ACHOperatorRoutingNumber); err != nil {
-		return fieldError("ACHOperatorRoutingNumber", err, ed.ACHOperatorRoutingNumber)
+	if ed.validateOpts == nil || !ed.validateOpts.AllowSpecialCharacters {
+		if err := ed.isAlphanumeric(ed.DFIAccountNumber); err != nil {
+			return fieldError("DFIAccountNumber", err, ed.DFIAccountNumber)
+		}
+		if err := ed.isAlphanumeric(ed.AdviceRoutingNumber); err != nil {
+			return fieldError("AdviceRoutingNumber", err, ed.AdviceRoutingNumber)
+		}
+		if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
+			return fieldError("IndividualName", err, ed.IndividualName)
+		}
+		if err := ed.isAlphanumeric(ed.DiscretionaryData); err != nil {
+			return fieldError("DiscretionaryData", err, ed.DiscretionaryData)
+		}
+		if err := ed.isAlphanumeric(ed.ACHOperatorRoutingNumber); err != nil {
+			return fieldError("ACHOperatorRoutingNumber", err, ed.ACHOperatorRoutingNumber)
+		}
 	}
 	calculated := CalculateCheckDigit(ed.RDFIIdentificationField())
 

--- a/advEntryDetail_test.go
+++ b/advEntryDetail_test.go
@@ -345,3 +345,18 @@ func TestADVUnmarshal(t *testing.T) {
 		t.Errorf("ed.JulianDay=%d", ed.JulianDay)
 	}
 }
+
+func TestADVEntryDetailSpecialCharacter(t *testing.T) {
+	record := mockADVEntryDetail()
+	record.IndividualName = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/batch.go
+++ b/batch.go
@@ -472,6 +472,7 @@ func (batch *Batch) build() error {
 		}
 		// build a BatchADVControl record
 		bcADV := NewADVBatchControl()
+		bcADV.validateOpts = batch.validateOpts
 		bcADV.ServiceClassCode = batch.Header.ServiceClassCode
 		bcADV.ACHOperatorData = batch.Header.CompanyName
 		bcADV.ODFIIdentification = batch.Header.ODFIIdentification

--- a/batchControl.go
+++ b/batchControl.go
@@ -165,12 +165,14 @@ func (bc *BatchControl) Validate() error {
 		return fieldError("ServiceClassCode", err, strconv.Itoa(bc.ServiceClassCode))
 	}
 
-	if err := bc.isAlphanumeric(bc.CompanyIdentification); err != nil {
-		return fieldError("CompanyIdentification", err, bc.CompanyIdentification)
-	}
+	if bc.validateOpts == nil || !bc.validateOpts.AllowSpecialCharacters {
+		if err := bc.isAlphanumeric(bc.CompanyIdentification); err != nil {
+			return fieldError("CompanyIdentification", err, bc.CompanyIdentification)
+		}
 
-	if err := bc.isAlphanumeric(bc.MessageAuthenticationCode); err != nil {
-		return fieldError("MessageAuthenticationCode", err, bc.MessageAuthenticationCode)
+		if err := bc.isAlphanumeric(bc.MessageAuthenticationCode); err != nil {
+			return fieldError("MessageAuthenticationCode", err, bc.MessageAuthenticationCode)
+		}
 	}
 
 	if err := bc.totalDebitsOverflowsField(); err != nil {

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -312,17 +312,19 @@ func (bh *BatchHeader) Validate() error {
 		return fieldError("OriginatorStatusCode", ErrOrigStatusCode, bh.OriginatorStatusCode)
 	}
 
-	if err := bh.isAlphanumeric(bh.CompanyName); err != nil {
-		return fieldError("CompanyName", err, bh.CompanyName)
-	}
-	if err := bh.isAlphanumeric(bh.CompanyDiscretionaryData); err != nil {
-		return fieldError("CompanyDiscretionaryData", err, bh.CompanyDiscretionaryData)
-	}
-	if err := bh.isAlphanumeric(bh.CompanyIdentification); err != nil {
-		return fieldError("CompanyIdentification", err, bh.CompanyIdentification)
-	}
-	if err := bh.isAlphanumeric(bh.CompanyEntryDescription); err != nil {
-		return fieldError("CompanyEntryDescription", err, bh.CompanyEntryDescription)
+	if bh.validateOpts == nil || !bh.validateOpts.AllowSpecialCharacters {
+		if err := bh.isAlphanumeric(bh.CompanyName); err != nil {
+			return fieldError("CompanyName", err, bh.CompanyName)
+		}
+		if err := bh.isAlphanumeric(bh.CompanyDiscretionaryData); err != nil {
+			return fieldError("CompanyDiscretionaryData", err, bh.CompanyDiscretionaryData)
+		}
+		if err := bh.isAlphanumeric(bh.CompanyIdentification); err != nil {
+			return fieldError("CompanyIdentification", err, bh.CompanyIdentification)
+		}
+		if err := bh.isAlphanumeric(bh.CompanyEntryDescription); err != nil {
+			return fieldError("CompanyEntryDescription", err, bh.CompanyEntryDescription)
+		}
 	}
 	return nil
 }

--- a/batchHeader_test.go
+++ b/batchHeader_test.go
@@ -556,3 +556,18 @@ func TestBatchHeader__IsValidWithPreserveSpacesOpt(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestBatchHeaderSpecialCharacter(t *testing.T) {
+	record := mockBatchHeader()
+	record.CompanyName = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -326,23 +326,25 @@ func (ed *EntryDetail) Validate() error {
 			return fieldError("TransactionCode", err, strconv.Itoa(ed.TransactionCode))
 		}
 	}
-	if err := ed.isAlphanumeric(ed.DFIAccountNumber); err != nil {
-		return fieldError("DFIAccountNumber", err, ed.DFIAccountNumber)
-	}
 	if ed.Amount < 0 {
 		return fieldError("Amount", ErrNegativeAmount, ed.Amount)
 	}
 	if err := ed.amountOverflowsField(); err != nil {
 		return fieldError("Amount", err, ed.Amount)
 	}
-	if err := ed.isAlphanumeric(ed.IdentificationNumber); err != nil {
-		return fieldError("IdentificationNumber", err, ed.IdentificationNumber)
-	}
-	if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
-		return fieldError("IndividualName", err, ed.IndividualName)
-	}
-	if err := ed.isAlphanumeric(ed.DiscretionaryData); err != nil {
-		return fieldError("DiscretionaryData", err, ed.DiscretionaryData)
+	if ed.validateOpts == nil || !ed.validateOpts.AllowSpecialCharacters {
+		if err := ed.isAlphanumeric(ed.DFIAccountNumber); err != nil {
+			return fieldError("DFIAccountNumber", err, ed.DFIAccountNumber)
+		}
+		if err := ed.isAlphanumeric(ed.IdentificationNumber); err != nil {
+			return fieldError("IdentificationNumber", err, ed.IdentificationNumber)
+		}
+		if err := ed.isAlphanumeric(ed.IndividualName); err != nil {
+			return fieldError("IndividualName", err, ed.IndividualName)
+		}
+		if err := ed.isAlphanumeric(ed.DiscretionaryData); err != nil {
+			return fieldError("DiscretionaryData", err, ed.DiscretionaryData)
+		}
 	}
 
 	if ed.validateOpts == nil || !ed.validateOpts.AllowInvalidCheckDigit {

--- a/file.go
+++ b/file.go
@@ -750,6 +750,9 @@ type ValidateOpts struct {
 
 	// AllowZeroEntryAmount will skip enforcing the entry Amount to be non-zero
 	AllowZeroEntryAmount bool `json:"allowZeroEntryAmount"`
+
+	// AllowSpecialCharacters will permit a wider range of characters in alphanumeric fields
+	AllowSpecialCharacters bool `json:"flexibleAlphanumericFields"`
 }
 
 // merge will combine two ValidateOpts structs and keep any non-zero field values.

--- a/fileHeader.go
+++ b/fileHeader.go
@@ -231,9 +231,6 @@ func (fh *FileHeader) ValidateWith(opts *ValidateOpts) error {
 	if fh.formatCode != "1" {
 		return fieldError("formatCode", ErrFormatCode, fh.formatCode)
 	}
-	if err := fh.isAlphanumeric(fh.ImmediateDestinationName); err != nil {
-		return fieldError("ImmediateDestinationName", err, fh.ImmediateDestinationName)
-	}
 	if !opts.BypassOriginValidation {
 		if fh.ImmediateOrigin == zeroRoutingNumber9 || fh.ImmediateOrigin == zeroRoutingNumber10 {
 			return fieldError("ImmediateOrigin", ErrConstructor, fh.ImmediateOrigin)
@@ -252,11 +249,16 @@ func (fh *FileHeader) ValidateWith(opts *ValidateOpts) error {
 			return fieldError("ImmediateDestination", err, fh.ImmediateDestination)
 		}
 	}
-	if err := fh.isAlphanumeric(fh.ImmediateOriginName); err != nil {
-		return fieldError("ImmediateOriginName", err, fh.ImmediateOriginName)
-	}
-	if err := fh.isAlphanumeric(fh.ReferenceCode); err != nil {
-		return fieldError("ReferenceCode", err, fh.ReferenceCode)
+	if fh.validateOpts == nil || !fh.validateOpts.AllowSpecialCharacters {
+		if err := fh.isAlphanumeric(fh.ImmediateDestinationName); err != nil {
+			return fieldError("ImmediateDestinationName", err, fh.ImmediateDestinationName)
+		}
+		if err := fh.isAlphanumeric(fh.ImmediateOriginName); err != nil {
+			return fieldError("ImmediateOriginName", err, fh.ImmediateOriginName)
+		}
+		if err := fh.isAlphanumeric(fh.ReferenceCode); err != nil {
+			return fieldError("ReferenceCode", err, fh.ReferenceCode)
+		}
 	}
 	// todo: handle test cases for before date
 	/*

--- a/fileHeader_test.go
+++ b/fileHeader_test.go
@@ -825,3 +825,18 @@ func TestFileHeader__IsValidWithPreserveSpacesOpt(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestFileHeaderSpecialCharacter(t *testing.T) {
+	record := mockFileHeader()
+	record.ImmediateOriginName = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -111,8 +111,10 @@ func (iatBatch *IATBatch) verify() error {
 		return iatBatch.Error("BatchNumber",
 			NewErrBatchHeaderControlEquality(iatBatch.Header.BatchNumber, iatBatch.Control.BatchNumber))
 	}
-	if err := iatBatch.Control.isAlphanumeric(iatBatch.Control.CompanyIdentification); err != nil {
-		return fieldError("CompanyIdentification", err, iatBatch.Control.CompanyIdentification)
+	if iatBatch.validateOpts == nil || !iatBatch.validateOpts.AllowSpecialCharacters {
+		if err := iatBatch.Control.isAlphanumeric(iatBatch.Control.CompanyIdentification); err != nil {
+			return fieldError("CompanyIdentification", err, iatBatch.Control.CompanyIdentification)
+		}
 	}
 	if _, err := iatBatch.isBatchEntryCount(); err != nil {
 		return err

--- a/iatBatchHeader_test.go
+++ b/iatBatchHeader_test.go
@@ -744,3 +744,18 @@ func BenchmarkIATBHODFIIdentification(b *testing.B) {
 		testIATBHODFIIdentification(b)
 	}
 }
+
+func TestIATBatchHeaderSpecialCharacter(t *testing.T) {
+	record := mockIATBatchHeaderFF()
+	record.CompanyEntryDescription = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/iatEntryDetail.go
+++ b/iatEntryDetail.go
@@ -272,8 +272,10 @@ func (iatEd *IATEntryDetail) Validate() error {
 			return fieldError("TransactionCode", err, strconv.Itoa(iatEd.TransactionCode))
 		}
 	}
-	if err := iatEd.isAlphanumeric(iatEd.DFIAccountNumber); err != nil {
-		return fieldError("DFIAccountNumber", err, iatEd.DFIAccountNumber)
+	if iatEd.validateOpts == nil || !iatEd.validateOpts.AllowSpecialCharacters {
+		if err := iatEd.isAlphanumeric(iatEd.DFIAccountNumber); err != nil {
+			return fieldError("DFIAccountNumber", err, iatEd.DFIAccountNumber)
+		}
 	}
 	// CheckDigit calculations
 	calculated := CalculateCheckDigit(iatEd.RDFIIdentificationField())

--- a/iatEntryDetail_test.go
+++ b/iatEntryDetail_test.go
@@ -433,3 +433,18 @@ func BenchmarkIATEDAddendaRecordIndicator(b *testing.B) {
 		testIATEDAddendaRecordIndicator(b)
 	}
 }
+
+func TestIATEntryDetailSpecialCharacter(t *testing.T) {
+	record := mockIATEntryDetail()
+	record.DFIAccountNumber = "Łomża"
+	err := record.Validate()
+	if err == nil {
+		t.Error("Special character should have caused a validation failure")
+	}
+
+	record.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	err = record.Validate()
+	if err != nil {
+		t.Error("Special character should have been allowed with override set.")
+	}
+}

--- a/reader.go
+++ b/reader.go
@@ -541,6 +541,7 @@ func (r *Reader) parseEntryDetail() error {
 		r.currentBatch.AddEntry(ed)
 	} else {
 		ed := NewADVEntryDetail()
+		ed.validateOpts = r.File.validateOpts
 		ed.Parse(r.line)
 		ed.LineNumber = r.lineNum
 		if err := maybeValidate(ed, r.File.validateOpts); err != nil {
@@ -569,6 +570,7 @@ func (r *Reader) parseAddenda() error {
 			switch r.line[1:3] {
 			case "02":
 				addenda02 := NewAddenda02()
+				addenda02.SetValidation(r.File.validateOpts)
 				addenda02.Parse(r.line)
 				addenda02.LineNumber = r.lineNum
 				if err := maybeValidate(addenda02, r.File.validateOpts); err != nil {
@@ -577,6 +579,7 @@ func (r *Reader) parseAddenda() error {
 				r.currentBatch.GetEntries()[entryIndex].Addenda02 = addenda02
 			case "05":
 				addenda05 := NewAddenda05()
+				addenda05.SetValidation(r.File.validateOpts)
 				addenda05.Parse(r.line)
 				addenda05.LineNumber = r.lineNum
 				if err := maybeValidate(addenda05, r.File.validateOpts); err != nil {
@@ -755,6 +758,7 @@ func (r *Reader) parseIATBatchHeader() error {
 
 	// Ensure we have a valid IAT BatchHeader before building a batch.
 	bh := NewIATBatchHeader()
+	bh.validateOpts = r.File.validateOpts
 	bh.Parse(r.line)
 	bh.LineNumber = r.lineNum
 	if err := maybeValidate(bh, r.File.validateOpts); err != nil {
@@ -837,6 +841,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 	switch r.line[1:3] {
 	case "10":
 		addenda10 := NewAddenda10()
+		addenda10.SetValidation(r.File.validateOpts)
 		addenda10.Parse(r.line)
 		addenda10.LineNumber = r.lineNum
 		if err := maybeValidate(addenda10, r.File.validateOpts); err != nil {
@@ -845,6 +850,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 		r.IATCurrentBatch.Entries[entryIndex].Addenda10 = addenda10
 	case "11":
 		addenda11 := NewAddenda11()
+		addenda11.SetValidation(r.File.validateOpts)
 		addenda11.Parse(r.line)
 		addenda11.LineNumber = r.lineNum
 		if err := maybeValidate(addenda11, r.File.validateOpts); err != nil {
@@ -853,6 +859,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 		r.IATCurrentBatch.Entries[entryIndex].Addenda11 = addenda11
 	case "12":
 		addenda12 := NewAddenda12()
+		addenda12.SetValidation(r.File.validateOpts)
 		addenda12.Parse(r.line)
 		addenda12.LineNumber = r.lineNum
 		if err := maybeValidate(addenda12, r.File.validateOpts); err != nil {
@@ -861,6 +868,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 		r.IATCurrentBatch.Entries[entryIndex].Addenda12 = addenda12
 	case "13":
 		addenda13 := NewAddenda13()
+		addenda13.SetValidation(r.File.validateOpts)
 		addenda13.Parse(r.line)
 		addenda13.LineNumber = r.lineNum
 		if err := maybeValidate(addenda13, r.File.validateOpts); err != nil {
@@ -869,6 +877,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 		r.IATCurrentBatch.Entries[entryIndex].Addenda13 = addenda13
 	case "14":
 		addenda14 := NewAddenda14()
+		addenda14.SetValidation(r.File.validateOpts)
 		addenda14.Parse(r.line)
 		addenda14.LineNumber = r.lineNum
 		if err := maybeValidate(addenda14, r.File.validateOpts); err != nil {
@@ -877,6 +886,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 		r.IATCurrentBatch.Entries[entryIndex].Addenda14 = addenda14
 	case "15":
 		addenda15 := NewAddenda15()
+		addenda15.SetValidation(r.File.validateOpts)
 		addenda15.Parse(r.line)
 		addenda15.LineNumber = r.lineNum
 		if err := maybeValidate(addenda15, r.File.validateOpts); err != nil {
@@ -885,6 +895,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 		r.IATCurrentBatch.Entries[entryIndex].Addenda15 = addenda15
 	case "16":
 		addenda16 := NewAddenda16()
+		addenda16.SetValidation(r.File.validateOpts)
 		addenda16.Parse(r.line)
 		addenda16.LineNumber = r.lineNum
 		if err := maybeValidate(addenda16, r.File.validateOpts); err != nil {
@@ -893,6 +904,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 		r.IATCurrentBatch.Entries[entryIndex].Addenda16 = addenda16
 	case "17":
 		addenda17 := NewAddenda17()
+		addenda17.SetValidation(r.File.validateOpts)
 		addenda17.Parse(r.line)
 		addenda17.LineNumber = r.lineNum
 		if err := maybeValidate(addenda17, r.File.validateOpts); err != nil {
@@ -901,6 +913,7 @@ func (r *Reader) mandatoryOptionalIATAddenda(entryIndex int) error {
 		r.IATCurrentBatch.Entries[entryIndex].AddAddenda17(addenda17)
 	case "18":
 		addenda18 := NewAddenda18()
+		addenda18.SetValidation(r.File.validateOpts)
 		addenda18.Parse(r.line)
 		addenda18.LineNumber = r.lineNum
 		if err := maybeValidate(addenda18, r.File.validateOpts); err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -2060,12 +2060,18 @@ func TestReader__morphing(t *testing.T) {
 func TestReader_explicit_contenttype(t *testing.T) {
 	// weird character appears past the first 1024 bytes of the file, so encoding detection fails
 	path := filepath.Join("test", "testdata", "extended-ascii.ach")
-	file, err := readACHFilepath(path)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer f.Close()
+
+	reader := NewReader(f)
+	reader.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
+	_, err = reader.Read()
+
 	if err == nil {
 		t.Error("expected error because of decoding issue")
-	}
-	if file == nil {
-		t.Fatal("nil File")
 	}
 
 	// providing an explicit content type allows us to parse the file
@@ -2076,7 +2082,7 @@ func TestReader_explicit_contenttype(t *testing.T) {
 	defer fd.Close()
 
 	utf8Reader := NewReaderWithContentType(fd, "plain/text; charset=utf-8")
-	utf8Reader.SetValidation(&ValidateOpts{SkipAll: true})
+	utf8Reader.SetValidation(&ValidateOpts{AllowSpecialCharacters: true})
 
 	utf8File, err := utf8Reader.Read()
 	if err != nil {


### PR DESCRIPTION
Though the NACHA rulebook defines the set of characters that are considered "alphanumeric", in practice we sometimes receive incoming files with obscure special characters that we'd like to be able to accept. These are especially common in IAT entries.

Add a new validation option, `AllowSpecialCharacters`, which disables all `isAlphanumeric` checks. This is a more far-reaching version of the validation option added by https://github.com/moov-io/ach/pull/1582/files, which restricts the special character allowance to the IndividualName field (that's a little safer but sometimes insufficient)