### PR TITLE
Update Validate File spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -357,7 +357,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
+                $ref: '#/components/schemas/ValidateFileResponse'
         '400':
           description: Validation failed. Check response for errors
     post:
@@ -2713,3 +2713,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/File'
+    ValidateFileResponse:
+      properties:
+        error:
+            type: string


### PR DESCRIPTION
the Validate File endpoint 200 response returns 
```
{ error: null }
```

However, the spec defines error as a required string. I updated the spec to allow error to be nullable. I had to create a new type since the original type is a reference to another repo.
