### PR TITLE
fix: always return BlockCount in ADVFileControl json

### DIFF
--- a/advFileControl.go
+++ b/advFileControl.go
@@ -32,7 +32,7 @@ type ADVFileControl struct {
 
 	// BlockCount total number of records in the file (include all headers and trailer) divided
 	// by 10 (This number must be evenly divisible by 10. If not, additional records consisting of all 9's are added to the file after the initial '9' record to fill out the block 10.)
-	BlockCount int `json:"blockCount,omitempty"`
+	BlockCount int `json:"blockCount"`
 
 	// EntryAddendaCount total detail and addenda records in the file
 	EntryAddendaCount int `json:"entryAddendaCount"`


### PR DESCRIPTION
Fixes: https://github.com/moov-io/ach/issues/1617