### PR TITLE
server: add POST /files/{fileID}/reverse endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -480,6 +480,48 @@ paths:
                 $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
         '404':
           description: A resource with the specified ID was not found
+  /files/{fileID}/reverse:
+    post:
+      tags: ['ACH Files']
+      summary: Reverse File
+      description: Creates a new file that is a REVERSAL of the given fileID.
+      operationId: reverseFile
+      parameters:
+        - name: X-Request-ID
+          in: header
+          description: Optional Request ID allows application developer to trace requests through the system's logs
+          example: "rs4f9915"
+          schema:
+            type: string
+        - name: fileID
+          in: path
+          description: File ID
+          required: true
+          schema:
+            type: string
+            example: "3f2d23ee214"
+      requestBody:
+        description: Optional configuration for reversing a file
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReverseFileRequest'
+      responses:
+        '200':
+          description: An ID of the new ACH file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReverseFileResponse'
+        '400':
+          description: See error in response body
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/moov-io/base/master/api/common.yaml#/components/schemas/Error'
+        '404':
+          description: A resource with the specified ID was not found
   /files/{fileID}/batches:
     get:
       tags: ['ACH Files']
@@ -892,6 +934,24 @@ components:
         - batches
         - IATBatches
     CreateFileResponse:
+      properties:
+        id:
+          type: string
+          description: File ID
+          example: "1e522dc8"
+        file:
+          $ref: '#/components/schemas/File'
+        error:
+          type: string
+          description: An error message describing the problem intended for humans.
+          example: Validation error(s) present.
+    ReverseFileRequest:
+      properties:
+        effectiveEntryDate:
+          type: string
+          description: ISO 8601 formatted timestamp of the Effectve Entry Date
+          example: "2018-11-27T00:54:53Z"
+    ReverseFileResponse:
       properties:
         id:
           type: string

--- a/server/files.go
+++ b/server/files.go
@@ -980,7 +980,7 @@ func decodeReverseFileRequest(_ context.Context, r *http.Request) (interface{}, 
 	}
 
 	var body struct {
-		EffectiveEntryDate time.Time `json:"effectiveEntryDate"`
+		EffectiveEntryDate base.Time `json:"effectiveEntryDate"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err != io.EOF {
 		return nil, fmt.Errorf("parsing reverse request: %w", err)
@@ -989,7 +989,7 @@ func decodeReverseFileRequest(_ context.Context, r *http.Request) (interface{}, 
 	if body.EffectiveEntryDate.IsZero() {
 		req.effectiveEntryDate = time.Now().In(time.UTC)
 	} else {
-		req.effectiveEntryDate = body.EffectiveEntryDate
+		req.effectiveEntryDate = body.EffectiveEntryDate.Time
 	}
 
 	return req, nil

--- a/server/files.go
+++ b/server/files.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/moov-io/ach"
 	"github.com/moov-io/base"
@@ -907,6 +908,89 @@ func decodeMergeFilesRequest(_ context.Context, r *http.Request) (interface{}, e
 	}
 
 	req.RequestID = cmp.Or(req.RequestID, moovhttp.GetRequestID(r))
+
+	return req, nil
+}
+
+type reverseFileRequest struct {
+	fileID             string
+	effectiveEntryDate time.Time
+	requestID          string
+}
+
+type reverseFileResponse struct {
+	ID   string    `json:"id"`
+	File *ach.File `json:"file"`
+	Err  error     `json:"error"`
+}
+
+func (r reverseFileResponse) error() error { return r.Err }
+
+func reverseFileEndpoint(s Service, r Repository, logger log.Logger) endpoint.Endpoint {
+	return func(_ context.Context, request interface{}) (interface{}, error) {
+		req, ok := request.(reverseFileRequest)
+		if !ok {
+			return reverseFileResponse{Err: ErrFoundABug}, ErrFoundABug
+		}
+
+		reversedFile, err := s.ReverseFile(req.fileID, req.effectiveEntryDate)
+		if logger != nil {
+			logger := logger.With(log.Fields{
+				"files":     log.String("ReverseFile"),
+				"requestID": log.String(req.requestID),
+			})
+			if err != nil {
+				logger.Error().LogError(err)
+			} else {
+				logger.Info().Log("reverse file")
+			}
+		}
+		if err != nil {
+			return reverseFileResponse{Err: err}, err
+		}
+
+		if reversedFile.ID != "" {
+			err = r.StoreFile(reversedFile)
+			if logger != nil && err != nil {
+				logger.With(log.Fields{
+					"files":     log.String("storeReversedFile"),
+					"requestID": log.String(req.requestID),
+				}).LogError(err)
+			}
+		}
+
+		return reverseFileResponse{
+			ID:   reversedFile.ID,
+			File: reversedFile,
+			Err:  err,
+		}, nil
+	}
+}
+
+func decodeReverseFileRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	fileID, ok := vars["fileID"]
+	if !ok {
+		return nil, ErrBadRouting
+	}
+
+	req := reverseFileRequest{
+		fileID:    fileID,
+		requestID: moovhttp.GetRequestID(r),
+	}
+
+	var body struct {
+		EffectiveEntryDate time.Time `json:"effectiveEntryDate"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("parsing reverse request: %w", err)
+	}
+
+	if body.EffectiveEntryDate.IsZero() {
+		req.effectiveEntryDate = time.Now().In(time.UTC)
+	} else {
+		req.effectiveEntryDate = body.EffectiveEntryDate
+	}
 
 	return req, nil
 }

--- a/server/routing.go
+++ b/server/routing.go
@@ -217,6 +217,12 @@ func MakeHTTPHandler(s Service, repo Repository, kitlog gokitlog.Logger) http.Ha
 		encodeResponse,
 		options...,
 	))
+	r.Methods("POST").Path("/files/{fileID}/reverse").Handler(httptransport.NewServer(
+		reverseFileEndpoint(s, repo, logger),
+		decodeReverseFileRequest,
+		encodeResponse,
+		options...,
+	))
 	r.Methods("POST").Path("/merge").Handler(httptransport.NewServer(
 		mergeFilesEndpoint(s, repo, logger),
 		decodeMergeFilesRequest,


### PR DESCRIPTION
Expose existing File.Reversal() functionality through the HTTP API. This endpoint creates a NACHA-compliant reversal file that undoes fund movement by inverting transaction codes (credits become debits and vice versa).

The endpoint accepts an optional effectiveEntryDate in the request body. If not provided, defaults to current UTC time.

Request:
  POST /files/{fileID}/reverse
  {"effectiveEntryDate": "2025-01-15T10:00:00Z"}

Response:
  {"id": "new-file-id", "file": {...}}

The implementation clones the original file before applying the reversal to preserve the original in the repository.

Closes #1674