### PR TITLE
fix(deps): bump moov-io/base to v0.63.0 for CORS origin allowlist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/igrmk/treemap/v2 v2.0.1
 	github.com/juju/ansiterm v1.0.0
-	github.com/moov-io/base v0.62.1
+	github.com/moov-io/base v0.63.0
 	github.com/moov-io/iso3166 v0.4.0
 	github.com/moov-io/iso4217 v0.4.0
 	github.com/prometheus/client_golang v1.24.1
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
-	github.com/rickar/cal/v2 v2.1.28 // indirect
+	github.com/rickar/cal/v2 v2.1.29 // indirect
 	golang.org/x/exp v0.0.0-20260529124908-c761662dc8c9 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/moov-io/base v0.62.1 h1:nM+RdTWMsWaUd572D/Hitgf+wND6vnfnYjM9MNWLd7g=
-github.com/moov-io/base v0.62.1/go.mod h1:Rndo5mNk38K74u6zTA8K5pxpsgmnK7CirAf++zXuWuM=
+github.com/moov-io/base v0.63.0 h1:J2dGj5z5X2dbLumWkbCCjM6rWycf/Zfdvk31fHJQjZk=
+github.com/moov-io/base v0.63.0/go.mod h1:7lW1P0fiFOrINtS2zoxYtvTgvhdI0EcGSi5J//pIZcY=
 github.com/moov-io/iso3166 v0.4.0 h1:WtXIptANC16DrHpbSAt4+itFciCCnA+C6eAi9k7HEsA=
 github.com/moov-io/iso3166 v0.4.0/go.mod h1:13ubAoOZNfWzs2fN3x467zg8q982U867Ee+ulqrArlM=
 github.com/moov-io/iso4217 v0.4.0 h1:+97e9chdg8Cx3kMLmGmvN64+CtmtodPLfUT2PaCXUUE=
@@ -64,8 +64,8 @@ github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi
 github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/rickar/cal/v2 v2.1.28 h1:PLNjsw5YrCMkcE+EtD/wFh0Ys+a4Qp9yN6SKyksVso0=
-github.com/rickar/cal/v2 v2.1.28/go.mod h1:/fdlMcx7GjPlIBibMzOM9gMvDBsrK+mOtRXdTzUqV/A=
+github.com/rickar/cal/v2 v2.1.29 h1:VDs0S1RZTD7DUbc/pDBdZyTMOQn0uOf5Qjz3sIpaeAU=
+github.com/rickar/cal/v2 v2.1.29/go.mod h1:/fdlMcx7GjPlIBibMzOM9gMvDBsrK+mOtRXdTzUqV/A=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/server/routing_test.go
+++ b/server/routing_test.go
@@ -29,11 +29,18 @@ import (
 	"time"
 
 	"github.com/moov-io/ach"
+	moovhttp "github.com/moov-io/base/http"
 	"github.com/moov-io/base/log"
 
 	httptransport "github.com/go-kit/kit/transport/http"
 	kitlog "github.com/go-kit/log"
 )
+
+func withCORSAllowOrigins(t *testing.T, origins ...string) {
+	t.Helper()
+	moovhttp.SetCORSAllowedOrigins(origins)
+	t.Cleanup(moovhttp.ResetCORSAllowlistForTest)
+}
 
 func TestRouting_codeFrom(t *testing.T) {
 	if v := codeFrom(nil); v != http.StatusOK {
@@ -54,6 +61,8 @@ func TestRouting_codeFrom(t *testing.T) {
 }
 
 func TestRouting_ping(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+
 	logger := log.NewNopLogger()
 	r := NewRepositoryInMemory(1*time.Minute, logger)
 	svc := NewService(r)
@@ -165,6 +174,8 @@ func TestBatchesXTotalCountHeader(t *testing.T) {
 }
 
 func TestRouting__CORSHeaders(t *testing.T) {
+	withCORSAllowOrigins(t, "https://api.moov.io")
+
 	ctx := context.TODO()
 	req := httptest.NewRequest("GET", "/files/create", nil)
 	req.Header.Set("Origin", "https://api.moov.io")
@@ -197,7 +208,22 @@ func TestRouting__CORSHeaders(t *testing.T) {
 	}
 }
 
+func TestRouting__CORSRejectsUnlistedOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+
+	w := httptest.NewRecorder()
+	moovhttp.SetAccessControlAllowHeaders(w, "https://evil.example")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("expected no ACAO for unlisted origin, got %q", v)
+	}
+	if v := w.Header().Get("Access-Control-Allow-Credentials"); v != "" {
+		t.Errorf("expected no credentials header, got %q", v)
+	}
+}
+
 func TestPreflightHandler(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+
 	options := []httptransport.ServerOption{
 		httptransport.ServerBefore(saveCORSHeadersIntoContext()),
 		httptransport.ServerAfter(respondWithSavedCORSHeaders()),


### PR DESCRIPTION
## Summary
- Bump `github.com/moov-io/base` to **[v0.63.0](https://github.com/moov-io/base/releases/tag/v0.63.0)**.
- Credentialed CORS now uses base's shared allowlist (`MOOV_CORS_ALLOW_ORIGINS` / `SetCORSAllowedOrigins`) via existing `AddCORSHandler` / `SetAccessControlAllowHeaders` / `Wrap` call sites — **no service-local CORS fork**.
- Tests cover listed / unlisted / localhost Origins using the base API.

Supersedes #1830 (local allowlist copy).

## Deploy note
Set `MOOV_CORS_ALLOW_ORIGINS=https://…` (exact browser Origins) wherever credentialed cross-origin browser calls are expected. Server-to-server clients are unaffected.

## Test plan
- [x] `go test` for CORS-related packages
- [ ] Confirm deploy sets `MOOV_CORS_ALLOW_ORIGINS` before relying on browser credentialed CORS