### PR TITLE
test(fuzz): harden ACH reader/writer fuzzers with round-trip seeds

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,11 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         command:
-          - "go test ./addenda/... -fuzz Fuzz -fuzztime 10m"
-          - "go test ./test/fuzz/... -fuzz ACH -fuzztime 10m"
-          - "go test ./test/fuzz/... -fuzz JSON -fuzztime 10m"
+          - "go test ./addenda/... -fuzz FuzzParseTXP -fuzztime 10m"
+          - "go test ./test/fuzz/... -fuzz FuzzReaderWriterACH -fuzztime 10m"
+          - "go test ./test/fuzz/... -fuzz FuzzReaderWriterJSON -fuzztime 10m"
 
     steps:
     - name: Set up Go 1.x
@@ -37,5 +38,4 @@ jobs:
     - name: Report Failures
       if: ${{ failure() }}
       run: |
-        find ./addenda/testdata/fuzz/ -type f | xargs -n1 tail -n +1 -v
-        find ./test/fuzz/testdata/fuzz/ -type f | xargs -n1 tail -n +1 -v
+        find . -path '*/testdata/fuzz/*' -type f 2>/dev/null | xargs -r -n1 tail -n +1 -v || true

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"io/fs"
 	"os"
@@ -15,24 +16,37 @@ func FuzzReaderWriterACH(f *testing.F) {
 	populateCorpus(f, true)
 
 	f.Fuzz(func(t *testing.T, contents string) {
-		// Read the sample file
+		if len(contents) > 1<<20 {
+			t.Skip()
+		}
+
+		// Read the sample file with validation skipped so more inputs parse.
 		r := ach.NewReader(strings.NewReader(contents))
 		r.SetValidation(&ach.ValidateOpts{
 			SkipAll: true,
 		})
 		file, err := r.Read()
 		if err != nil {
-			t.Skip()
+			return
 		}
 
 		// Write the file
-		ach.NewWriter(io.Discard).Write(&file)
+		var buf bytes.Buffer
+		if err := ach.NewWriter(&buf).Write(&file); err != nil {
+			// Write errors are fine; panics are not.
+			_ = ach.NewWriter(io.Discard).Write(&file)
+		}
 
-		// Remove Validation override
-		file.SetValidation(&ach.ValidateOpts{
-			SkipAll: false,
-		})
-		file.Validate()
+		// Re-read what we wrote (round trip)
+		if buf.Len() > 0 {
+			r2 := ach.NewReader(bytes.NewReader(buf.Bytes()))
+			r2.SetValidation(&ach.ValidateOpts{SkipAll: true})
+			_, _ = r2.Read()
+		}
+
+		// Validate without SkipAll — must not panic
+		file.SetValidation(&ach.ValidateOpts{SkipAll: false})
+		_ = file.Validate()
 	})
 }
 
@@ -40,37 +54,52 @@ func FuzzReaderWriterJSON(f *testing.F) {
 	populateCorpus(f, false)
 
 	f.Fuzz(func(t *testing.T, contents string) {
-		file, err := ach.FileFromJSONWith([]byte(contents), &ach.ValidateOpts{
-			SkipAll: true,
-		})
-		if err != nil {
+		if len(contents) > 1<<20 {
 			t.Skip()
 		}
 
-		// Write the file
-		file.MarshalJSON()
-
-		// Remove Validation override
-		file.SetValidation(&ach.ValidateOpts{
-			SkipAll: false,
+		file, err := ach.FileFromJSONWith([]byte(contents), &ach.ValidateOpts{
+			SkipAll: true,
 		})
-		file.Validate()
+		if err != nil || file == nil {
+			return
+		}
+
+		_, _ = file.MarshalJSON()
+
+		file.SetValidation(&ach.ValidateOpts{SkipAll: false})
+		_ = file.Validate()
+
+		_ = ach.NewWriter(io.Discard).Write(file)
 	})
 }
 
-func populateCorpus(f *testing.F, ach bool) {
+func populateCorpus(f *testing.F, achFiles bool) {
 	f.Helper()
 
+	f.Add("")
+	f.Add("{}")
+
 	err := filepath.Walk(filepath.Join("..", ".."), func(path string, info fs.FileInfo, err error) error {
-		if info.IsDir() {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		// Skip generated fuzz cache and vendor-like trees
+		if strings.Contains(path, string(filepath.Separator)+"testdata"+string(filepath.Separator)+"fuzz") {
+			return nil
+		}
+		if strings.Contains(path, ".git") {
 			return nil
 		}
 
 		ext := filepath.Ext(strings.ToLower(path))
-		if (ext == ".ach" && ach) || (ext == ".json" && !ach) {
+		if (ext == ".ach" && achFiles) || (ext == ".json" && !achFiles) {
 			bs, err := os.ReadFile(path)
 			if err != nil {
-				f.Fatal(err)
+				return nil
+			}
+			if len(bs) > 256*1024 {
+				return nil
 			}
 			f.Add(string(bs))
 		}


### PR DESCRIPTION
## Summary
Improve native Go fuzzers for ACH file and JSON parsing using real `.ach`/`.json` samples from the repo. Bound input size, skip validation on first parse so more seeds exercise the writer path, then round-trip re-read written output.

## Test plan
- [x] `go test` for affected packages
- [x] `go test -run='^$' -fuzz=Fuzz... -fuzztime=3s` smoke on new/updated fuzzers
- [x] Regression tests for any panics fixed by fuzzing