### PR TITLE
fix: Iterator scanner errors and fixed-width rune splitting

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -109,6 +109,9 @@ start:
 				break
 			}
 		}
+		if err := i.scanner.Err(); err != nil {
+			return nil, nil, fmt.Errorf("scanning line %d failed: %w", i.reader.lineNum+1, err)
+		}
 		// If we've exhausted all lines in the reader then quit
 		if line == "" || allSpaces(line) {
 			return nil, nil, nil
@@ -181,6 +184,9 @@ start:
 						return bh, returnableEntry, nil
 					}
 				} else {
+					if err := i.scanner.Err(); err != nil {
+						return nil, nil, fmt.Errorf("scanning line %d failed: %w", i.reader.lineNum+1, err)
+					}
 					break // quit processing if we can't read another line
 				}
 			}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -18,6 +18,7 @@
 package ach
 
 import (
+	"bufio"
 	"bytes"
 	"os"
 	"path/filepath"
@@ -218,6 +219,52 @@ func TestIterator(t *testing.T) {
 			}
 		}
 		require.Len(t, entries, 1)
+	})
+
+	t.Run("scanner error on overlong line", func(t *testing.T) {
+		// bufio.Scanner stops permanently on any line over bufio.MaxScanTokenSize,
+		// so the iterator must surface the error instead of reporting a clean end of file.
+		content := `101 121042882 2313801042308080808A094101Federal Reserve Bank   My Bank Name
+5220ACME Corporation                    121042882 PPDPAYROLL         000000   1121042880000001
+622121042882123456789        0100000000ABC##jvkdjfuiwnWade Arnold             1121042880000001
+` + strings.Repeat("9", bufio.MaxScanTokenSize+1) + "\n"
+
+		iter := NewIterator(strings.NewReader(content))
+
+		var err error
+		for {
+			bh, ed, e := iter.NextEntry()
+			if e != nil {
+				err = e
+				break
+			}
+			if bh == nil && ed == nil {
+				break
+			}
+		}
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token too long")
+	})
+
+	t.Run("fixed-width file with multibyte characters", func(t *testing.T) {
+		bs, err := os.ReadFile(filepath.Join("test", "testdata", "ppd-debit-fixedLength.ach"))
+		require.NoError(t, err)
+
+		// Swap one ASCII letter for a multibyte UTF-8 character, keeping the single line's
+		// rune count an exact multiple of the 94-character record length. Validation is
+		// skipped since NACHA field rules reject non-ASCII characters outright.
+		data := strings.Replace(string(bs), "achdestname", "achdestnáme", 1)
+		require.NotEqual(t, string(bs), data)
+
+		iter := NewIterator(strings.NewReader(data))
+		iter.SetValidation(&ValidateOpts{SkipAll: true})
+
+		_, _, err = iter.NextEntry()
+		require.NoError(t, err)
+
+		header := iter.GetHeader()
+		require.NotNil(t, header)
+		require.Equal(t, "achdestnáme", header.ImmediateDestinationName)
 	})
 
 	t.Run("get header and control", func(t *testing.T) {

--- a/reader.go
+++ b/reader.go
@@ -387,17 +387,24 @@ func rightPadShortLine(s string) (string, error) {
 }
 
 func (r *Reader) processFixedWidthFile(line string) error {
-	// It should be safe to parse this byte by byte since ACH files are ASCII only.
+	// Records are RecordLength characters each, so split on rune boundaries rather
+	// than byte offsets, which desynchronize when the line contains multibyte characters.
 	record := ""
-	for i, c := range line {
+	runes := 0
+	for _, c := range line {
 		record = record + string(c)
-		if i > 0 && (i+1)%RecordLength == 0 {
+		runes++
+		if runes == RecordLength {
 			r.line = record
 			if err := r.parseLine(); err != nil {
 				return err
 			}
 			record = ""
+			runes = 0
 		}
+	}
+	if runes > 0 {
+		return r.parseError(fmt.Errorf("%d extra character(s) in ACH file: records must be %d characters", runes, RecordLength))
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

Two robustness issues in the streaming and fixed-width read paths, both reachable through `NewIterator`:

**1. `Iterator.NextEntry` silently drops entries after any line over 64KB**

`bufio.Scanner` stops permanently once a line exceeds `bufio.MaxScanTokenSize` (64KB). `NextEntry` never checks `i.scanner.Err()` after its scan loops, so when this happens the iterator returns `(nil, nil, nil)`, the exact clean end-of-file signal. Every entry after an overlong line is silently discarded with success semantics. The sibling `Reader.Read` path already checks `scanner.Err()`.

**2. Fixed-width splitter desynchronizes on multibyte input and drops the trailing record**

`processFixedWidthFile` breaks records on byte offsets (`(i+1) % RecordLength`) while the record contract is 94 characters. When the first line contains multibyte UTF-8 characters, record boundaries shift and any leftover bytes after the last 94-byte boundary are discarded without an error.

## Fix

- `iterator.go`: check `i.scanner.Err()` after both scan loops and return it wrapped with line-number context.
- `reader.go`: split fixed-width input on rune boundaries instead of byte offsets, and return an error if a partial record remains after the last full record.

## Tests

- `TestIterator/scanner_error_on_overlong_line`: a file with a line over `bufio.MaxScanTokenSize` now returns an error containing "token too long" instead of a clean EOF. Fails without the fix.
- `TestIterator/fixed-width_file_with_multibyte_characters`: a fixed-width file whose single line contains a multibyte character (rune count still an exact multiple of 94) now parses all records cleanly. Fails without the fix.

`go build`, `go vet`, and `go test ./...` pass.

Made with [Cursor](https://cursor.com)