### PR TITLE
fix: check PaymentRelatedInformation length during validation

### DIFF
--- a/addenda05.go
+++ b/addenda05.go
@@ -151,6 +151,11 @@ func (addenda05 *Addenda05) Validate() error {
 		}
 	}
 
+	infoLength := utf8.RuneCountInString(addenda05.PaymentRelatedInformation)
+	if infoLength > 80 {
+		return fieldError("PaymentRelatedInformation", ErrExceedsFieldLength, addenda05.PaymentRelatedInformation)
+	}
+
 	return nil
 }
 

--- a/addenda05_test.go
+++ b/addenda05_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/moov-io/base"
+
+	"github.com/stretchr/testify/require"
 )
 
 func mockAddenda05() *Addenda05 {
@@ -209,4 +211,14 @@ func TestAddenda05RuneCountInString(t *testing.T) {
 	if addenda05.PaymentRelatedInformation != "" {
 		t.Error("Parsed with an invalid RuneCountInString not equal to 94")
 	}
+}
+
+func TestAddenda05_PaymentRelatedInformation_Length(t *testing.T) {
+	addenda05 := NewAddenda05()
+	addenda05.SequenceNumber = 1
+	addenda05.PaymentRelatedInformation = strings.Repeat("1", 95)
+
+	err := addenda05.Validate()
+	require.ErrorContains(t, err, "PaymentRelatedInformation")
+	require.ErrorContains(t, err, "exceeds the Nacha field length")
 }

--- a/fieldErrors.go
+++ b/fieldErrors.go
@@ -95,6 +95,8 @@ var (
 	ErrBlockingFactor = errors.New("is not 10")
 	// ErrFormatCode is given when there's an invalid format code
 	ErrFormatCode = errors.New("is not 1")
+	// ErrExceedsFieldLength is given when a field exceeds its Nacha allowed length
+	ErrExceedsFieldLength = errors.New("exceeds the Nacha field length")
 
 	// IAT
 


### PR DESCRIPTION
See: https://github.com/moov-io/ach/pull/1667 