### PR TITLE
feat: adds a new validation option to only check batch + file totals and entry counts

### DIFF
--- a/batchACK.go
+++ b/batchACK.go
@@ -41,6 +41,17 @@ func (batch *BatchACK) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchACK.go
+++ b/batchACK.go
@@ -41,7 +41,7 @@ func (batch *BatchACK) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchADV.go
+++ b/batchADV.go
@@ -43,7 +43,7 @@ func (batch *BatchADV) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchADV.go
+++ b/batchADV.go
@@ -43,6 +43,17 @@ func (batch *BatchADV) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	if batch.Header.StandardEntryClassCode != ADV {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, ADV)

--- a/batchARC.go
+++ b/batchARC.go
@@ -51,7 +51,7 @@ func (batch *BatchARC) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchARC.go
+++ b/batchARC.go
@@ -51,6 +51,17 @@ func (batch *BatchARC) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchATX.go
+++ b/batchATX.go
@@ -47,7 +47,7 @@ func (batch *BatchATX) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchATX.go
+++ b/batchATX.go
@@ -47,6 +47,17 @@ func (batch *BatchATX) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -56,7 +56,7 @@ func (batch *BatchBOC) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -56,6 +56,17 @@ func (batch *BatchBOC) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchCCD.go
+++ b/batchCCD.go
@@ -38,6 +38,17 @@ func (batch *BatchCCD) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchCCD.go
+++ b/batchCCD.go
@@ -38,7 +38,7 @@ func (batch *BatchCCD) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchCIE.go
+++ b/batchCIE.go
@@ -47,7 +47,7 @@ func (batch *BatchCIE) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchCIE.go
+++ b/batchCIE.go
@@ -47,6 +47,17 @@ func (batch *BatchCIE) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchCOR.go
+++ b/batchCOR.go
@@ -38,7 +38,7 @@ func (batch *BatchCOR) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchCOR.go
+++ b/batchCOR.go
@@ -38,6 +38,17 @@ func (batch *BatchCOR) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchCTX.go
+++ b/batchCTX.go
@@ -48,6 +48,17 @@ func (batch *BatchCTX) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchCTX.go
+++ b/batchCTX.go
@@ -48,7 +48,7 @@ func (batch *BatchCTX) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchDNE.go
+++ b/batchDNE.go
@@ -49,7 +49,7 @@ func (batch *BatchDNE) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchDNE.go
+++ b/batchDNE.go
@@ -49,6 +49,17 @@ func (batch *BatchDNE) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	if err := batch.verify(); err != nil {
 		return err

--- a/batchENR.go
+++ b/batchENR.go
@@ -46,6 +46,17 @@ func (batch *BatchENR) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	if err := batch.verify(); err != nil {
 		return err

--- a/batchENR.go
+++ b/batchENR.go
@@ -46,7 +46,7 @@ func (batch *BatchENR) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchMTE.go
+++ b/batchMTE.go
@@ -48,6 +48,17 @@ func (batch *BatchMTE) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchMTE.go
+++ b/batchMTE.go
@@ -48,7 +48,7 @@ func (batch *BatchMTE) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchPOP.go
+++ b/batchPOP.go
@@ -53,6 +53,17 @@ func (batch *BatchPOP) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchPOP.go
+++ b/batchPOP.go
@@ -53,7 +53,7 @@ func (batch *BatchPOP) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -56,6 +56,17 @@ func (batch *BatchPOS) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchPOS.go
+++ b/batchPOS.go
@@ -56,7 +56,7 @@ func (batch *BatchPOS) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchPPD.go
+++ b/batchPPD.go
@@ -39,7 +39,7 @@ func (batch *BatchPPD) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchPPD.go
+++ b/batchPPD.go
@@ -39,6 +39,17 @@ func (batch *BatchPPD) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -42,6 +42,17 @@ func (batch *BatchRCK) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -42,7 +42,7 @@ func (batch *BatchRCK) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -51,6 +51,17 @@ func (batch *BatchSHR) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchSHR.go
+++ b/batchSHR.go
@@ -51,7 +51,7 @@ func (batch *BatchSHR) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchTEL.go
+++ b/batchTEL.go
@@ -40,6 +40,17 @@ func (batch *BatchTEL) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchTEL.go
+++ b/batchTEL.go
@@ -40,7 +40,7 @@ func (batch *BatchTEL) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchTRC.go
+++ b/batchTRC.go
@@ -41,6 +41,17 @@ func (batch *BatchTRC) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchTRC.go
+++ b/batchTRC.go
@@ -41,7 +41,7 @@ func (batch *BatchTRC) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchTRX.go
+++ b/batchTRX.go
@@ -45,7 +45,7 @@ func (batch *BatchTRX) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchTRX.go
+++ b/batchTRX.go
@@ -45,6 +45,17 @@ func (batch *BatchTRX) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -38,6 +38,17 @@ func (batch *BatchWEB) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchWeb.go
+++ b/batchWeb.go
@@ -38,7 +38,7 @@ func (batch *BatchWEB) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/batchXCK.go
+++ b/batchXCK.go
@@ -41,6 +41,17 @@ func (batch *BatchXCK) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if batch.validateOpts.SkipAllValidationsExceptTotals {
+		err := batch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = batch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := batch.verify(); err != nil {

--- a/batchXCK.go
+++ b/batchXCK.go
@@ -41,7 +41,7 @@ func (batch *BatchXCK) Validate() error {
 	if batch.validateOpts != nil && (batch.validateOpts.SkipAll || batch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if batch.validateOpts.SkipAllValidationsExceptTotals {
+	if batch.validateOpts != nil && batch.validateOpts.SkipAllValidationsExceptTotals {
 		err := batch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/docs/create-file.md
+++ b/docs/create-file.md
@@ -63,6 +63,7 @@ Example: `POST /files/create?requireABAOrigin=true&bypassDestination=true`
 | `requireABAOrigin`                 | `RequireABAOrigin`                 |
 | `skipAll`                          | `SkipAll`                          |
 | `skipFileCreationValidation`       | `SkipFileCreationValidation`       |
+| `skipAllValidationsExceptTotals`   | `skipAllValidationsExceptTotals`   |
 | `unequalAddendaCounts`             | `UnequalAddendaCounts`             |
 | `unequalServiceClassCode`          | `UnequalServiceClassCode`          |
 

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -628,6 +628,17 @@ func (iatBatch *IATBatch) Validate() error {
 	if iatBatch.validateOpts != nil && (iatBatch.validateOpts.SkipAll || iatBatch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
+	if iatBatch.validateOpts.SkipAllValidationsExceptTotals {
+		_, err := iatBatch.isBatchEntryCount()
+		if err != nil {
+			return err
+		}
+		err = iatBatch.isBatchAmount()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 
 	// basic verification of the batch before we validate specific rules.
 	if err := iatBatch.verify(); err != nil {

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -628,7 +628,7 @@ func (iatBatch *IATBatch) Validate() error {
 	if iatBatch.validateOpts != nil && (iatBatch.validateOpts.SkipAll || iatBatch.validateOpts.BypassBatchValidation) {
 		return nil
 	}
-	if iatBatch.validateOpts.SkipAllValidationsExceptTotals {
+	if iatBatch.validateOpts != nil && iatBatch.validateOpts.SkipAllValidationsExceptTotals {
 		_, err := iatBatch.isBatchEntryCount()
 		if err != nil {
 			return err

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -89,6 +89,7 @@ paths:
         - $ref: "#/components/parameters/PreserveSpaces"
         - $ref: "#/components/parameters/RequireABAOrigin"
         - $ref: "#/components/parameters/SkipFileCreationValidation"
+        - $ref: "#/components/parameters/SkipAllValidationsExceptTotals"
         - $ref: "#/components/parameters/UnequalAddendaCounts"
         - $ref: "#/components/parameters/UnequalServiceClassCode"
         - $ref: "#/components/parameters/UnorderedBatchNumbers"
@@ -223,6 +224,7 @@ paths:
         - $ref: "#/components/parameters/PreserveSpaces"
         - $ref: "#/components/parameters/RequireABAOrigin"
         - $ref: "#/components/parameters/SkipFileCreationValidation"
+        - $ref: "#/components/parameters/SkipAllValidationsExceptTotals"
         - $ref: "#/components/parameters/UnequalAddendaCounts"
         - $ref: "#/components/parameters/UnequalServiceClassCode"
         - $ref: "#/components/parameters/UnorderedBatchNumbers"
@@ -338,6 +340,7 @@ paths:
       - $ref: "#/components/parameters/PreserveSpaces"
       - $ref: "#/components/parameters/RequireABAOrigin"
       - $ref: "#/components/parameters/SkipFileCreationValidation"
+      - $ref: "#/components/parameters/SkipAllValidationsExceptTotals"
       - $ref: "#/components/parameters/UnequalAddendaCounts"
       - $ref: "#/components/parameters/UnequalServiceClassCode"
       - $ref: "#/components/parameters/UnorderedBatchNumbers"
@@ -891,6 +894,12 @@ components:
       name: skipFileCreationValidation
       in: query
       description: Optional parameter to skip validation of the FileCreationTime and FileCreationDate fields in a file header
+      schema:
+        type: boolean
+    SkipAllValidationsExceptTotals:
+      name: skipAllValidationsExceptTotals
+      in: query
+      description: Optional parameter to skip all validations except checking credit/debit totals and addenda entry counts on file and batch footers
       schema:
         type: boolean
   schemas:

--- a/server/validate.go
+++ b/server/validate.go
@@ -53,6 +53,7 @@ const (
 	allowEmptyIndividualName         = "allowEmptyIndividualName"
 	bypassBatchValidation            = "bypassBatchValidation"
 	skipFileCreationValidation       = "skipFileCreationValidation"
+	skipAllValidationsExceptTotals   = "skipAllValidationsExceptTotals"
 )
 
 // readValidateOpts parses ValidateOpts from the URL query parameters and from the request body.
@@ -85,6 +86,7 @@ func readValidateOpts(request *http.Request) (io.ReadCloser, *ach.ValidateOpts, 
 		allowEmptyIndividualName,
 		bypassBatchValidation,
 		skipFileCreationValidation,
+		skipAllValidationsExceptTotals,
 	}
 
 	var buf bytes.Buffer
@@ -150,6 +152,8 @@ func readValidateOpts(request *http.Request) (io.ReadCloser, *ach.ValidateOpts, 
 			opts.BypassBatchValidation = yes
 		case skipFileCreationValidation:
 			opts.SkipFileCreationValidation = yes
+		case skipAllValidationsExceptTotals:
+			opts.SkipAllValidationsExceptTotals = yes
 		}
 	}
 


### PR DESCRIPTION
Adds functionality requested in https://github.com/moov-io/ach/issues/1570

This is performed using a new Validation Option `skipAllValidationsExceptTotals`.  This changes file and batch validation logic to only check the credit and debit entry amounts + the entry addenda counts.