### PR TITLE
fix: set ValidateOpts on EntryDetails from json, don't overwrite ValidateOpts

### DIFF
--- a/file.go
+++ b/file.go
@@ -149,14 +149,13 @@ func FileFromJSONWith(bs []byte, opts *ValidateOpts) (*File, error) {
 	}
 
 	// Read the ValidateOpts first
-	out := NewFile()
-	out.SetValidation(opts)
-
 	validateOpts, err := readValidateOpts(bs)
 	if err != nil {
 		return nil, fmt.Errorf("reading validate opts: %w", err)
 	}
-	out.SetValidation(out.validateOpts.merge(validateOpts))
+
+	out := NewFile()
+	out.SetValidation(opts.merge(validateOpts))
 
 	// read file root level
 	var f file
@@ -164,9 +163,6 @@ func FileFromJSONWith(bs []byte, opts *ValidateOpts) (*File, error) {
 		return nil, fmt.Errorf("problem reading File: %v", err)
 	}
 	out.ID = f.ID
-	if opts != nil {
-		out.SetValidation(opts)
-	}
 
 	// Read FileHeader
 	header := fileHeader{
@@ -383,6 +379,8 @@ func (f *File) setBatchesFromJSON(bs []byte) error {
 		batch.SetValidation(f.validateOpts)
 
 		for _, e := range batch.Entries {
+			e.SetValidation(f.validateOpts)
+
 			// these values need to be inferred from the json field names
 			setEntryRecordType(e)
 

--- a/file_test.go
+++ b/file_test.go
@@ -553,6 +553,37 @@ func TestFileReadJSONFile(t *testing.T) {
 	}
 }
 
+func TestFileFromJSONWith(t *testing.T) {
+	opts := &ValidateOpts{
+		AllowZeroEntryAmount:   true,
+		AllowSpecialCharacters: true,
+	}
+
+	bs, err := os.ReadFile(filepath.Join("test", "testdata", "ppd-valid-preserve-spaces.json"))
+	require.NoError(t, err)
+
+	file, err := FileFromJSONWith(bs, opts)
+	require.NoError(t, err)
+
+	found := file.GetValidation()
+	require.True(t, found.PreserveSpaces)
+	require.True(t, found.AllowZeroEntryAmount)
+	require.True(t, found.AllowSpecialCharacters)
+
+	// Check the entries
+	entries := file.Batches[0].GetEntries()
+	require.Len(t, entries, 2)
+
+	for idx := range entries {
+		found := entries[idx].validateOpts
+		require.NotNil(t, found)
+
+		require.True(t, found.PreserveSpaces)
+		require.True(t, found.AllowZeroEntryAmount)
+		require.True(t, found.AllowSpecialCharacters)
+	}
+}
+
 // TestFile__jsonFileNoControlBlobs will read an ach.File from its JSON form, but the JSON has no
 // batchControl or fileControl sub-objects.
 func TestFile__jsonFileNoControlBlobs(t *testing.T) {


### PR DESCRIPTION


Fixes: https://github.com/moov-io/ach/issues/1630