### PR TITLE
fix(server): require CORS origin allowlist for credentialed responses

### DIFF
--- a/server/cors.go
+++ b/server/cors.go
@@ -1,0 +1,80 @@
+// Licensed to The Moov Authors under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. The Moov Authors licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package server
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+// CORSAllowedOriginsEnv is a comma-separated list of exact Origins permitted for
+// credentialed CORS. Example: "https://moov.io,https://dashboard.moov.io".
+// Localhost (http://localhost:<port>) remains allowed for development.
+//
+// Temporary ACH-local allowlist until moov-io/base#509 lands and is bumped here.
+const CORSAllowedOriginsEnv = "MOOV_CORS_ALLOW_ORIGINS"
+
+var (
+	corsAllowlistOnce sync.Once
+	corsAllowlist     map[string]struct{}
+)
+
+func loadCORSAllowlist() map[string]struct{} {
+	corsAllowlistOnce.Do(func() {
+		corsAllowlist = make(map[string]struct{})
+		for _, part := range strings.Split(os.Getenv(CORSAllowedOriginsEnv), ",") {
+			origin := strings.TrimSpace(part)
+			if origin != "" {
+				corsAllowlist[origin] = struct{}{}
+			}
+		}
+	})
+	return corsAllowlist
+}
+
+// resetCORSAllowlistForTest clears the cached allowlist. Intended for tests only.
+func resetCORSAllowlistForTest() {
+	corsAllowlistOnce = sync.Once{}
+	corsAllowlist = nil
+}
+
+func originAllowedForCORS(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	if strings.HasPrefix(origin, "http://localhost:") {
+		return true
+	}
+	_, ok := loadCORSAllowlist()[origin]
+	return ok
+}
+
+// setAccessControlAllowHeaders writes Access-Control-Allow-* headers only for
+// allowlisted Origins. Do not call moov-io/base's reflector until it gains an
+// allowlist (base#509).
+func setAccessControlAllowHeaders(w http.ResponseWriter, origin string) {
+	if !originAllowedForCORS(origin) {
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PATCH,DELETE,OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-User-Id,X-Request-Id,Content-Type")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+}

--- a/server/routing.go
+++ b/server/routing.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	"github.com/moov-io/base"
-	moovhttp "github.com/moov-io/base/http"
 	"github.com/moov-io/base/log"
 
 	"github.com/go-kit/kit/endpoint"
@@ -72,7 +71,7 @@ func respondWithSavedCORSHeaders() httptransport.ServerResponseFunc {
 	return func(ctx context.Context, w http.ResponseWriter) context.Context {
 		v, ok := ctx.Value(contextKey).(string)
 		if ok && v != "" {
-			moovhttp.SetAccessControlAllowHeaders(w, v) // set CORS headers
+			setAccessControlAllowHeaders(w, v) // set CORS headers (allowlisted only)
 		}
 		return ctx
 	}
@@ -111,7 +110,7 @@ func MakeHTTPHandler(s Service, repo Repository, kitlog gokitlog.Logger) http.Ha
 	// HTTP Methods
 	r.Methods("OPTIONS").Handler(preflightHandler(options)) // CORS pre-flight handler
 	r.Methods("GET").Path("/ping").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		moovhttp.SetAccessControlAllowHeaders(w, r.Header.Get("Origin"))
+		setAccessControlAllowHeaders(w, r.Header.Get("Origin"))
 		w.Header().Set("Content-Type", "text/plain")
 		w.Write([]byte("PONG"))
 	})

--- a/server/routing_test.go
+++ b/server/routing_test.go
@@ -53,7 +53,16 @@ func TestRouting_codeFrom(t *testing.T) {
 	}
 }
 
+func withCORSAllowOrigins(t *testing.T, origins string) {
+	t.Helper()
+	t.Setenv(CORSAllowedOriginsEnv, origins)
+	resetCORSAllowlistForTest()
+	t.Cleanup(resetCORSAllowlistForTest)
+}
+
 func TestRouting_ping(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+
 	logger := log.NewNopLogger()
 	r := NewRepositoryInMemory(1*time.Minute, logger)
 	svc := NewService(r)
@@ -165,6 +174,8 @@ func TestBatchesXTotalCountHeader(t *testing.T) {
 }
 
 func TestRouting__CORSHeaders(t *testing.T) {
+	withCORSAllowOrigins(t, "https://api.moov.io")
+
 	ctx := context.TODO()
 	req := httptest.NewRequest("GET", "/files/create", nil)
 	req.Header.Set("Origin", "https://api.moov.io")
@@ -197,7 +208,22 @@ func TestRouting__CORSHeaders(t *testing.T) {
 	}
 }
 
+func TestRouting__CORSRejectsUnlistedOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+
+	w := httptest.NewRecorder()
+	setAccessControlAllowHeaders(w, "https://evil.example")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("expected no ACAO for unlisted origin, got %q", v)
+	}
+	if v := w.Header().Get("Access-Control-Allow-Credentials"); v != "" {
+		t.Errorf("expected no credentials header for unlisted origin, got %q", v)
+	}
+}
+
 func TestPreflightHandler(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+
 	options := []httptransport.ServerOption{
 		httptransport.ServerBefore(saveCORSHeadersIntoContext()),
 		httptransport.ServerAfter(respondWithSavedCORSHeaders()),


### PR DESCRIPTION
## Summary
- ACH routed CORS through `moov-io/base` `SetAccessControlAllowHeaders`, which reflects any `https://` Origin with `Access-Control-Allow-Credentials: true`.
- Add an ACH-local allowlist via `MOOV_CORS_ALLOW_ORIGINS` (exact Origins); keep `http://localhost:<port>` for local development.
- Temporary until [moov-io/base#509](https://github.com/moov-io/base/pull/509) merges and can be bumped here.

## Test plan
- [x] `go test ./server/ -run 'CORS|ping|Preflight' -count=1`
- [x] Unlisted `https://evil.example` gets no ACAO/ACAC

## Deploy note
Set `MOOV_CORS_ALLOW_ORIGINS=https://moov.io,...` in environments that rely on credentialed browser calls.


Made with [Cursor](https://cursor.com)