### PR TITLE
Correct OpenAPI schema for /files/{fileID}/build endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -274,7 +274,7 @@ paths:
           content:
             text/plain:
               schema:
-                $ref: '#/components/schemas/File'
+                $ref: '#/components/schemas/BuildFileResponse'
   /files/{fileID}/contents:
     get:
       tags: ['ACH Files']
@@ -825,6 +825,14 @@ components:
       schema:
         type: boolean
   schemas:
+    BuildFileResponse:
+      properties:
+        file:
+          $ref: '#/components/schemas/File'
+        error:
+          type: string
+          description: An error message describing the problem intended for humans.
+          example: Any error(s) present.
     CreateFile:
       description: \`batches\` OR `IATBatches` is required
       properties:


### PR DESCRIPTION
The `/files/{fileID}/build` endpoint is incorrectly defined in the OpenAPI spec as returning a `File` blob, when it actually returns a wrapper with `"file"` and `"error"` keys defined. The incorrect definition breaks auto-generated clients. This PR corrects the YAML spec to match the actual behavior.