### PR TITLE
cmd/achcli/describe: include IdentificationNumber on EntryDetail, add mask option

### DIFF
--- a/cmd/achcli/describe/file.go
+++ b/cmd/achcli/describe/file.go
@@ -24,6 +24,7 @@ type Opts struct {
 	MaskNames          bool
 	MaskAccountNumbers bool
 	MaskCorrectedData  bool
+	MaskIdentification bool
 
 	PrettyAmounts bool
 }
@@ -67,7 +68,7 @@ func File(ww io.Writer, file *ach.File, opts *Opts) {
 
 		entries := file.Batches[i].GetEntries()
 		for j := range entries {
-			fmt.Fprintln(w, "\n    TransactionCode\tRDFIIdentification\tAccountNumber\tAmount\tName\tTraceNumber\tCategory")
+			fmt.Fprintln(w, "\n    TransactionCode\tRDFIIdentification\tAccountNumber\tAmount\tName\tIdentificationNumber\tTraceNumber\tCategory")
 
 			e := entries[j]
 			accountNumber := e.DFIAccountNumberField()
@@ -82,7 +83,12 @@ func File(ww io.Writer, file *ach.File, opts *Opts) {
 				name = maskName(name)
 			}
 
-			fmt.Fprintf(w, "    %d %s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.TransactionCode, transactionCodes[e.TransactionCode], e.RDFIIdentificationField(), accountNumber, amount, name, e.TraceNumberField(), e.Category)
+			identificationNumber := e.IdentificationNumberField()
+			if opts.MaskIdentification {
+				name = maskNumber(identificationNumber)
+			}
+
+			fmt.Fprintf(w, "    %d %s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", e.TransactionCode, transactionCodes[e.TransactionCode], e.RDFIIdentificationField(), accountNumber, amount, name, identificationNumber, e.TraceNumberField(), e.Category)
 
 			dumpAddenda02(w, e.Addenda02)
 			for a := range e.Addenda05 {

--- a/cmd/achcli/describe/file_test.go
+++ b/cmd/achcli/describe/file_test.go
@@ -23,7 +23,7 @@ func TestDescribeFile(t *testing.T) {
 	if testing.Verbose() {
 		os.Stdout.Write(buf.Bytes())
 	}
-	require.Equal(t, 1174, buf.Len())
+	require.Equal(t, 1218, buf.Len())
 }
 
 func TestDescribeIAT(t *testing.T) {
@@ -47,7 +47,7 @@ func TestDescribeReturn(t *testing.T) {
 	if testing.Verbose() {
 		os.Stdout.Write(buf.Bytes())
 	}
-	require.Equal(t, 2604, buf.Len())
+	require.Equal(t, 2692, buf.Len())
 }
 
 func TestDescribeCorrection(t *testing.T) {
@@ -59,7 +59,7 @@ func TestDescribeCorrection(t *testing.T) {
 	if testing.Verbose() {
 		os.Stdout.Write(buf.Bytes())
 	}
-	require.Equal(t, 1357, buf.Len())
+	require.Equal(t, 1401, buf.Len())
 }
 
 func TestFormatAmount(t *testing.T) {
@@ -108,4 +108,12 @@ func TestMaskName(t *testing.T) {
 		IndividualName: "Jane Smith Jr",
 	}
 	require.Equal(t, "Ja** Sm*** **", maskName(ed.IndividualNameField()))
+}
+
+func TestMaskIdentification(t *testing.T) {
+	ed := &ach.EntryDetail{
+		IdentificationNumber: "abc123",
+	}
+	require.Equal(t, "**c123", maskNumber(ed.IdentificationNumber))
+	require.Equal(t, "**c123         ", maskNumber(ed.IdentificationNumberField()))
 }


### PR DESCRIPTION
This field is useful, so let's include it going forward. Found while testing out https://github.com/moov-io/ach/pull/1592 