### PR TITLE
fix: preserve OriginatorStatusCode=0 for ADV batches (#1725)

### DIFF
--- a/advEntryDetail.go
+++ b/advEntryDetail.go
@@ -67,7 +67,7 @@ type ADVEntryDetail struct {
 	// AddendaRecordIndicator indicates the existence of an Addenda Record.
 	// A value of "1" indicates that one ore more addenda records follow,
 	// and "0" means no such record is present.
-	AddendaRecordIndicator int `json:"addendaRecordIndicator,omitempty"`
+	AddendaRecordIndicator int `json:"addendaRecordIndicator"`
 	// ACHOperatorRoutingNumber
 	ACHOperatorRoutingNumber string `json:"achOperatorRoutingNumber"`
 	// JulianDay

--- a/batchHeader.go
+++ b/batchHeader.go
@@ -101,7 +101,7 @@ type BatchHeader struct {
 	// 0 ADV File prepared by an ACH Operator.
 	// 1 This code identifies the Originator as a depository financial institution.
 	// 2 This code identifies the Originator as a Federal Government entity or agency.
-	OriginatorStatusCode int `json:"originatorStatusCode,omitempty"`
+	OriginatorStatusCode int `json:"originatorStatusCode"`
 
 	//ODFIIdentification First 8 digits of the originating DFI transit routing number
 	ODFIIdentification string `json:"ODFIIdentification"`

--- a/entryDetail.go
+++ b/entryDetail.go
@@ -62,7 +62,7 @@ type EntryDetail struct {
 	// AddendaRecordIndicator indicates the existence of an Addenda Record.
 	// A value of "1" indicates that one ore more addenda records follow,
 	// and "0" means no such record is present.
-	AddendaRecordIndicator int `json:"addendaRecordIndicator,omitempty"`
+	AddendaRecordIndicator int `json:"addendaRecordIndicator"`
 	// TraceNumber is assigned by the ODFI or software vendor and used as part of identification.
 	//
 	// The format of trace numbers is the first 8 digits of the ODFI's routing number followed by

--- a/iatBatchHeader.go
+++ b/iatBatchHeader.go
@@ -145,7 +145,7 @@ type IATBatchHeader struct {
 	// 0 ADV File prepared by an ACH Operator.
 	// 1 This code identifies the Originator as a depository financial institution.
 	// 2 This code identifies the Originator as a Federal Government entity or agency.
-	OriginatorStatusCode int `json:"originatorStatusCode,omitempty"`
+	OriginatorStatusCode int `json:"originatorStatusCode"`
 
 	// ODFIIdentification First 8 digits of the originating DFI transit routing number
 	// For Inbound IAT Entries, this field contains the routing number of the U.S. Gateway


### PR DESCRIPTION
Remove `omitempty` from OriginatorStatusCode in batchHeader.go and iatBatchHeader.go Also remove from AddendaRecordIndicator in entryDetail.go and advEntryDetail.go

The `omitempty` JSON tag caused zero values to be omitted during serialization. When cloneFile() used JSON marshal/unmarshal, OriginatorStatusCode=0 was lost and replaced with default value 1, breaking ADV batches which require OriginatorStatusCode=0.

Fixes: https://github.com/moov-io/ach/issues/1725 