### PR TITLE
Fix: Prevent Addenda17 and Addenda18 in IAT return entries

### DIFF
--- a/iatBatch.go
+++ b/iatBatch.go
@@ -352,6 +352,16 @@ func (iatBatch *IATBatch) isFieldInclusion() error {
 			if err := entry.Addenda99.Validate(); err != nil {
 				return err
 			}
+
+			// IAT Return entries must not include Addenda17 or Addenda18
+			// Per NACHA rules, only Addenda10-16 and Addenda99 are allowed in IAT returns
+			// Including Addenda17/18 in returns will cause Fed rejection with R25 (Addenda error)
+			if len(entry.Addenda17) > 0 {
+				return fieldError("Addenda17", ErrFieldInclusion)
+			}
+			if len(entry.Addenda18) > 0 {
+				return fieldError("Addenda18", ErrFieldInclusion)
+			}
 		}
 	}
 	return iatBatch.Control.Validate()


### PR DESCRIPTION
 Fixes #1746

  Changes

  This PR adds validation to prevent Addenda17 and Addenda18 records from being included in IAT return entries, which causes Federal Reserve rejections with return code R25 (Addenda error).

  What was changed

  iatBatch.go:
  - Added validation in isFieldInclusion() method  to check that IAT return entries do not contain Addenda17 or Addenda18 records
  - Per NACHA rules, IAT returns must only include Addenda10-16 and Addenda99

  iatBatch_test.go:
  - Fixed testIATBatchAddenda99Count() to remove Addenda17 from the mock return entry
  - Added testIATBatchReturnAddenda17Error() to verify Addenda17 is rejected in returns
  - Added testIATBatchReturnAddenda18Error() to verify Addenda18 is rejected in returns
  - Added corresponding test and benchmark functions