### PR TITLE
fix: parse BatchControl by rune to prevent multibyte field misalignment

### DIFF
--- a/batchControl.go
+++ b/batchControl.go
@@ -99,27 +99,40 @@ func (bc *BatchControl) Parse(record string) {
 		return
 	}
 
+	// Precompute byte positions for all rune boundaries (0 to 94) so multi-byte
+	// UTF-8 in a field (e.g. an accented CompanyIdentification) does not shift the
+	// byte offsets of the fields that follow it. Field slices below are zero-copy
+	// byte substrings. Mirrors EntryDetail.Parse.
+	bytePositions := make([]int, 95)
+	byteIndex := 0
+	for i := 0; i < 94; i++ {
+		bytePositions[i] = byteIndex
+		_, size := utf8.DecodeRuneInString(record[byteIndex:])
+		byteIndex += size
+	}
+	bytePositions[94] = byteIndex
+
 	// 1-1 Always "8"
 	// 2-4 This is the same as the "Service code" field in previous Batch Header Record
-	bc.ServiceClassCode = bc.parseNumField(record[1:4])
+	bc.ServiceClassCode = bc.parseNumField(record[bytePositions[1]:bytePositions[4]])
 	// 5-10 Total number of Entry Detail Record in the batch
-	bc.EntryAddendaCount = bc.parseNumField(record[4:10])
+	bc.EntryAddendaCount = bc.parseNumField(record[bytePositions[4]:bytePositions[10]])
 	// 11-20 Total of all positions 4-11 on each Entry Detail Record in the batch. This is essentially the sum of all the RDFI routing numbers in the batch.
 	// If the sum exceeds 10 digits (because you have lots of Entry Detail Records), lop off the most significant digits of the sum until there are only 10
-	bc.EntryHash = bc.parseNumField(record[10:20])
+	bc.EntryHash = bc.parseNumField(record[bytePositions[10]:bytePositions[20]])
 	// 21-32 Number of cents of debit entries within the batch
-	bc.TotalDebitEntryDollarAmount = bc.parseNumField(record[20:32])
+	bc.TotalDebitEntryDollarAmount = bc.parseNumField(record[bytePositions[20]:bytePositions[32]])
 	// 33-44 Number of cents of credit entries within the batch
-	bc.TotalCreditEntryDollarAmount = bc.parseNumField(record[32:44])
+	bc.TotalCreditEntryDollarAmount = bc.parseNumField(record[bytePositions[32]:bytePositions[44]])
 	// 45-54 This is the same as the "Company identification" field in previous Batch Header Record
-	bc.CompanyIdentification = bc.parseStringFieldWithOpts(record[44:54], bc.validateOpts)
+	bc.CompanyIdentification = bc.parseStringFieldWithOpts(record[bytePositions[44]:bytePositions[54]], bc.validateOpts)
 	// 55-73 Seems to always be blank
-	bc.MessageAuthenticationCode = bc.parseStringFieldWithOpts(record[54:73], bc.validateOpts)
+	bc.MessageAuthenticationCode = bc.parseStringFieldWithOpts(record[bytePositions[54]:bytePositions[73]], bc.validateOpts)
 	// 74-79 Always blank (just fill with spaces)
 	// 80-87 This is the same as the "ODFI identification" field in previous Batch Header Record
-	bc.ODFIIdentification = bc.parseStringFieldWithOpts(record[79:87], bc.validateOpts)
+	bc.ODFIIdentification = bc.parseStringFieldWithOpts(record[bytePositions[79]:bytePositions[87]], bc.validateOpts)
 	// 88-94 This is the same as the "Batch number" field in previous Batch Header Record
-	bc.BatchNumber = bc.parseNumField(record[87:94])
+	bc.BatchNumber = bc.parseNumField(record[bytePositions[87]:bytePositions[94]])
 }
 
 // NewBatchControl returns a new BatchControl with default values for none exported fields

--- a/batchControl_test.go
+++ b/batchControl_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/moov-io/base"
 	"github.com/stretchr/testify/require"
@@ -306,6 +307,27 @@ func testBatchControlLength(t testing.TB) {
 }
 
 // TestBatchControlLength tests verifying batch control length
+// TestBatchControl__ParseUTF8RoundTrip verifies that a multi-byte UTF-8 rune in a
+// variable field (here CompanyIdentification) does not shift the byte offsets of
+// the fields that follow it. Parse indexes by rune, so the trailing fields must
+// round-trip unchanged even though the encoded record is longer in bytes than runes.
+func TestBatchControl__ParseUTF8RoundTrip(t *testing.T) {
+	bc := mockBatchControl()
+	bc.CompanyIdentification = "Café12345" // 9 runes, 10 bytes (é is 2 bytes)
+
+	line := bc.String()
+	require.Equal(t, 94, utf8.RuneCountInString(line))
+	require.Greater(t, len(line), 94, "record should be longer in bytes than runes")
+
+	parsed := NewBatchControl()
+	parsed.Parse(line)
+
+	require.Equal(t, bc.CompanyIdentification, parsed.CompanyIdentification)
+	require.Equal(t, bc.ODFIIdentification, parsed.ODFIIdentification)
+	require.Equal(t, bc.BatchNumber, parsed.BatchNumber)
+	require.Equal(t, bc.EntryHash, parsed.EntryHash)
+}
+
 func TestBatchControlLength(t *testing.T) {
 	testBatchControlLength(t)
 }

--- a/batchControl_test.go
+++ b/batchControl_test.go
@@ -313,7 +313,7 @@ func testBatchControlLength(t testing.TB) {
 // round-trip unchanged even though the encoded record is longer in bytes than runes.
 func TestBatchControl__ParseUTF8RoundTrip(t *testing.T) {
 	bc := mockBatchControl()
-	bc.CompanyIdentification = "Café12345" // 9 runes, 10 bytes (é is 2 bytes)
+	bc.CompanyIdentification = "Caféé12345"
 
 	line := bc.String()
 	require.Equal(t, 94, utf8.RuneCountInString(line))


### PR DESCRIPTION
Fixes #1795

## Problem

`BatchControl.Parse` gates record length by **rune** count (`utf8.RuneCountInString(record) != 94`) but then extracts every field by **byte** offset (`record[44:54]`, etc.). A multi-byte UTF-8 value in a variable field — e.g. an accented `CompanyIdentification` like `Café12345` (9 runes, 10 bytes) — shifts the byte offsets of every following field. `ODFIIdentification`, `BatchNumber`, and `EntryHash` are then read from the wrong positions.

This is the only record parser still slicing by byte; `EntryDetail.Parse` and the others already index rune-aware.

## Fix

Index the record via `[]rune(record)` and slice the same field offsets, matching the existing rune-aware parsers. ASCII records are unaffected (rune index == byte index), so all existing tests stay green.

## Test

`TestBatchControl__ParseUTF8RoundTrip` builds a `BatchControl` with a multibyte `CompanyIdentification`, encodes, and re-parses. It **fails on master** (`ODFIIdentification` `12104288`→`1210428`) and **passes with this change**.