### PR TITLE
Add maxLength constraint to FileHeader fields

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1042,6 +1042,7 @@ components:
         fileCreationTime:
           description: 'The File Creation Time is the time when the file was prepared by an ODFI. (Format HHmm - H=Hour, m=Minute)'
           type: string
+          maxLength: 4
           format: "HHmm"
           example: "1504"
         fileCreationDate:
@@ -1049,12 +1050,15 @@ components:
           type: string
           format: "YYMMDD"
           example: "190102"
+          maxLength: 6
         fileIDModifier:
           type: string
           description: Incremented value for each file for RDFIs.
           example: "0"
+          maxLength: 1
         referenceCode:
           type: string
+          maxLength: 8
           description: Reserved field for information pertinent to the Originator.
         lineNumber:
           type: integer


### PR DESCRIPTION
## What did I do?
I added 'maxLength' constraints to a few fields in the 'FileHeader' schema in your openapi.yaml file. This is to help the openapi spec better match the NACHA ACH File Details specification (found [here](https://achdevguide.nacha.org/ach-file-details))

## Specific Changes
- Added maxLength: 4 to fileCreationTime
- Added maxLength: 6 to fileCreationDate
- Added maxLength: 1 to fileIDModifier
- Added maxLength: 8 to referenceCode

I got these values from the NACHA ACH File Details spec page (link provided above)

## Questions for you
- Should I also add `minLength`, `pattern`, `enum`, and other constraints mentioned in the issue? 
   - There are a few props in the .yaml file for FileHeader that are still missing them (where applicable)
- Would you like me to continue with the FileControl schema? 

For issue Enhance API spec #1584