### PR TITLE
feat: exposes a new function to only check batch + file totals and entry counts

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -301,7 +301,7 @@ func (batch *Batch) Validate() error {
 	return errors.New("use an implementation of batch or NewBatch")
 }
 
-// ValidateTotals performs checks on the dollar and entry addenda totals of the batch
+// ValidateTotals performs checks on: 1. Batch entry count 2. Batch credit/debit totals of the 3. Batch entry hash
 // ValidateTotals will never modify the Batch.
 //
 // The first error encountered is returned.
@@ -310,6 +310,9 @@ func (batch *Batch) ValidateTotals() error {
 		return err
 	}
 	if err := batch.isBatchAmount(); err != nil {
+		return err
+	}
+	if err := batch.isEntryHash(); err != nil {
 		return err
 	}
 	return nil
@@ -386,18 +389,12 @@ func (batch *Batch) verify() error {
 		}
 	}
 
-	if err := batch.isBatchEntryCount(); err != nil {
-		return err
-	}
 	if batch.validateOpts == nil || !batch.validateOpts.CustomTraceNumbers {
 		if err := batch.isSequenceAscending(); err != nil {
 			return err
 		}
 	}
-	if err := batch.isBatchAmount(); err != nil {
-		return err
-	}
-	if err := batch.isEntryHash(); err != nil {
+	if err := batch.ValidateTotals(); err != nil {
 		return err
 	}
 	if err := batch.isOriginatorDNE(); err != nil {

--- a/batch.go
+++ b/batch.go
@@ -306,12 +306,10 @@ func (batch *Batch) Validate() error {
 //
 // The first error encountered is returned.
 func (batch *Batch) ValidateTotals() error {
-	err := batch.isBatchEntryCount()
-	if err != nil {
+	if err := batch.isBatchEntryCount(); err != nil {
 		return err
 	}
-	err = batch.isBatchAmount()
-	if err != nil {
+	if err := batch.isBatchAmount(); err != nil {
 		return err
 	}
 	return nil

--- a/batch.go
+++ b/batch.go
@@ -388,14 +388,13 @@ func (batch *Batch) verify() error {
 				NewErrBatchHeaderControlEquality(batch.Header.BatchNumber, batch.ADVControl.BatchNumber))
 		}
 	}
-
+	if err := batch.ValidateTotals(); err != nil {
+		return err
+	}
 	if batch.validateOpts == nil || !batch.validateOpts.CustomTraceNumbers {
 		if err := batch.isSequenceAscending(); err != nil {
 			return err
 		}
-	}
-	if err := batch.ValidateTotals(); err != nil {
-		return err
 	}
 	if err := batch.isOriginatorDNE(); err != nil {
 		return err

--- a/batch.go
+++ b/batch.go
@@ -301,6 +301,22 @@ func (batch *Batch) Validate() error {
 	return errors.New("use an implementation of batch or NewBatch")
 }
 
+// ValidateTotals performs checks on the dollar and entry addenda totals of the batch
+// ValidateTotals will never modify the Batch.
+//
+// The first error encountered is returned.
+func (batch *Batch) ValidateTotals() error {
+	err := batch.isBatchEntryCount()
+	if err != nil {
+		return err
+	}
+	err = batch.isBatchAmount()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // SetValidation stores ValidateOpts on the Batch which are to be used to override
 // the default NACHA validation rules.
 func (batch *Batch) SetValidation(opts *ValidateOpts) {

--- a/batch_test.go
+++ b/batch_test.go
@@ -426,6 +426,8 @@ func testBatchIsSequenceAscending(t testing.TB) {
 	e3.TraceNumber = "1"
 	mockBatch.AddEntry(e3)
 	mockBatch.GetControl().EntryAddendaCount = 2
+	mockBatch.GetControl().TotalCreditEntryDollarAmount, mockBatch.GetControl().TotalDebitEntryDollarAmount = mockBatch.calculateBatchAmounts()
+	mockBatch.GetControl().EntryHash = mockBatch.calculateEntryHash()
 	err := mockBatch.verify()
 	if !base.Match(err, NewErrBatchAscending(121042880000001, 1)) {
 		t.Errorf("%T: %s", err, err)

--- a/batch_test.go
+++ b/batch_test.go
@@ -1820,3 +1820,135 @@ func TestBatch_upsertOffsets_PanicRegression(t *testing.T) {
 
 	require.Len(t, batch.Entries, 4)
 }
+
+// TestBatch_ValidateTotals tests the ValidateTotals method
+func TestBatch_ValidateTotals(t *testing.T) {
+	t.Run("valid batch", func(t *testing.T) {
+		batch := mockBatch(t)
+		err := batch.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid PPD batch", func(t *testing.T) {
+		batch := mockBatchPPD(t)
+		err := batch.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid ADV batch", func(t *testing.T) {
+		batch := mockBatchADV(t)
+		err := batch.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("entry count mismatch", func(t *testing.T) {
+		batch := mockBatch(t)
+		// Corrupt the entry count in control record
+		batch.Control.EntryAddendaCount = 999
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryAddendaCount")
+	})
+
+	t.Run("debit amount mismatch", func(t *testing.T) {
+		batch := mockBatch(t)
+		// Corrupt the debit amount in control record
+		batch.Control.TotalDebitEntryDollarAmount = 999999
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalDebitEntryDollarAmount")
+	})
+
+	t.Run("credit amount mismatch", func(t *testing.T) {
+		batch := mockBatch(t)
+		// Change entry to credit and corrupt credit amount
+		batch.Entries[0].TransactionCode = CheckingCredit
+		batch.Control.TotalCreditEntryDollarAmount = 999999
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalCreditEntryDollarAmount")
+	})
+
+	t.Run("empty batch", func(t *testing.T) {
+		batch := &Batch{}
+		batch.SetHeader(mockBatchHeader())
+		batch.Control = &BatchControl{
+			EntryAddendaCount:            0,
+			TotalDebitEntryDollarAmount:  0,
+			TotalCreditEntryDollarAmount: 0,
+		}
+
+		err := batch.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("batch with zero amounts", func(t *testing.T) {
+		batch := &Batch{}
+		batch.SetHeader(mockBatchHeader())
+
+		// Add entry with zero amount
+		entry := mockEntryDetail()
+		entry.Amount = 0
+		batch.AddEntry(entry)
+		require.NoError(t, batch.build())
+
+		err := batch.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("multiple entries with amount mismatch", func(t *testing.T) {
+		batch := &Batch{}
+		batch.SetHeader(mockBatchHeader())
+		batch.AddEntry(mockEntryDetail())
+		batch.AddEntry(mockEntryDetail())
+		require.NoError(t, batch.build())
+
+		// Corrupt one of the entry amounts but don't update control
+		originalAmount := batch.Entries[0].Amount
+		batch.Entries[0].Amount = originalAmount + 100000
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalCreditEntryDollarAmount")
+	})
+
+	t.Run("addenda count affects entry count", func(t *testing.T) {
+		batch := &Batch{}
+		batch.SetHeader(mockBatchHeader())
+		entry := mockEntryDetail()
+		entry.AddendaRecordIndicator = 1
+		entry.AddAddenda05(mockAddenda05())
+		batch.AddEntry(entry)
+		require.NoError(t, batch.build())
+
+		// Add extra addenda without updating control
+		entry.AddAddenda05(mockAddenda05())
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryAddendaCount")
+	})
+
+	t.Run("ADV batch entry count mismatch", func(t *testing.T) {
+		batch := mockBatchADV(t)
+		// Corrupt the entry count in ADV control record
+		batch.ADVControl.EntryAddendaCount = 999
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryAddendaCount")
+	})
+
+	t.Run("ADV batch amount mismatch", func(t *testing.T) {
+		batch := mockBatchADV(t)
+		// Corrupt the debit amount in ADV control record
+		batch.ADVControl.TotalDebitEntryDollarAmount = 999999
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalDebitEntryDollarAmount")
+	})
+}

--- a/batcher.go
+++ b/batcher.go
@@ -44,6 +44,7 @@ type Batcher interface {
 	DeleteADVEntries(func(*ADVEntryDetail) bool)
 	Create() error
 	Validate() error
+	ValidateTotals() error
 	SetID(string)
 	ID() string
 	// Category defines if a Forward or Return

--- a/file.go
+++ b/file.go
@@ -911,7 +911,7 @@ func (f *File) isBlockCount(IsADV bool) error {
 		numLines = f.Control.LineNumber
 		blockCount = f.Control.BlockCount
 	}
-	calculatedBlockCount := numLines / 10
+	calculatedBlockCount := 1 + numLines/10
 	if calculatedBlockCount != blockCount {
 		return NewErrFileCalculatedControlEquality("BlockCount", calculatedBlockCount, blockCount)
 	}

--- a/file.go
+++ b/file.go
@@ -884,6 +884,33 @@ func (f *File) ValidateWith(opts *ValidateOpts) error {
 	return f.isEntryHash(true)
 }
 
+// ValidateTotals performs checks on the dollar and entry addenda totals of the file and its contained batches
+// ValidateTotals will never modify the File.
+//
+// The first error encountered is returned.
+func (f *File) ValidateTotals() error {
+	if err := f.isEntryAddendaCount(false); err != nil {
+		return err
+	}
+	if err := f.isFileAmount(false); err != nil {
+		return err
+	}
+	if err := f.isEntryHash(false); err != nil {
+		return err
+	}
+	for _, b := range f.Batches {
+		if err := b.ValidateTotals(); err != nil {
+			return err
+		}
+	}
+	for _, b := range f.IATBatches {
+		if err := b.ValidateTotals(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // isEntryAddendaCount is prepared by hashing the RDFI's 8-digit Routing Number in each entry.
 // The Entry Hash provides a check against inadvertent alteration of data
 func (f *File) isEntryAddendaCount(IsADV bool) error {

--- a/file.go
+++ b/file.go
@@ -904,6 +904,7 @@ func (f *File) ValidateTotals() error {
 	return f.isBatchCount(isADV)
 }
 
+// isBlockCount validates that the block count is equal to the number of blocks in the file
 func (f *File) isBlockCount(IsADV bool) error {
 	var numLines int
 	var blockCount int
@@ -921,6 +922,7 @@ func (f *File) isBlockCount(IsADV bool) error {
 	return nil
 }
 
+// isBatchCount validates that the batch count is equal to the number of batches in the file
 func (f *File) isBatchCount(IsADV bool) error {
 	var batchCount int
 	if IsADV {

--- a/file.go
+++ b/file.go
@@ -888,9 +888,6 @@ func (f *File) ValidateTotals() error {
 	if err := f.isEntryHash(isADV); err != nil {
 		return err
 	}
-	if err := f.isBlockCount(isADV); err != nil {
-		return err
-	}
 	for _, b := range f.Batches {
 		if err := b.ValidateTotals(); err != nil {
 			return err
@@ -902,24 +899,6 @@ func (f *File) ValidateTotals() error {
 		}
 	}
 	return f.isBatchCount(isADV)
-}
-
-// isBlockCount validates that the block count is equal to the number of blocks in the file
-func (f *File) isBlockCount(IsADV bool) error {
-	var numLines int
-	var blockCount int
-	if IsADV {
-		numLines = f.ADVControl.LineNumber
-		blockCount = f.ADVControl.BlockCount
-	} else {
-		numLines = f.Control.LineNumber
-		blockCount = f.Control.BlockCount
-	}
-	calculatedBlockCount := 1 + numLines/10
-	if calculatedBlockCount != blockCount {
-		return NewErrFileCalculatedControlEquality("BlockCount", calculatedBlockCount, blockCount)
-	}
-	return nil
 }
 
 // isBatchCount validates that the batch count is equal to the number of batches in the file

--- a/file.go
+++ b/file.go
@@ -888,6 +888,9 @@ func (f *File) ValidateTotals() error {
 	if err := f.isEntryHash(isADV); err != nil {
 		return err
 	}
+	if err := f.isBlockCount(isADV); err != nil {
+		return err
+	}
 	for _, b := range f.Batches {
 		if err := b.ValidateTotals(); err != nil {
 			return err

--- a/file.go
+++ b/file.go
@@ -850,18 +850,12 @@ func (f *File) ValidateWith(opts *ValidateOpts) error {
 				return err
 			}
 		}
-		if err := f.isEntryAddendaCount(false); err != nil {
-			return err
-		}
-		if err := f.isFileAmount(false); err != nil {
-			return err
-		}
 		if !opts.AllowUnorderedBatchNumbers {
 			if err := f.isSequenceAscending(); err != nil {
 				return err
 			}
 		}
-		return f.isEntryHash(false)
+		return f.ValidateTotals()
 	}
 
 	// File contains ADV batches BatchADV
@@ -875,17 +869,12 @@ func (f *File) ValidateWith(opts *ValidateOpts) error {
 			return err
 		}
 	}
-	if err := f.isEntryAddendaCount(true); err != nil {
-		return err
-	}
-	if err := f.isFileAmount(true); err != nil {
-		return err
-	}
-	return f.isEntryHash(true)
+	return f.ValidateTotals()
 }
 
-// ValidateTotals performs checks on the dollar and entry addenda totals of the file and its contained batches
-// ValidateTotals will never modify the File.
+// ValidateTotals performs checks on: 1.File entry addenda counts 2. File credit/debit totals 3. File entry hash 4. File batch count
+// ValidateTotals will also call the ValidateTotals function on all contained batches
+// ValidateTotals will never modify the File or contained Batches.
 //
 // The first error encountered is returned.
 func (f *File) ValidateTotals() error {
@@ -908,6 +897,37 @@ func (f *File) ValidateTotals() error {
 		if err := b.ValidateTotals(); err != nil {
 			return err
 		}
+	}
+	return f.isBatchCount(isADV)
+}
+
+func (f *File) isBlockCount(IsADV bool) error {
+	var numLines int
+	var blockCount int
+	if IsADV {
+		numLines = f.ADVControl.LineNumber
+		blockCount = f.ADVControl.BlockCount
+	} else {
+		numLines = f.Control.LineNumber
+		blockCount = f.Control.BlockCount
+	}
+	calculatedBlockCount := numLines / 10
+	if calculatedBlockCount != blockCount {
+		return NewErrFileCalculatedControlEquality("BlockCount", calculatedBlockCount, blockCount)
+	}
+	return nil
+}
+
+func (f *File) isBatchCount(IsADV bool) error {
+	var batchCount int
+	if IsADV {
+		batchCount = f.ADVControl.BatchCount
+	} else {
+		batchCount = f.Control.BatchCount
+	}
+	calculatedBatchCount := len(f.Batches) + len(f.IATBatches)
+	if calculatedBatchCount != batchCount {
+		return NewErrFileCalculatedControlEquality("BatchCount", calculatedBatchCount, batchCount)
 	}
 	return nil
 }

--- a/file.go
+++ b/file.go
@@ -889,13 +889,14 @@ func (f *File) ValidateWith(opts *ValidateOpts) error {
 //
 // The first error encountered is returned.
 func (f *File) ValidateTotals() error {
-	if err := f.isEntryAddendaCount(false); err != nil {
+	isADV := f.IsADV()
+	if err := f.isEntryAddendaCount(isADV); err != nil {
 		return err
 	}
-	if err := f.isFileAmount(false); err != nil {
+	if err := f.isFileAmount(isADV); err != nil {
 		return err
 	}
-	if err := f.isEntryHash(false); err != nil {
+	if err := f.isEntryHash(isADV); err != nil {
 		return err
 	}
 	for _, b := range f.Batches {

--- a/file_test.go
+++ b/file_test.go
@@ -1500,6 +1500,10 @@ func TestFile__SegmentADVFileDebit(t *testing.T) {
 
 	// Force the ADVEntryDetail to Debit
 	f.Batches[0].GetADVEntries()[0].TransactionCode = DebitForDebitsReceived
+	f.Batches[0].GetADVControl().TotalDebitEntryDollarAmount = f.Batches[0].GetADVControl().TotalCreditEntryDollarAmount
+	f.Batches[0].GetADVControl().TotalCreditEntryDollarAmount = 0
+	f.ADVControl.TotalDebitEntryDollarAmountInFile = f.ADVControl.TotalCreditEntryDollarAmountInFile
+	f.ADVControl.TotalCreditEntryDollarAmountInFile = 0
 
 	creditFile, debitFile, err := f.SegmentFile(nil)
 	if err != nil {
@@ -2454,6 +2458,7 @@ func TestFile_ValidateTotals(t *testing.T) {
 		entry.Amount = 0
 		batch.AddEntry(entry)
 		batch.GetControl().EntryAddendaCount = 1
+		batch.GetControl().EntryHash = batch.calculateEntryHash()
 		file.AddBatch(batch)
 		require.NoError(t, file.Create())
 
@@ -2485,36 +2490,6 @@ func TestFile_ValidateTotals_FileControlErrors(t *testing.T) {
 
 		err := file.ValidateTotals()
 		require.Error(t, err)
-	})
-}
-
-func TestFile_isBlockCount(t *testing.T) {
-	t.Run("valid block count non-ADV", func(t *testing.T) {
-		file := mockFilePPD(t)
-		err := file.isBlockCount(false)
-		require.NoError(t, err)
-	})
-
-	t.Run("invalid block count non-ADV", func(t *testing.T) {
-		file := mockFilePPD(t)
-		file.Control.BlockCount = 999
-		err := file.isBlockCount(false)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "BlockCount")
-	})
-
-	t.Run("valid block count ADV", func(t *testing.T) {
-		file := mockFileADV(t)
-		err := file.isBlockCount(true)
-		require.NoError(t, err)
-	})
-
-	t.Run("invalid block count ADV", func(t *testing.T) {
-		file := mockFileADV(t)
-		file.ADVControl.BlockCount = 999
-		err := file.isBlockCount(true)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "BlockCount")
 	})
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -2330,3 +2330,160 @@ func TestFile_BypassBatchValidation(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+// TestFile_ValidateTotals tests the ValidateTotals method
+func TestFile_ValidateTotals(t *testing.T) {
+	t.Run("valid file with PPD batch", func(t *testing.T) {
+		file := mockFilePPD(t)
+		err := file.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid file with IAT batch", func(t *testing.T) {
+		file := NewFile()
+		file.SetHeader(mockFileHeader())
+		iatBatch := mockIATBatch(t)
+		file.AddIATBatch(iatBatch)
+		require.NoError(t, file.Create())
+
+		err := file.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid file with both PPD and IAT batches", func(t *testing.T) {
+		file := mockFilePPD(t)
+		iatBatch := mockIATBatch(t)
+		file.AddIATBatch(iatBatch)
+		require.NoError(t, file.Create())
+
+		err := file.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("file entry addenda count error", func(t *testing.T) {
+		file := mockFilePPD(t)
+		// Corrupt the entry addenda count
+		file.Control.EntryAddendaCount = 999
+
+		err := file.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryAddendaCount")
+	})
+
+	t.Run("file amount error", func(t *testing.T) {
+		file := mockFilePPD(t)
+		// Corrupt the total debit amount
+		file.Control.TotalDebitEntryDollarAmountInFile = 999999
+
+		err := file.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalDebitEntryDollarAmountInFile")
+	})
+
+	t.Run("file entry hash error", func(t *testing.T) {
+		file := mockFilePPD(t)
+		// Corrupt the entry hash
+		file.Control.EntryHash = 999999999
+
+		err := file.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryHash")
+	})
+
+	t.Run("batch ValidateTotals error", func(t *testing.T) {
+		file := mockFilePPD(t)
+		// Corrupt the batch entry count to trigger batch ValidateTotals error
+		file.Batches[0].GetControl().EntryAddendaCount = 999
+
+		err := file.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryAddendaCount")
+	})
+
+	t.Run("IAT batch ValidateTotals error", func(t *testing.T) {
+		file := NewFile()
+		file.SetHeader(mockFileHeader())
+		iatBatch := mockIATBatch(t)
+		file.AddIATBatch(iatBatch)
+		require.NoError(t, file.Create())
+
+		// Corrupt the IAT batch entry count to trigger IAT batch ValidateTotals error
+		file.IATBatches[0].GetControl().EntryAddendaCount = 999
+
+		err := file.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryAddendaCount")
+	})
+
+	t.Run("multiple batches with one invalid", func(t *testing.T) {
+		file := mockFilePPD(t)
+		// Add another valid batch
+		file.AddBatch(mockBatchPPD(t))
+		require.NoError(t, file.Create())
+
+		// Corrupt the second batch
+		file.Batches[1].GetControl().EntryAddendaCount = 999
+
+		err := file.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryAddendaCount")
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		file := NewFile()
+		file.SetHeader(mockFileHeader())
+		file.Control = mockFileControl()
+		file.Control.EntryAddendaCount = 0
+		file.Control.TotalCreditEntryDollarAmountInFile = 0
+		file.Control.TotalDebitEntryDollarAmountInFile = 0
+		file.Control.EntryHash = 0
+		file.Control.BatchCount = 0
+
+		err := file.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("file with zero amounts", func(t *testing.T) {
+		file := NewFile()
+		file.SetHeader(mockFileHeader())
+
+		// Create a batch with zero amounts
+		bh := mockBatchPPDHeader()
+		batch := NewBatchPPD(bh)
+		entry := mockPPDEntryDetail()
+		entry.Amount = 0
+		batch.AddEntry(entry)
+		batch.GetControl().EntryAddendaCount = 1
+		file.AddBatch(batch)
+		require.NoError(t, file.Create())
+
+		err := file.ValidateTotals()
+		require.NoError(t, err)
+	})
+}
+
+// TestFile_ValidateTotals_FileControlErrors tests specific file control validation errors
+func TestFile_ValidateTotals_FileControlErrors(t *testing.T) {
+	t.Run("credit amount mismatch", func(t *testing.T) {
+		file := mockFilePPD(t)
+		// Change entry to credit and corrupt file control credit amount
+		file.Batches[0].GetEntries()[0].TransactionCode = CheckingCredit
+		file.Batches[0].GetEntries()[0].Amount = 100000
+		require.NoError(t, file.Create())
+		file.Control.TotalCreditEntryDollarAmountInFile = 999999
+
+		err := file.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalCreditEntryDollarAmountInFile")
+	})
+
+	t.Run("batch count mismatch", func(t *testing.T) {
+		file := mockFilePPD(t)
+		// Add another batch but don't update file control
+		file.AddBatch(mockBatchPPD(t))
+		file.Control.BatchCount = 1 // Should be 2
+
+		err := file.ValidateTotals()
+		require.Error(t, err)
+	})
+}

--- a/file_test.go
+++ b/file_test.go
@@ -2487,3 +2487,81 @@ func TestFile_ValidateTotals_FileControlErrors(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestFile_isBlockCount(t *testing.T) {
+	t.Run("valid block count non-ADV", func(t *testing.T) {
+		file := mockFilePPD(t)
+		err := file.isBlockCount(false)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid block count non-ADV", func(t *testing.T) {
+		file := mockFilePPD(t)
+		file.Control.BlockCount = 999
+		err := file.isBlockCount(false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "BlockCount")
+	})
+
+	t.Run("valid block count ADV", func(t *testing.T) {
+		file := mockFileADV(t)
+		err := file.isBlockCount(true)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid block count ADV", func(t *testing.T) {
+		file := mockFileADV(t)
+		file.ADVControl.BlockCount = 999
+		err := file.isBlockCount(true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "BlockCount")
+	})
+}
+
+func TestFile_isBatchCount(t *testing.T) {
+	t.Run("valid batch count non-ADV", func(t *testing.T) {
+		file := mockFilePPD(t)
+		err := file.isBatchCount(false)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid batch count non-ADV", func(t *testing.T) {
+		file := mockFilePPD(t)
+		file.Control.BatchCount = 999
+		err := file.isBatchCount(false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "BatchCount")
+	})
+
+	t.Run("valid batch count ADV", func(t *testing.T) {
+		file := mockFileADV(t)
+		err := file.isBatchCount(true)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid batch count ADV", func(t *testing.T) {
+		file := mockFileADV(t)
+		file.ADVControl.BatchCount = 999
+		err := file.isBatchCount(true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "BatchCount")
+	})
+
+	t.Run("multiple batches", func(t *testing.T) {
+		file := mockFilePPD(t)
+		file.AddBatch(mockBatchPPD(t))
+		require.NoError(t, file.Create())
+
+		err := file.isBatchCount(false)
+		require.NoError(t, err)
+	})
+
+	t.Run("with IAT batches", func(t *testing.T) {
+		file := mockFilePPD(t)
+		file.AddIATBatch(mockIATBatch(t))
+		require.NoError(t, file.Create())
+
+		err := file.isBatchCount(false)
+		require.NoError(t, err)
+	})
+}

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -684,12 +684,10 @@ func (iatBatch *IATBatch) Validate() error {
 //
 // The first error encountered is returned.
 func (batch *IATBatch) ValidateTotals() error {
-	_, err := batch.isBatchEntryCount()
-	if err != nil {
+	if _, err := batch.isBatchEntryCount(); err != nil {
 		return err
 	}
-	err = batch.isBatchAmount()
-	if err != nil {
+	if err := batch.isBatchAmount(); err != nil {
 		return err
 	}
 	return nil

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -116,18 +116,12 @@ func (iatBatch *IATBatch) verify() error {
 			return fieldError("CompanyIdentification", err, iatBatch.Control.CompanyIdentification)
 		}
 	}
-	if _, err := iatBatch.isBatchEntryCount(); err != nil {
-		return err
-	}
 	if iatBatch.validateOpts == nil || !iatBatch.validateOpts.CustomTraceNumbers {
 		if err := iatBatch.isSequenceAscending(); err != nil {
 			return err
 		}
 	}
-	if err := iatBatch.isBatchAmount(); err != nil {
-		return err
-	}
-	if err := iatBatch.isEntryHash(); err != nil {
+	if err := iatBatch.ValidateTotals(); err != nil {
 		return err
 	}
 	if iatBatch.validateOpts == nil || !iatBatch.validateOpts.CustomTraceNumbers {
@@ -679,7 +673,7 @@ func (iatBatch *IATBatch) Validate() error {
 	return nil
 }
 
-// ValidateTotals performs checks on the dollar and entry addenda totals of the batch
+// ValidateTotals performs checks on: 1. Batch entry count 2. Batch credit/debit totals of the 3. Batch entry hash
 // ValidateTotals will never modify the Batch.
 //
 // The first error encountered is returned.
@@ -688,6 +682,9 @@ func (batch *IATBatch) ValidateTotals() error {
 		return err
 	}
 	if err := batch.isBatchAmount(); err != nil {
+		return err
+	}
+	if err := batch.isEntryHash(); err != nil {
 		return err
 	}
 	return nil

--- a/iatBatch.go
+++ b/iatBatch.go
@@ -679,6 +679,22 @@ func (iatBatch *IATBatch) Validate() error {
 	return nil
 }
 
+// ValidateTotals performs checks on the dollar and entry addenda totals of the batch
+// ValidateTotals will never modify the Batch.
+//
+// The first error encountered is returned.
+func (batch *IATBatch) ValidateTotals() error {
+	_, err := batch.isBatchEntryCount()
+	if err != nil {
+		return err
+	}
+	err = batch.isBatchAmount()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // SetValidation stores ValidateOpts on the Batch which are to be used to override
 // the default NACHA validation rules.
 func (iatBatch *IATBatch) SetValidation(opts *ValidateOpts) {

--- a/iatBatch_test.go
+++ b/iatBatch_test.go
@@ -2179,3 +2179,82 @@ func TestIATBatch_DeleteEntries(t *testing.T) {
 	require.Len(t, mockBatch.Entries, 1)
 	require.Equal(t, "1", mockBatch.Entries[0].TraceNumber)
 }
+
+// TestIATBatch_ValidateTotals tests the ValidateTotals method
+func TestIATBatch_ValidateTotals(t *testing.T) {
+	t.Run("valid IAT batch", func(t *testing.T) {
+		batch := mockIATBatch(t)
+		err := batch.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid IAT batch with multiple entries", func(t *testing.T) {
+		batch := mockIATBatchManyEntries(t)
+		err := batch.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("entry count mismatch", func(t *testing.T) {
+		batch := mockIATBatch(t)
+		// Corrupt the entry count in control record
+		batch.Control.EntryAddendaCount = 999
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "EntryAddendaCount")
+	})
+
+	t.Run("debit amount mismatch", func(t *testing.T) {
+		batch := mockIATBatch(t)
+		// Corrupt the debit amount in control record
+		batch.Control.TotalDebitEntryDollarAmount = 999999
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalDebitEntryDollarAmount")
+	})
+
+	t.Run("credit amount mismatch", func(t *testing.T) {
+		batch := mockIATBatch(t)
+		// Change entry to credit and corrupt credit amount
+		batch.Entries[0].TransactionCode = CheckingCredit
+		batch.Control.TotalCreditEntryDollarAmount = 999999
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalCreditEntryDollarAmount")
+	})
+
+	t.Run("batch with zero amounts", func(t *testing.T) {
+		batch := IATBatch{}
+		batch.SetHeader(mockIATBatchHeaderFF())
+
+		// Add entry with zero amount
+		entry := mockIATEntryDetail()
+		entry.Amount = 0
+		entry.Addenda10 = mockAddenda10()
+		entry.Addenda11 = mockAddenda11()
+		entry.Addenda12 = mockAddenda12()
+		entry.Addenda13 = mockAddenda13()
+		entry.Addenda14 = mockAddenda14()
+		entry.Addenda15 = mockAddenda15()
+		entry.Addenda16 = mockAddenda16()
+		batch.AddEntry(entry)
+
+		require.NoError(t, batch.build())
+
+		err := batch.ValidateTotals()
+		require.NoError(t, err)
+	})
+
+	t.Run("multiple entries with amount mismatch", func(t *testing.T) {
+		batch := mockIATBatchManyEntries(t)
+		// Corrupt one of the entry amounts but don't update control
+		originalAmount := batch.Entries[0].Amount
+		batch.Entries[0].Amount = originalAmount + 100000
+
+		err := batch.ValidateTotals()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "TotalCreditEntryDollarAmount")
+	})
+}

--- a/test/issues/issue1275_test.go
+++ b/test/issues/issue1275_test.go
@@ -38,6 +38,8 @@ func TestIssue1275(t *testing.T) {
 	entries[0].Addenda11 = nil
 	entries[0].Addenda12 = nil
 	entries[0].Addenda14 = nil
+	b1.Control.EntryAddendaCount = b1.Control.EntryAddendaCount - 3
+	file.Control.EntryAddendaCount = file.Control.EntryAddendaCount - 3
 
 	expectedLines := []string{
 		`101 121042882 2313801041908071540A094101Bank                   My Bank Name                   `,
@@ -59,8 +61,8 @@ func TestIssue1275(t *testing.T) {
 		`71598746549321398718 Fifth Street                                                      0000002`,
 		`716LetterTown*AB\                     CA*80014\                                        0000002`,
 		`718Bank of Fr` + "`" + `nce                     01456456456987987                   FR       00010000002`,
-		`82000000200024208576000000100000000000100000                                   231380100000001`,
-		`9000001000003000000200024208576000000100000000000100000                                       `,
+		`82000000170024208576000000100000000000100000                                   231380100000001`,
+		`9000001000003000000170024208576000000100000000000100000                                       `,
 	}
 
 	t.Run("with padding", func(t *testing.T) {
@@ -76,8 +78,34 @@ func TestIssue1275(t *testing.T) {
 		require.Equal(t, expected, buf.String())
 	})
 
+	expectedLines = []string{
+		`101 121042882 2313801041908071540A094101Bank                   My Bank Name                   `,
+		`5200                FF3               US123456789 IATTRADEPAYMTCADUSD190808   0231380100000001`,
+		`6271210428820007             0000100000123456789                              1231380100000001`,
+		`710ANN000000000000100000928383-23938          BEK Enterprises                          0000001`,
+		`713Wells Fargo                        01231380104                         US           0000001`,
+		`7159874654932139872121 Front Street                                                    0000001`,
+		`716LetterTown*AB\                     CA*80014\                                        0000001`, // [6]
+		`717This is an international payment                                                00020000001`,
+		`717This is an international payment                                                00020000001`,
+		`718Bank of Fr` + "`" + `nce                     01456456456987987                   FR       00010000001`,
+		`6221210428820007             0000100000123456789                              1231380100000002`,
+		`710ANN000000000000100000928383-23938          ADCAF Enterprises                        0000002`,
+		`711ADCAF Solutions                    15 West Place Street                             0000002`,
+		`712JacobsTown*PA\                     US*19305\                                        0000002`,
+		`713Wells Fargo                        01231380104                         US           0000002`,
+		`714Citadel Bank                       01121042882                         CA           0000002`,
+		`71598746549321398718 Fifth Street                                                      0000002`,
+		`716LetterTown*AB\                     CA*80014\                                        0000002`,
+		`718Bank of Fr` + "`" + `nce                     01456456456987987                   FR       00010000002`,
+		`82000000160024208576000000100000000000100000                                   231380100000001`,
+		`9000001000003000000160024208576000000100000000000100000                                       `,
+	}
+
 	t.Run("no padding", func(t *testing.T) {
 		entries[0].Addenda16 = nil
+		b1.Control.EntryAddendaCount = b1.Control.EntryAddendaCount - 1
+		file.Control.EntryAddendaCount = file.Control.EntryAddendaCount - 1
 		lines := append(expectedLines[:6], expectedLines[7:]...)
 
 		var buf bytes.Buffer


### PR DESCRIPTION
Adds functionality requested in https://github.com/moov-io/ach/issues/1570

This PR exposes a new function `ValidateTotals()`. This checks only the credit and debit entry amounts + the entry addenda counts.