### PR TITLE
fix(server): reject oversized request bodies instead of truncating

### DIFF
--- a/server/files.go
+++ b/server/files.go
@@ -166,6 +166,9 @@ func decodeCreateFileRequest(_ context.Context, request *http.Request) (interfac
 
 const defaultMaxBodySize int64 = 10 * 1024 * 1024 // 10MB
 
+// ErrRequestBodyTooLarge is returned when an HTTP request body exceeds MaxBodySize.
+var ErrRequestBodyTooLarge = errors.New("request body too large")
+
 // maxBodySize is the maximum number of bytes read from an HTTP request body.
 // Override with ACH_MAX_BODY_SIZE (see ParseMaxBodySize / SetMaxBodySize).
 var maxBodySize = defaultMaxBodySize
@@ -219,11 +222,17 @@ func ConfigureMaxBodySizeFromEnv() (int64, error) {
 func readBody(body io.ReadCloser) ([]byte, error) {
 	defer body.Close()
 
-	r := io.LimitReader(body, maxBodySize)
+	// Read one byte past the limit so we can reject oversized bodies instead of
+	// silently truncating with io.LimitReader (which would leave a partial parse
+	// that createFileEndpoint could still store).
+	r := io.LimitReader(body, maxBodySize+1)
 
 	bs, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("reading request body: %w", err)
+	}
+	if int64(len(bs)) > maxBodySize {
+		return nil, fmt.Errorf("%w: max %d bytes", ErrRequestBodyTooLarge, maxBodySize)
 	}
 	return bs, nil
 }

--- a/server/files_test.go
+++ b/server/files_test.go
@@ -1694,10 +1694,65 @@ func TestReadBodyRespectsMaxBodySize(t *testing.T) {
 	})
 
 	SetMaxBodySize(16)
-	body := io.NopCloser(strings.NewReader(strings.Repeat("a", 64)))
+
+	// Bodies within the limit are accepted in full.
+	body := io.NopCloser(strings.NewReader(strings.Repeat("a", 16)))
 	bs, err := readBody(body)
 	require.NoError(t, err)
 	require.Len(t, bs, 16)
+
+	// Bodies over the limit are rejected rather than silently truncated.
+	body = io.NopCloser(strings.NewReader(strings.Repeat("a", 64)))
+	bs, err = readBody(body)
+	require.ErrorIs(t, err, ErrRequestBodyTooLarge)
+	require.Nil(t, bs)
+}
+
+func TestCreateFileRejectsOversizedBody(t *testing.T) {
+	original := MaxBodySize()
+	t.Cleanup(func() {
+		SetMaxBodySize(original)
+	})
+
+	// Build a valid ACH JSON file, then pad it past a tight body limit so that a
+	// silent truncate would still leave parseable JSON prefix content.
+	f := ach.NewFile()
+	f.ID = "oversized-should-not-store"
+	f.Header = *mockFileHeader()
+	batch := mockBatchWEB(t)
+	batch.Entries[0].TraceNumber = "121042880000007"
+	f.AddBatch(batch)
+
+	var body bytes.Buffer
+	require.NoError(t, json.NewEncoder(&body).Encode(f))
+	// Pad with spaces after the JSON object; truncation mid-pad would still parse.
+	body.WriteString(strings.Repeat(" ", 256))
+
+	// Limit smaller than the full payload but large enough that a truncated read
+	// could still produce a partial *ach.File under the old LimitReader behavior.
+	require.Greater(t, body.Len(), 64)
+	SetMaxBodySize(int64(body.Len() - 32))
+
+	repo := NewRepositoryInMemory(testTTLDuration, log.NewNopLogger())
+	svc := NewService(repo)
+	handler := MakeHTTPHandler(svc, repo, kitlog.NewNopLogger())
+
+	req := httptest.NewRequest("POST", "/files/create", bytes.NewReader(body.Bytes()))
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-request-id", "oversized-body")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "request body too large")
+
+	// Failed create must leave the repository unchanged.
+	files := svc.GetFiles()
+	require.Empty(t, files)
+
+	_, err := svc.GetFile(f.ID)
+	require.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestSetMaxBodySizeIgnoresNonPositive(t *testing.T) {

--- a/server/routing.go
+++ b/server/routing.go
@@ -331,6 +331,10 @@ func codeFrom(err error) int {
 		return http.StatusOK
 	}
 
+	if errors.Is(err, ErrRequestBodyTooLarge) {
+		return http.StatusRequestEntityTooLarge
+	}
+
 	errString := fmt.Sprintf("%#v", err)
 	if el, ok := err.(base.ErrorList); ok {
 		errString = el.Error()

--- a/server/routing_test.go
+++ b/server/routing_test.go
@@ -55,6 +55,12 @@ func TestRouting_codeFrom(t *testing.T) {
 	if v := codeFrom(ErrAlreadyExists); v != http.StatusBadRequest {
 		t.Errorf("HTTP status: %d", v)
 	}
+	if v := codeFrom(ErrRequestBodyTooLarge); v != http.StatusRequestEntityTooLarge {
+		t.Errorf("HTTP status: %d", v)
+	}
+	if v := codeFrom(fmt.Errorf("%w: max 16 bytes", ErrRequestBodyTooLarge)); v != http.StatusRequestEntityTooLarge {
+		t.Errorf("HTTP status: %d", v)
+	}
 	if v := codeFrom(errors.New("other")); v != http.StatusInternalServerError {
 		t.Errorf("HTTP status: %d", v)
 	}

--- a/server/validate.go
+++ b/server/validate.go
@@ -89,10 +89,10 @@ func readValidateOpts(request *http.Request) (io.ReadCloser, *ach.ValidateOpts, 
 		skipBatchHeaderCompanyValidation,
 	}
 
-	var buf bytes.Buffer
-
-	r := io.LimitReader(request.Body, maxBodySize)
-	bs, _ := io.ReadAll(io.TeeReader(r, &buf))
+	bs, err := readBody(request.Body)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	opts := &ach.ValidateOpts{}
 	json.Unmarshal(bs, opts)
@@ -159,5 +159,5 @@ func readValidateOpts(request *http.Request) (io.ReadCloser, *ach.ValidateOpts, 
 		}
 	}
 
-	return io.NopCloser(&buf), opts, nil
+	return io.NopCloser(bytes.NewReader(bs)), opts, nil
 }


### PR DESCRIPTION
## Summary

- Oversized HTTP request bodies are rejected with `413 Request Entity Too Large` instead of being silently truncated by `io.LimitReader`
- `readBody` reads one byte past `MaxBodySize` to detect overflow and returns `ErrRequestBodyTooLarge`
- `readValidateOpts` uses the same path so create/segment flows cannot accept a truncated body
- Failed oversized creates leave the in-memory repository unchanged (no partial file stored)

Fixes #1832

## Test plan

- [x] `go test ./server/ -run 'TestReadBodyRespectsMaxBodySize|TestCreateFileRejectsOversizedBody|TestRouting_codeFrom'`
- [x] `go test ./server/`
- [x] `go build -o /tmp/ach-server ./cmd/server/`
- [ ] Manual: set `ACH_MAX_BODY_SIZE` low, POST a larger JSON ACH file, confirm `413` and empty `GET /files`