### PR TITLE
feat: add v2 API with structured validation errors

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/moov-io/base"
 )
 
 // Batch holds the Batch Header and Batch Control and all Entry Records
@@ -301,6 +303,18 @@ func (batch *Batch) Validate() error {
 	return errors.New("use an implementation of batch or NewBatch")
 }
 
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+// Unlike Validate which returns the first error, this method accumulates all validation errors.
+//
+// ValidateAll will never modify the batch.
+func (batch *Batch) ValidateAll() base.ErrorList {
+	// This stub returns nil - specific batch types should override this method.
+	// If this method is called on the base Batch type, we treat it as an error.
+	var errors base.ErrorList
+	errors.Add(batch.Error("Batch", ErrBatchSECType))
+	return errors
+}
+
 // SetValidation stores ValidateOpts on the Batch which are to be used to override
 // the default NACHA validation rules.
 func (batch *Batch) SetValidation(opts *ValidateOpts) {
@@ -393,6 +407,98 @@ func (batch *Batch) verify() error {
 		return err
 	}
 	return nil
+}
+
+// verifyAll checks basic valid NACHA batch rules and returns ALL errors found.
+// Unlike verify which returns on first error, this method accumulates all validation errors.
+func (batch *Batch) verifyAll() base.ErrorList {
+	var errors base.ErrorList
+
+	// No entries in batch
+	if len(batch.Entries) <= 0 && len(batch.ADVEntries) <= 0 {
+		errors.Add(batch.Error("entries", ErrBatchNoEntries))
+	}
+	// verify field inclusion in all the records of the batch.
+	if err := batch.isFieldInclusion(); err != nil {
+		// convert the field error in to a batch error for a consistent api
+		errors.Add(batch.Error("FieldError", err))
+	}
+
+	if !batch.IsADV() {
+		// validate batch header and control codes are the same
+		if (batch.validateOpts == nil || !batch.validateOpts.UnequalServiceClassCode) &&
+			batch.Header.ServiceClassCode != batch.Control.ServiceClassCode {
+			errors.Add(batch.Error("ServiceClassCode",
+				NewErrBatchHeaderControlEquality(batch.Header.ServiceClassCode, batch.Control.ServiceClassCode)))
+		}
+		// Company Identification in the batch header and control must match if bypassCompanyIdentificationMatch is not enabled.
+		if batch.Header.CompanyIdentification != batch.Control.CompanyIdentification &&
+			!(batch.validateOpts != nil && batch.validateOpts.BypassCompanyIdentificationMatch) {
+			errors.Add(batch.Error("CompanyIdentification",
+				NewErrBatchHeaderControlEquality(batch.Header.CompanyIdentification, batch.Control.CompanyIdentification)))
+		}
+
+		// Control ODFIIdentification must be the same as batch header
+		if batch.Header.ODFIIdentification != batch.Control.ODFIIdentification {
+			errors.Add(batch.Error("ODFIIdentification",
+				NewErrBatchHeaderControlEquality(batch.Header.ODFIIdentification, batch.Control.ODFIIdentification)))
+		}
+		// batch number header and control must match
+		if batch.Header.BatchNumber != batch.Control.BatchNumber {
+			errors.Add(batch.Error("BatchNumber",
+				NewErrBatchHeaderControlEquality(batch.Header.BatchNumber, batch.Control.BatchNumber)))
+		}
+	} else {
+		if (batch.validateOpts == nil || !batch.validateOpts.UnequalServiceClassCode) &&
+			batch.Header.ServiceClassCode != batch.ADVControl.ServiceClassCode {
+			errors.Add(batch.Error("ServiceClassCode",
+				NewErrBatchHeaderControlEquality(batch.Header.ServiceClassCode, batch.ADVControl.ServiceClassCode)))
+		}
+		// Control ODFIIdentification must be the same as batch header
+		if batch.Header.ODFIIdentification != batch.ADVControl.ODFIIdentification {
+			errors.Add(batch.Error("ODFIIdentification",
+				NewErrBatchHeaderControlEquality(batch.Header.ODFIIdentification, batch.ADVControl.ODFIIdentification)))
+		}
+		// batch number header and control must match
+		if batch.Header.BatchNumber != batch.ADVControl.BatchNumber {
+			errors.Add(batch.Error("BatchNumber",
+				NewErrBatchHeaderControlEquality(batch.Header.BatchNumber, batch.ADVControl.BatchNumber)))
+		}
+	}
+
+	if err := batch.isBatchEntryCount(); err != nil {
+		errors.Add(err)
+	}
+	if batch.validateOpts == nil || !batch.validateOpts.CustomTraceNumbers {
+		if err := batch.isSequenceAscending(); err != nil {
+			errors.Add(err)
+		}
+	}
+	if err := batch.isBatchAmount(); err != nil {
+		errors.Add(err)
+	}
+	if err := batch.isEntryHash(); err != nil {
+		errors.Add(err)
+	}
+	if err := batch.isOriginatorDNE(); err != nil {
+		errors.Add(err)
+	}
+	if batch.validateOpts == nil || !batch.validateOpts.CustomTraceNumbers {
+		if err := batch.isTraceNumberODFI(); err != nil {
+			errors.Add(err)
+		}
+		if err := batch.isAddendaSequence(); err != nil {
+			errors.Add(err)
+		}
+	}
+	if err := batch.isCategory(); err != nil {
+		errors.Add(err)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // Build creates valid batch by building sequence numbers and batch control. An error is returned if

--- a/batchARC.go
+++ b/batchARC.go
@@ -17,6 +17,8 @@
 
 package ach
 
+import "github.com/moov-io/base"
+
 // BatchARC holds the BatchHeader and BatchControl and all EntryDetail for ARC Entries.
 //
 // Accounts Receivable Entry (ARC). A consumer check converted to a one-time ACH debit.
@@ -74,6 +76,40 @@ func (batch *BatchARC) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchARC) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	if batch.Header.StandardEntryClassCode != ARC {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, ARC))
+	}
+
+	// ARC detail entries can only be a debit, ServiceClassCode must allow debits
+	switch batch.Header.ServiceClassCode {
+	case CreditsOnly:
+		errors.Add(batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -17,6 +17,8 @@
 
 package ach
 
+import "github.com/moov-io/base"
+
 // BatchBOC holds the BatchHeader and BatchControl and all EntryDetail for BOC Entries.
 //
 // Back Office Conversion (BOC) A single entry debit initiated at the point of purchase
@@ -79,6 +81,39 @@ func (batch *BatchBOC) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchBOC) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	if batch.Header.StandardEntryClassCode != BOC {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, BOC))
+	}
+
+	switch batch.Header.ServiceClassCode {
+	case CreditsOnly:
+		errors.Add(batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchCIE.go
+++ b/batchCIE.go
@@ -17,6 +17,8 @@
 
 package ach
 
+import "github.com/moov-io/base"
+
 // BatchCIE holds the BatchHeader and BatchControl and all EntryDetail for CIE Entries.
 //
 // Customer-Initiated Entry (or CIE entry) is a credit entry initiated on behalf of,
@@ -72,6 +74,39 @@ func (batch *BatchCIE) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchCIE) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	if batch.Header.StandardEntryClassCode != CIE {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, CIE))
+	}
+
+	switch batch.Header.ServiceClassCode {
+	case DebitsOnly:
+		errors.Add(batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchCTX.go
+++ b/batchCTX.go
@@ -19,6 +19,8 @@ package ach
 
 import (
 	"strconv"
+
+	"github.com/moov-io/base"
 )
 
 // BatchCTX holds the BatchHeader and BatchControl and all EntryDetail for CTX Entries.
@@ -65,6 +67,35 @@ func (batch *BatchCTX) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchCTX) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	// Add configuration and type specific validation for this type.
+	if batch.Header.StandardEntryClassCode != CTX {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, CTX))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchDNE.go
+++ b/batchDNE.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/moov-io/base"
 )
 
 // BatchDNE is a batch file that handles SEC code Death Notification Entry (DNE)
@@ -65,6 +67,35 @@ func (batch *BatchDNE) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchDNE) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	// SEC code
+	if batch.Header.StandardEntryClassCode != DNE {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, DNE))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchPOP.go
+++ b/batchPOP.go
@@ -17,6 +17,8 @@
 
 package ach
 
+import "github.com/moov-io/base"
+
 // BatchPOP holds the BatchHeader and BatchControl and all EntryDetail for POP Entries.
 //
 // Point-of-Purchase. A check presented in-person to a merchant for purchase is presented
@@ -76,6 +78,41 @@ func (batch *BatchPOP) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchPOP) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	// Add configuration and type specific validation for this type.
+	if batch.Header.StandardEntryClassCode != POP {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, POP))
+	}
+
+	// POP detail entries can only be a debit, ServiceClassCode must allow debits
+	switch batch.Header.ServiceClassCode {
+	case CreditsOnly:
+		errors.Add(batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -17,6 +17,8 @@
 
 package ach
 
+import "github.com/moov-io/base"
+
 // BatchRCK holds the BatchHeader and BatchControl and all EntryDetail for RCK Entries.
 //
 // Represented Check Entries (RCK). A physical check that was presented but returned because of
@@ -70,6 +72,46 @@ func (batch *BatchRCK) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchRCK) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	// Add configuration and type specific validation for this type.
+	if batch.Header.StandardEntryClassCode != RCK {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, RCK))
+	}
+
+	// RCK detail entries can only be a debit, ServiceClassCode must allow debits
+	switch batch.Header.ServiceClassCode {
+	case CreditsOnly:
+		errors.Add(batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode))
+	}
+
+	// CompanyEntryDescription is required to be REDEPCHECK
+	if batch.Header.CompanyEntryDescription != "REDEPCHECK" {
+		errors.Add(batch.Error("CompanyEntryDescription", ErrBatchCompanyEntryDescriptionREDEPCHECK, batch.Header.CompanyEntryDescription))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -19,6 +19,7 @@ package ach
 
 import (
 	"github.com/moov-io/ach/internal/usabbrev"
+	"github.com/moov-io/base"
 )
 
 // BatchSHR holds the BatchHeader and BatchControl and all EntryDetail for SHR Entries.
@@ -76,6 +77,43 @@ func (batch *BatchSHR) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchSHR) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	// Add configuration and type specific validation for this type.
+	if batch.Header.StandardEntryClassCode != SHR {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, SHR))
+	}
+
+	// SHR entries can be debit, credit or mixed ServiceClassCode
+	switch batch.Header.ServiceClassCode {
+	case MixedDebitsAndCredits, CreditsOnly, DebitsOnly:
+		// do nothing
+	default:
+		errors.Add(batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchTRC.go
+++ b/batchTRC.go
@@ -17,6 +17,8 @@
 
 package ach
 
+import "github.com/moov-io/base"
+
 // BatchTRC holds the BatchHeader and BatchControl and all EntryDetail for TRC Entries.
 //
 // Check Truncation Entry (Truncated Entry) is used to identify a debit entry of a truncated check.
@@ -64,6 +66,41 @@ func (batch *BatchTRC) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchTRC) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	// Add configuration and type specific validation for this type.
+	if batch.Header.StandardEntryClassCode != TRC {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, TRC))
+	}
+
+	// TRC detail entries can only be a debit, ServiceClassCode must allow debits
+	switch batch.Header.ServiceClassCode {
+	case CreditsOnly:
+		errors.Add(batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batchXCK.go
+++ b/batchXCK.go
@@ -17,6 +17,8 @@
 
 package ach
 
+import "github.com/moov-io/base"
+
 // BatchXCK holds the BatchHeader and BatchControl and all EntryDetail for XCK Entries.
 //
 // Destroyed Check Entry identifies a debit entry initiated for a XCK eligible items.
@@ -64,6 +66,41 @@ func (batch *BatchXCK) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateAll checks properties of the ACH batch and returns ALL errors found.
+func (batch *BatchXCK) ValidateAll() base.ErrorList {
+	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
+		return nil
+	}
+
+	var errors base.ErrorList
+
+	if verifyErrs := batch.verifyAll(); verifyErrs != nil {
+		for _, err := range verifyErrs {
+			errors.Add(err)
+		}
+	}
+
+	// Add configuration and type specific validation for this type.
+	if batch.Header.StandardEntryClassCode != XCK {
+		errors.Add(batch.Error("StandardEntryClassCode", ErrBatchSECType, XCK))
+	}
+
+	// XCK detail entries can only be a debit, ServiceClassCode must allow debits
+	switch batch.Header.ServiceClassCode {
+	case CreditsOnly:
+		errors.Add(batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode))
+	}
+
+	for _, inv := range batch.InvalidEntries() {
+		errors.Add(inv.Error)
+	}
+
+	if errors.Empty() {
+		return nil
+	}
+	return errors
 }
 
 // InvalidEntries returns entries with validation errors in the batch

--- a/batcher.go
+++ b/batcher.go
@@ -19,6 +19,8 @@ package ach
 
 import (
 	"fmt"
+
+	"github.com/moov-io/base"
 )
 
 // Batcher abstract the different ACH batch types that can exist in a file.
@@ -44,6 +46,7 @@ type Batcher interface {
 	DeleteADVEntries(func(*ADVEntryDetail) bool)
 	Create() error
 	Validate() error
+	ValidateAll() base.ErrorList
 	SetID(string)
 	ID() string
 	// Category defines if a Forward or Return

--- a/server/batches_v2.go
+++ b/server/batches_v2.go
@@ -1,0 +1,113 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+
+	"github.com/moov-io/base/log"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+// v2 API batch response types with structured errors
+
+// createBatchResponseV2 is the v2 response for batch creation with structured errors
+type createBatchResponseV2 struct {
+	ID     string            `json:"id,omitempty"`
+	Errors []ValidationError `json:"errors,omitempty"`
+}
+
+func (r createBatchResponseV2) error() error {
+	if len(r.Errors) > 0 {
+		return errors.New("validation errors found")
+	}
+	return nil
+}
+
+// createBatchEndpointV2 creates a batch and returns ALL validation errors in structured format
+func createBatchEndpointV2(s Service, logger log.Logger) endpoint.Endpoint {
+	return func(_ context.Context, request interface{}) (interface{}, error) {
+		req, ok := request.(createBatchRequest)
+		if !ok {
+			return createBatchResponseV2{
+				Errors: []ValidationError{{
+					ErrorType: "RequestError",
+					Message:   "invalid request type",
+				}},
+			}, nil
+		}
+
+		var validationErrors []ValidationError
+
+		// Run ValidateAll on the batch to collect all errors
+		if req.Batch != nil {
+			if errs := req.Batch.ValidateAll(); errs != nil {
+				for _, err := range errs {
+					validationErrors = append(validationErrors, ConvertError(err))
+				}
+			}
+		}
+
+		// If there are validation errors, return them without creating the batch
+		if len(validationErrors) > 0 {
+			if logger != nil {
+				logger.With(log.Fields{
+					"batches":   log.String("createBatchV2"),
+					"file":      log.String(req.FileID),
+					"requestID": log.String(req.requestID),
+				}).Info().Logf("batch has %d validation errors", len(validationErrors))
+			}
+			return createBatchResponseV2{
+				Errors: validationErrors,
+			}, nil
+		}
+
+		// Create the batch
+		id, err := s.CreateBatch(req.FileID, req.Batch)
+		if err != nil {
+			validationErrors = append(validationErrors, ValidationError{
+				ErrorType: "ServiceError",
+				Message:   err.Error(),
+			})
+			if logger != nil {
+				logger.With(log.Fields{
+					"batches":   log.String("createBatchV2"),
+					"file":      log.String(req.FileID),
+					"requestID": log.String(req.requestID),
+				}).Error().LogError(err)
+			}
+			return createBatchResponseV2{
+				Errors: validationErrors,
+			}, nil
+		}
+
+		if logger != nil {
+			logger.With(log.Fields{
+				"batches":   log.String("createBatchV2"),
+				"file":      log.String(req.FileID),
+				"requestID": log.String(req.requestID),
+			}).Info().Log("batch created")
+		}
+
+		return createBatchResponseV2{
+			ID: id,
+		}, nil
+	}
+}

--- a/server/batches_v2_test.go
+++ b/server/batches_v2_test.go
@@ -1,0 +1,144 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/base/log"
+
+	kitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchesV2__CreateBatchWithErrors(t *testing.T) {
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// Create a file first
+	f := ach.NewFile()
+	f.ID = "test-file-for-batch-v2"
+	f.Header = *mockFileHeader()
+	err := repo.StoreFile(f)
+	require.NoError(t, err)
+
+	// Create an invalid batch
+	batch := ach.NewBatchWEB(mockBatchHeaderWeb())
+	entry := mockWEBEntryDetail()
+	entry.TransactionCode = 0 // invalid
+	batch.AddEntry(entry)
+
+	var body bytes.Buffer
+	err = json.NewEncoder(&body).Encode(batch)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/v2/files/test-file-for-batch-v2/batches", &body)
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-request-id", "test-v2-batch-create")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp createBatchResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.Errors)
+	require.Empty(t, resp.ID)
+
+	// Check structured error format
+	for _, verr := range resp.Errors {
+		require.NotEmpty(t, verr.ErrorType)
+		require.NotEmpty(t, verr.Message)
+	}
+}
+
+func TestBatchesV2__CreateBatchValid(t *testing.T) {
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// Create a file first
+	f := ach.NewFile()
+	f.ID = "test-file-for-batch-v2-valid"
+	f.Header = *mockFileHeader()
+	err := repo.StoreFile(f)
+	require.NoError(t, err)
+
+	// Create a valid batch
+	batch := mockBatchWEB(t)
+
+	var body bytes.Buffer
+	err = json.NewEncoder(&body).Encode(batch)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/v2/files/test-file-for-batch-v2-valid/batches", &body)
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-request-id", "test-v2-batch-create-valid")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp createBatchResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.Empty(t, resp.Errors)
+}
+
+func TestBatchesV2__CreateBatchFileNotFound(t *testing.T) {
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	batch := mockBatchWEB(t)
+
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(batch)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/v2/files/non-existent-file/batches", &body)
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-request-id", "test-v2-batch-not-found")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp createBatchResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.Errors)
+	require.Equal(t, "ServiceError", resp.Errors[0].ErrorType)
+}

--- a/server/errors_v2.go
+++ b/server/errors_v2.go
@@ -1,0 +1,239 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"errors"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/base"
+)
+
+// ValidationError represents a single structured validation error for the v2 API.
+// It provides detailed, machine-readable information about validation failures.
+type ValidationError struct {
+	// LineNumber is the line number where the error occurred (from parsing)
+	LineNumber int `json:"lineNumber,omitempty"`
+
+	// RecordType is the type of record being processed when the error occurred
+	RecordType string `json:"recordType,omitempty"`
+
+	// ErrorType categorizes the error (e.g., "FieldError", "BatchError", "FileError")
+	ErrorType string `json:"errorType"`
+
+	// BatchNumber identifies which batch in the file had the error
+	BatchNumber int `json:"batchNumber,omitempty"`
+
+	// BatchType is the SEC code of the batch (e.g., "PPD", "WEB", "CCD")
+	BatchType string `json:"batchType,omitempty"`
+
+	// FieldName is the name of the field that failed validation
+	FieldName string `json:"fieldName,omitempty"`
+
+	// FieldValue is the value that caused the validation error
+	FieldValue interface{} `json:"fieldValue,omitempty"`
+
+	// Message is a human-readable description of the error
+	Message string `json:"message"`
+}
+
+// ConvertError transforms various ACH error types into a ValidationError.
+// It handles FieldError, BatchError, FileError, ParseError, and generic errors.
+func ConvertError(err error) ValidationError {
+	if err == nil {
+		return ValidationError{}
+	}
+
+	ve := ValidationError{
+		Message:   err.Error(),
+		ErrorType: "Error",
+	}
+
+	// Check for ParseError wrapper first and extract line/record info
+	var parseErr *base.ParseError
+	if errors.As(err, &parseErr) {
+		ve.LineNumber = parseErr.Line
+		ve.RecordType = parseErr.Record
+		ve.ErrorType = "ParseError"
+		// Unwrap and continue processing the inner error
+		if parseErr.Err != nil {
+			err = parseErr.Err
+		}
+	}
+
+	// Check specific ACH error types
+	var fieldErr *ach.FieldError
+	if errors.As(err, &fieldErr) {
+		ve.ErrorType = "FieldError"
+		ve.FieldName = fieldErr.FieldName
+		ve.FieldValue = fieldErr.Value
+		ve.Message = fieldErr.Error()
+		return ve
+	}
+
+	var batchErr *ach.BatchError
+	if errors.As(err, &batchErr) {
+		ve.ErrorType = "BatchError"
+		ve.BatchNumber = batchErr.BatchNumber
+		ve.BatchType = batchErr.BatchType
+		ve.FieldName = batchErr.FieldName
+		ve.FieldValue = batchErr.FieldValue
+		ve.Message = batchErr.Error()
+		return ve
+	}
+
+	var fileErr *ach.FileError
+	if errors.As(err, &fileErr) {
+		ve.ErrorType = "FileError"
+		ve.FieldName = fileErr.FieldName
+		ve.Message = fileErr.Error()
+		return ve
+	}
+
+	// Check for specific error types that have additional structured info
+	var checkDigitErr ach.ErrValidCheckDigit
+	if errors.As(err, &checkDigitErr) {
+		ve.ErrorType = "FieldError"
+		ve.Message = checkDigitErr.Error()
+		return ve
+	}
+
+	var fieldLengthErr ach.ErrValidFieldLength
+	if errors.As(err, &fieldLengthErr) {
+		ve.ErrorType = "FieldError"
+		ve.Message = fieldLengthErr.Error()
+		return ve
+	}
+
+	var recordTypeErr ach.ErrRecordType
+	if errors.As(err, &recordTypeErr) {
+		ve.ErrorType = "FieldError"
+		ve.Message = recordTypeErr.Error()
+		return ve
+	}
+
+	// Batch-specific structured errors
+	var batchHeaderControlErr ach.ErrBatchHeaderControlEquality
+	if errors.As(err, &batchHeaderControlErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchHeaderControlErr.Error()
+		return ve
+	}
+
+	var batchCalcControlErr ach.ErrBatchCalculatedControlEquality
+	if errors.As(err, &batchCalcControlErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchCalcControlErr.Error()
+		return ve
+	}
+
+	var batchAscendingErr ach.ErrBatchAscending
+	if errors.As(err, &batchAscendingErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchAscendingErr.Error()
+		return ve
+	}
+
+	var batchCategoryErr ach.ErrBatchCategory
+	if errors.As(err, &batchCategoryErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchCategoryErr.Error()
+		return ve
+	}
+
+	var batchTraceErr ach.ErrBatchTraceNumberNotODFI
+	if errors.As(err, &batchTraceErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchTraceErr.Error()
+		return ve
+	}
+
+	var batchAddendaTraceErr ach.ErrBatchAddendaTraceNumber
+	if errors.As(err, &batchAddendaTraceErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchAddendaTraceErr.Error()
+		return ve
+	}
+
+	var batchAddendaCountErr ach.ErrBatchAddendaCount
+	if errors.As(err, &batchAddendaCountErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchAddendaCountErr.Error()
+		return ve
+	}
+
+	var batchRequiredAddendaErr ach.ErrBatchRequiredAddendaCount
+	if errors.As(err, &batchRequiredAddendaErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchRequiredAddendaErr.Error()
+		return ve
+	}
+
+	var batchExpectedAddendaErr ach.ErrBatchExpectedAddendaCount
+	if errors.As(err, &batchExpectedAddendaErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchExpectedAddendaErr.Error()
+		return ve
+	}
+
+	var batchServiceClassErr ach.ErrBatchServiceClassTranCode
+	if errors.As(err, &batchServiceClassErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchServiceClassErr.Error()
+		return ve
+	}
+
+	var batchAmountErr ach.ErrBatchAmount
+	if errors.As(err, &batchAmountErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchAmountErr.Error()
+		return ve
+	}
+
+	var batchIATNOCErr ach.ErrBatchIATNOC
+	if errors.As(err, &batchIATNOCErr) {
+		ve.ErrorType = "BatchError"
+		ve.Message = batchIATNOCErr.Error()
+		return ve
+	}
+
+	return ve
+}
+
+// ConvertErrors transforms a slice of errors into ValidationErrors.
+func ConvertErrors(errs []error) []ValidationError {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	result := make([]ValidationError, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			result = append(result, ConvertError(err))
+		}
+	}
+	return result
+}
+
+// ConvertErrorList transforms a base.ErrorList into ValidationErrors.
+func ConvertErrorList(el base.ErrorList) []ValidationError {
+	if el.Empty() {
+		return nil
+	}
+	return ConvertErrors(el)
+}

--- a/server/errors_v2_test.go
+++ b/server/errors_v2_test.go
@@ -1,0 +1,129 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/base"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertError__FieldError(t *testing.T) {
+	fieldErr := &ach.FieldError{
+		FieldName: "Amount",
+		Value:     "abc",
+		Msg:       "invalid amount",
+	}
+
+	result := ConvertError(fieldErr)
+
+	require.Equal(t, "FieldError", result.ErrorType)
+	require.Equal(t, "Amount", result.FieldName)
+	require.Equal(t, "abc", result.FieldValue)
+	require.NotEmpty(t, result.Message)
+}
+
+func TestConvertError__BatchError(t *testing.T) {
+	batchErr := &ach.BatchError{
+		BatchNumber: 1,
+		FieldName:   "EntryCount",
+		Err:         errors.New("count mismatch"),
+	}
+
+	result := ConvertError(batchErr)
+
+	require.Equal(t, "BatchError", result.ErrorType)
+	require.Equal(t, 1, result.BatchNumber)
+	require.Equal(t, "EntryCount", result.FieldName)
+	require.Contains(t, result.Message, "count mismatch")
+}
+
+func TestConvertError__FileError(t *testing.T) {
+	fileErr := &ach.FileError{
+		FieldName: "ImmediateDestination",
+		Msg:       "invalid routing number",
+	}
+
+	result := ConvertError(fileErr)
+
+	require.Equal(t, "FileError", result.ErrorType)
+	require.Equal(t, "ImmediateDestination", result.FieldName)
+	require.Contains(t, result.Message, "invalid routing number")
+}
+
+func TestConvertError__ParseError(t *testing.T) {
+	parseErr := &base.ParseError{
+		Line:   5,
+		Record: "EntryDetail",
+		Err:    errors.New("parse failed"),
+	}
+
+	result := ConvertError(parseErr)
+
+	require.Equal(t, "ParseError", result.ErrorType)
+	require.Equal(t, 5, result.LineNumber)
+	require.Equal(t, "EntryDetail", result.RecordType)
+	require.Contains(t, result.Message, "parse failed")
+}
+
+func TestConvertError__GenericError(t *testing.T) {
+	err := errors.New("generic error")
+
+	result := ConvertError(err)
+
+	require.Equal(t, "Error", result.ErrorType)
+	require.Equal(t, "generic error", result.Message)
+}
+
+func TestConvertErrors(t *testing.T) {
+	errs := []error{
+		&ach.FieldError{FieldName: "Amount", Msg: "error 1"},
+		&ach.BatchError{BatchNumber: 2, Err: errors.New("error 2")},
+		errors.New("error 3"),
+	}
+
+	result := ConvertErrors(errs)
+
+	require.Len(t, result, 3)
+	require.Equal(t, "FieldError", result[0].ErrorType)
+	require.Equal(t, "BatchError", result[1].ErrorType)
+	require.Equal(t, "Error", result[2].ErrorType)
+}
+
+func TestConvertErrorList(t *testing.T) {
+	var el base.ErrorList
+	el.Add(&ach.FieldError{FieldName: "Field1", Msg: "msg1"})
+	el.Add(&ach.FieldError{FieldName: "Field2", Msg: "msg2"})
+
+	result := ConvertErrorList(el)
+
+	require.Len(t, result, 2)
+	require.Equal(t, "Field1", result[0].FieldName)
+	require.Equal(t, "Field2", result[1].FieldName)
+}
+
+func TestConvertError__NilError(t *testing.T) {
+	result := ConvertError(nil)
+
+	require.Empty(t, result.ErrorType)
+	require.Empty(t, result.Message)
+}

--- a/server/files_v2.go
+++ b/server/files_v2.go
@@ -1,0 +1,191 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/base"
+	"github.com/moov-io/base/log"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+// v2 API response types with structured errors
+
+// createFileResponseV2 is the v2 response for file creation with structured errors
+type createFileResponseV2 struct {
+	ID     string            `json:"id,omitempty"`
+	File   *ach.File         `json:"file,omitempty"`
+	Errors []ValidationError `json:"errors,omitempty"`
+}
+
+func (r createFileResponseV2) error() error {
+	if len(r.Errors) > 0 {
+		return errors.New("validation errors found")
+	}
+	return nil
+}
+
+// validateFileResponseV2 is the v2 response for file validation with structured errors
+type validateFileResponseV2 struct {
+	Valid  bool              `json:"valid"`
+	Errors []ValidationError `json:"errors,omitempty"`
+}
+
+func (r validateFileResponseV2) error() error {
+	if len(r.Errors) > 0 {
+		return errors.New("validation errors found")
+	}
+	return nil
+}
+
+// createFileEndpointV2 creates a file and returns ALL validation errors in structured format
+func createFileEndpointV2(s Service, r Repository, logger log.Logger) endpoint.Endpoint {
+	return func(_ context.Context, request interface{}) (interface{}, error) {
+		req, ok := request.(createFileRequest)
+		if !ok {
+			return createFileResponseV2{
+				Errors: []ValidationError{{
+					ErrorType: "RequestError",
+					Message:   "invalid request type",
+				}},
+			}, nil
+		}
+
+		var validationErrors []ValidationError
+
+		// Handle parse errors first
+		if req.parseError != nil {
+			if el, ok := req.parseError.(base.ErrorList); ok {
+				validationErrors = ConvertErrorList(el)
+			} else {
+				validationErrors = append(validationErrors, ConvertError(req.parseError))
+			}
+		}
+
+		// Run full validation if file was parsed
+		if req.File != nil {
+			// Record metrics
+			if req.File.Header.ImmediateDestination != "" && req.File.Header.ImmediateOrigin != "" {
+				filesCreated.With("destination", req.File.Header.ImmediateDestination, "origin", req.File.Header.ImmediateOrigin).Add(1)
+			}
+
+			// Create a random file ID if none was provided
+			if req.File.ID == "" {
+				req.File.ID = base.ID()
+			}
+
+			if req.validateOpts != nil {
+				req.File.SetValidation(req.validateOpts)
+			}
+
+			// Run ValidateAll to collect all errors
+			if errs := req.File.ValidateAll(); errs != nil {
+				for _, err := range errs {
+					validationErrors = append(validationErrors, ConvertError(err))
+				}
+			}
+
+			// Store the file even if there are validation errors
+			err := r.StoreFile(req.File)
+			if err != nil {
+				validationErrors = append(validationErrors, ValidationError{
+					ErrorType: "StorageError",
+					Message:   err.Error(),
+				})
+			}
+
+			if logger != nil {
+				logger := logger.With(log.Fields{
+					"files":     log.String("createFileV2"),
+					"requestID": log.String(req.requestID),
+				})
+				if len(validationErrors) > 0 {
+					logger.Info().Log("create file with validation errors")
+				} else {
+					logger.Info().Log("create file")
+				}
+			}
+		}
+
+		return createFileResponseV2{
+			ID:     req.File.ID,
+			File:   req.File,
+			Errors: validationErrors,
+		}, nil
+	}
+}
+
+// validateFileEndpointV2 validates a file and returns ALL errors in structured format
+func validateFileEndpointV2(s Service, logger log.Logger) endpoint.Endpoint {
+	return func(_ context.Context, request interface{}) (interface{}, error) {
+		req, ok := request.(validateFileRequest)
+		if !ok {
+			return validateFileResponseV2{
+				Valid: false,
+				Errors: []ValidationError{{
+					ErrorType: "RequestError",
+					Message:   "invalid request type",
+				}},
+			}, nil
+		}
+
+		file, err := s.GetFile(req.ID)
+		if err != nil {
+			return validateFileResponseV2{
+				Valid: false,
+				Errors: []ValidationError{{
+					ErrorType: "FileError",
+					Message:   err.Error(),
+				}},
+			}, nil
+		}
+
+		// Use ValidateAllWith to collect all errors
+		errs := file.ValidateAllWith(req.opts)
+		if errs == nil || errs.Empty() {
+			if logger != nil {
+				logger.With(log.Fields{
+					"files":     log.String("validateFileV2"),
+					"requestID": log.String(req.requestID),
+				}).Info().Log("file is valid")
+			}
+			return validateFileResponseV2{Valid: true}, nil
+		}
+
+		var validationErrors []ValidationError
+		for _, e := range errs {
+			validationErrors = append(validationErrors, ConvertError(e))
+		}
+
+		if logger != nil {
+			logger.With(log.Fields{
+				"files":     log.String("validateFileV2"),
+				"requestID": log.String(req.requestID),
+			}).Info().Logf("file has %d validation errors", len(validationErrors))
+		}
+
+		return validateFileResponseV2{
+			Valid:  false,
+			Errors: validationErrors,
+		}, nil
+	}
+}

--- a/server/files_v2_test.go
+++ b/server/files_v2_test.go
@@ -1,0 +1,300 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moov-io/ach"
+	"github.com/moov-io/base/log"
+
+	kitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilesV2__CreateFileWithValidationErrors(t *testing.T) {
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// Create an invalid file - use NACHA format (not JSON) which is easier to create invalid
+	fd, err := os.Open(filepath.Join("..", "test", "issues", "testdata", "issue702.ach"))
+	require.NoError(t, err)
+	defer fd.Close()
+
+	req := httptest.NewRequest("POST", "/v2/files/create", fd)
+	req.Header.Set("x-request-id", "test-v2-create")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Parse response manually to avoid ach.File JSON unmarshal validation
+	var rawResp map[string]json.RawMessage
+	err = json.NewDecoder(w.Body).Decode(&rawResp)
+	require.NoError(t, err)
+
+	// Check errors exist
+	errorsJSON, ok := rawResp["errors"]
+	require.True(t, ok, "expected errors field in response")
+
+	var errors []ValidationError
+	err = json.Unmarshal(errorsJSON, &errors)
+	require.NoError(t, err)
+
+	// Should have validation errors
+	require.NotEmpty(t, errors, "expected validation errors")
+
+	// All errors should have structured format
+	for _, verr := range errors {
+		require.NotEmpty(t, verr.ErrorType)
+		require.NotEmpty(t, verr.Message)
+	}
+}
+
+func TestFilesV2__CreateFileValid(t *testing.T) {
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// Create a valid file
+	f := ach.NewFile()
+	f.ID = "test-file-v2"
+	f.Header = *mockFileHeader()
+	batch := mockBatchWEB(t)
+	batch.Entries[0].TraceNumber = "121042880000007"
+	f.AddBatch(batch)
+
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(f)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/v2/files/create", &body)
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-request-id", "test-v2-create-valid")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp createFileResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, resp.ID)
+	require.NotNil(t, resp.File)
+	require.Empty(t, resp.Errors)
+}
+
+func TestFilesV2__CreateFileWithFileID(t *testing.T) {
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	fd, err := os.Open(filepath.Join("..", "test", "testdata", "ppd-debit.ach"))
+	require.NoError(t, err)
+	defer fd.Close()
+
+	req := httptest.NewRequest("POST", "/v2/files/my-custom-id", fd)
+	req.Header.Set("x-request-id", "test-v2-create-id")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp createFileResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.Equal(t, "my-custom-id", resp.ID)
+	require.NotNil(t, resp.File)
+	require.Empty(t, resp.Errors)
+}
+
+func TestFilesV2__ValidateFileWithErrors(t *testing.T) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(testTTLDuration, logger)
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// Store an invalid file
+	fd, err := os.Open(filepath.Join("..", "test", "testdata", "ppd-valid.json"))
+	require.NoError(t, err)
+	defer fd.Close()
+	bs, _ := io.ReadAll(fd)
+	file, _ := ach.FileFromJSON(bs)
+	file.Header.ImmediateDestination = "" // invalid routing number
+	repo.StoreFile(file)
+
+	// Validate via v2 endpoint
+	req := httptest.NewRequest("GET", "/v2/files/"+file.ID+"/validate", nil)
+	req.Header.Set("x-request-id", "test-v2-validate")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp validateFileResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.False(t, resp.Valid)
+	require.NotEmpty(t, resp.Errors)
+
+	// Check structured error format
+	for _, verr := range resp.Errors {
+		require.NotEmpty(t, verr.ErrorType)
+		require.NotEmpty(t, verr.Message)
+	}
+}
+
+func TestFilesV2__ValidateFileValid(t *testing.T) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(testTTLDuration, logger)
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// Store a valid file
+	fd, err := os.Open(filepath.Join("..", "test", "testdata", "ppd-valid.json"))
+	require.NoError(t, err)
+	defer fd.Close()
+	bs, _ := io.ReadAll(fd)
+	file, _ := ach.FileFromJSON(bs)
+	repo.StoreFile(file)
+
+	req := httptest.NewRequest("GET", "/v2/files/"+file.ID+"/validate", nil)
+	req.Header.Set("x-request-id", "test-v2-validate-valid")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp validateFileResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.True(t, resp.Valid)
+	require.Empty(t, resp.Errors)
+}
+
+func TestFilesV2__ValidateFilePOST(t *testing.T) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(testTTLDuration, logger)
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// Store a file that requires validation options
+	fd, err := os.Open(filepath.Join("..", "test", "testdata", "ppd-valid.json"))
+	require.NoError(t, err)
+	defer fd.Close()
+	bs, _ := io.ReadAll(fd)
+	file, _ := ach.FileFromJSON(bs)
+	file.Header.ImmediateOrigin = "123456789" // needs bypass
+	repo.StoreFile(file)
+
+	// POST with validation options
+	body := bytes.NewReader([]byte(`{"requireABAOrigin": false, "bypassOrigin": true}`))
+	req := httptest.NewRequest("POST", "/v2/files/"+file.ID+"/validate", body)
+	req.Header.Set("x-request-id", "test-v2-validate-post")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp validateFileResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.True(t, resp.Valid)
+}
+
+func TestFilesV2__ValidateFileNotFound(t *testing.T) {
+	logger := log.NewNopLogger()
+	repo := NewRepositoryInMemory(testTTLDuration, logger)
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	req := httptest.NewRequest("GET", "/v2/files/non-existent/validate", nil)
+	req.Header.Set("x-request-id", "test-v2-validate-not-found")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp validateFileResponseV2
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	require.False(t, resp.Valid)
+	require.NotEmpty(t, resp.Errors)
+	require.Equal(t, "FileError", resp.Errors[0].ErrorType)
+}
+
+func TestFilesV2__MultipleValidationErrors(t *testing.T) {
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	// Store a file with multiple validation issues
+	f := ach.NewFile()
+	f.ID = "multi-error-file"
+	f.Header = *mockFileHeader()
+	f.Header.ImmediateDestination = "" // error 1
+	f.Header.ImmediateOrigin = ""      // error 2
+	err := repo.StoreFile(f)
+	require.NoError(t, err)
+
+	// Validate it
+	req := httptest.NewRequest("GET", "/v2/files/multi-error-file/validate", nil)
+	req.Header.Set("x-request-id", "test-v2-multi-error")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	w.Flush()
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp validateFileResponseV2
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.NoError(t, err)
+
+	// Should have multiple errors, not just the first one
+	require.False(t, resp.Valid)
+	require.GreaterOrEqual(t, len(resp.Errors), 1, "should collect multiple validation errors")
+}


### PR DESCRIPTION
Add /v2/files/* and /v2/files/{id}/batches endpoints that return all validation errors in structured JSON format instead of a single error string.

Add ValidateAll() methods to File and Batch types to collect all errors. v1 API unchanged.

Closes #1625