### PR TITLE
Let the debit-only SEC types validate after a reversal

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -290,19 +290,6 @@ func ConvertBatchType(b Batch) Batcher {
 //
 // Create implementations are free to modify computable fields in a file and should
 // call the Batch's Validate function at the end of their execution.
-// IsReversal reports whether this batch was turned into a reversal, which the
-// Nacha rules signal by putting "REVERSAL" in the Company Entry Description.
-//
-// A reversal moves funds the other way, so a batch type that normally carries
-// debits only carries credits here, and its ServiceClassCode becomes
-// CreditsOnly. Validation that assumes the forward direction has to know about
-// this or it rejects a file the library itself produced.
-func (batch *Batch) IsReversal() bool {
-	if batch.Header == nil {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(batch.Header.CompanyEntryDescription), "REVERSAL")
-}
 
 func (batch *Batch) Create() error {
 	return errors.New("use an implementation of batch or NewBatch")
@@ -1096,6 +1083,14 @@ func (batch *Batch) addendaFieldInclusionReturn(entry *EntryDetail) error {
 		return batch.Error("Addenda99", ErrFieldInclusion)
 	}
 	return nil
+}
+
+// IsReversal determines if a batch carries reversing entries - see File.Reversal
+func (batch *Batch) IsReversal() bool {
+	if batch.Header == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(batch.Header.CompanyEntryDescription), "REVERSAL")
 }
 
 // IsADV determines if a batch is batch type ADV - BatchADV

--- a/batch.go
+++ b/batch.go
@@ -290,6 +290,20 @@ func ConvertBatchType(b Batch) Batcher {
 //
 // Create implementations are free to modify computable fields in a file and should
 // call the Batch's Validate function at the end of their execution.
+// IsReversal reports whether this batch was turned into a reversal, which the
+// Nacha rules signal by putting "REVERSAL" in the Company Entry Description.
+//
+// A reversal moves funds the other way, so a batch type that normally carries
+// debits only carries credits here, and its ServiceClassCode becomes
+// CreditsOnly. Validation that assumes the forward direction has to know about
+// this or it rejects a file the library itself produced.
+func (batch *Batch) IsReversal() bool {
+	if batch.Header == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(batch.Header.CompanyEntryDescription), "REVERSAL")
+}
+
 func (batch *Batch) Create() error {
 	return errors.New("use an implementation of batch or NewBatch")
 }

--- a/batchARC.go
+++ b/batchARC.go
@@ -62,10 +62,14 @@ func (batch *BatchARC) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, ARC)
 	}
 
-	// ARC detail entries can only be a debit, ServiceClassCode must allow debits
-	switch batch.Header.ServiceClassCode {
-	case CreditsOnly:
-		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+	// ARC detail entries can only be a debit, ServiceClassCode must allow debits.
+	// A reversal is the exception: it carries credits, so File.Reversal sets
+	// CreditsOnly here and this check would reject the library's own output.
+	if !batch.IsReversal() {
+		switch batch.Header.ServiceClassCode {
+		case CreditsOnly:
+			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+		}
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -80,9 +84,19 @@ func (batch *BatchARC) Validate() error {
 func (batch *BatchARC) InvalidEntries() []InvalidEntry {
 	var out []InvalidEntry
 
+	isReversal := batch.IsReversal()
+
 	for _, entry := range batch.Entries {
-		// ARC detail entries must be a debit
-		if entry.CreditOrDebit() != "D" {
+		// Forward ARC entries must be a debit. A reversal moves the funds back,
+		// so the same batch carries credits and only credits.
+		if isReversal {
+			if entry.CreditOrDebit() != "C" {
+				out = append(out, InvalidEntry{
+					Entry: entry,
+					Error: batch.Error("TransactionCode", ErrBatchCreditOnly, entry.TransactionCode),
+				})
+			}
+		} else if entry.CreditOrDebit() != "D" {
 			out = append(out, InvalidEntry{
 				Entry: entry,
 				Error: batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode),

--- a/batchARC.go
+++ b/batchARC.go
@@ -62,14 +62,9 @@ func (batch *BatchARC) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, ARC)
 	}
 
-	// ARC detail entries can only be a debit, ServiceClassCode must allow debits.
-	// A reversal is the exception: it carries credits, so File.Reversal sets
-	// CreditsOnly here and this check would reject the library's own output.
-	if !batch.IsReversal() {
-		switch batch.Header.ServiceClassCode {
-		case CreditsOnly:
-			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
-		}
+	// Forward ARC batches can only have debit entries, but REVERSAL batches can only have credits
+	if batch.Header.ServiceClassCode == CreditsOnly && !batch.IsReversal() {
+		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -87,8 +82,7 @@ func (batch *BatchARC) InvalidEntries() []InvalidEntry {
 	isReversal := batch.IsReversal()
 
 	for _, entry := range batch.Entries {
-		// Forward ARC entries must be a debit. A reversal moves the funds back,
-		// so the same batch carries credits and only credits.
+		// Forward ARC batches can only have debit entries, but REVERSAL batches can only have credits
 		if isReversal {
 			if entry.CreditOrDebit() != "C" {
 				out = append(out, InvalidEntry{

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -67,10 +67,14 @@ func (batch *BatchBOC) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, BOC)
 	}
 
-	// BOC detail entries can only be a debit, ServiceClassCode must allow debits
-	switch batch.Header.ServiceClassCode {
-	case CreditsOnly:
-		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+	// BOC detail entries can only be a debit, ServiceClassCode must allow debits.
+	// A reversal is the exception: it carries credits, so File.Reversal sets
+	// CreditsOnly here and this check would reject the library's own output.
+	if !batch.IsReversal() {
+		switch batch.Header.ServiceClassCode {
+		case CreditsOnly:
+			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+		}
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -85,9 +89,19 @@ func (batch *BatchBOC) Validate() error {
 func (batch *BatchBOC) InvalidEntries() []InvalidEntry {
 	var out []InvalidEntry
 
+	isReversal := batch.IsReversal()
+
 	for _, entry := range batch.Entries {
-		// BOC detail entries must be a debit
-		if entry.CreditOrDebit() != "D" {
+		// Forward BOC entries must be a debit. A reversal moves the funds back,
+		// so the same batch carries credits and only credits.
+		if isReversal {
+			if entry.CreditOrDebit() != "C" {
+				out = append(out, InvalidEntry{
+					Entry: entry,
+					Error: batch.Error("TransactionCode", ErrBatchCreditOnly, entry.TransactionCode),
+				})
+			}
+		} else if entry.CreditOrDebit() != "D" {
 			out = append(out, InvalidEntry{
 				Entry: entry,
 				Error: batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode),

--- a/batchBOC.go
+++ b/batchBOC.go
@@ -67,14 +67,9 @@ func (batch *BatchBOC) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, BOC)
 	}
 
-	// BOC detail entries can only be a debit, ServiceClassCode must allow debits.
-	// A reversal is the exception: it carries credits, so File.Reversal sets
-	// CreditsOnly here and this check would reject the library's own output.
-	if !batch.IsReversal() {
-		switch batch.Header.ServiceClassCode {
-		case CreditsOnly:
-			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
-		}
+	// Forward BOC batches can only have debit entries, but REVERSAL batches can only have credits
+	if batch.Header.ServiceClassCode == CreditsOnly && !batch.IsReversal() {
+		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -92,8 +87,7 @@ func (batch *BatchBOC) InvalidEntries() []InvalidEntry {
 	isReversal := batch.IsReversal()
 
 	for _, entry := range batch.Entries {
-		// Forward BOC entries must be a debit. A reversal moves the funds back,
-		// so the same batch carries credits and only credits.
+		// Forward BOC batches can only have debit entries, but REVERSAL batches can only have credits
 		if isReversal {
 			if entry.CreditOrDebit() != "C" {
 				out = append(out, InvalidEntry{

--- a/batchPOP.go
+++ b/batchPOP.go
@@ -64,14 +64,9 @@ func (batch *BatchPOP) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, POP)
 	}
 
-	// POP detail entries can only be a debit, ServiceClassCode must allow debits.
-	// A reversal is the exception: it carries credits, so File.Reversal sets
-	// CreditsOnly here and this check would reject the library's own output.
-	if !batch.IsReversal() {
-		switch batch.Header.ServiceClassCode {
-		case CreditsOnly:
-			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
-		}
+	// Forward POP batches can only have debit entries, but REVERSAL batches can only have credits
+	if batch.Header.ServiceClassCode == CreditsOnly && !batch.IsReversal() {
+		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -89,8 +84,7 @@ func (batch *BatchPOP) InvalidEntries() []InvalidEntry {
 	isReversal := batch.IsReversal()
 
 	for _, entry := range batch.Entries {
-		// Forward POP entries must be a debit. A reversal moves the funds back,
-		// so the same batch carries credits and only credits.
+		// Forward POP batches can only have debit entries, but REVERSAL batches can only have credits
 		if isReversal {
 			if entry.CreditOrDebit() != "C" {
 				out = append(out, InvalidEntry{

--- a/batchPOP.go
+++ b/batchPOP.go
@@ -64,10 +64,14 @@ func (batch *BatchPOP) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, POP)
 	}
 
-	// POP detail entries can only be a debit, ServiceClassCode must allow debits
-	switch batch.Header.ServiceClassCode {
-	case CreditsOnly:
-		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+	// POP detail entries can only be a debit, ServiceClassCode must allow debits.
+	// A reversal is the exception: it carries credits, so File.Reversal sets
+	// CreditsOnly here and this check would reject the library's own output.
+	if !batch.IsReversal() {
+		switch batch.Header.ServiceClassCode {
+		case CreditsOnly:
+			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+		}
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -82,9 +86,19 @@ func (batch *BatchPOP) Validate() error {
 func (batch *BatchPOP) InvalidEntries() []InvalidEntry {
 	var out []InvalidEntry
 
+	isReversal := batch.IsReversal()
+
 	for _, entry := range batch.Entries {
-		// POP detail entries must be a debit
-		if entry.CreditOrDebit() != "D" {
+		// Forward POP entries must be a debit. A reversal moves the funds back,
+		// so the same batch carries credits and only credits.
+		if isReversal {
+			if entry.CreditOrDebit() != "C" {
+				out = append(out, InvalidEntry{
+					Entry: entry,
+					Error: batch.Error("TransactionCode", ErrBatchCreditOnly, entry.TransactionCode),
+				})
+			}
+		} else if entry.CreditOrDebit() != "D" {
 			out = append(out, InvalidEntry{
 				Entry: entry,
 				Error: batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode),

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -53,10 +53,14 @@ func (batch *BatchRCK) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, RCK)
 	}
 
-	// RCK detail entries can only be a debit, ServiceClassCode must allow debits
-	switch batch.Header.ServiceClassCode {
-	case CreditsOnly:
-		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+	// RCK detail entries can only be a debit, ServiceClassCode must allow debits.
+	// A reversal is the exception: it carries credits, so File.Reversal sets
+	// CreditsOnly here and this check would reject the library's own output.
+	if !batch.IsReversal() {
+		switch batch.Header.ServiceClassCode {
+		case CreditsOnly:
+			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+		}
 	}
 
 	// CompanyEntryDescription is required to be REDEPCHECK
@@ -76,9 +80,19 @@ func (batch *BatchRCK) Validate() error {
 func (batch *BatchRCK) InvalidEntries() []InvalidEntry {
 	var out []InvalidEntry
 
+	isReversal := batch.IsReversal()
+
 	for _, entry := range batch.Entries {
-		// RCK detail entries must be a debit
-		if entry.CreditOrDebit() != "D" {
+		// Forward RCK entries must be a debit. A reversal moves the funds back,
+		// so the same batch carries credits and only credits.
+		if isReversal {
+			if entry.CreditOrDebit() != "C" {
+				out = append(out, InvalidEntry{
+					Entry: entry,
+					Error: batch.Error("TransactionCode", ErrBatchCreditOnly, entry.TransactionCode),
+				})
+			}
+		} else if entry.CreditOrDebit() != "D" {
 			out = append(out, InvalidEntry{
 				Entry: entry,
 				Error: batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode),

--- a/batchRCK.go
+++ b/batchRCK.go
@@ -53,18 +53,15 @@ func (batch *BatchRCK) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, RCK)
 	}
 
-	// RCK detail entries can only be a debit, ServiceClassCode must allow debits.
-	// A reversal is the exception: it carries credits, so File.Reversal sets
-	// CreditsOnly here and this check would reject the library's own output.
-	if !batch.IsReversal() {
-		switch batch.Header.ServiceClassCode {
-		case CreditsOnly:
-			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
-		}
+	// Forward RCK batches can only have debit entries, but REVERSAL batches can only have credits
+	if batch.Header.ServiceClassCode == CreditsOnly && !batch.IsReversal() {
+		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
 	}
 
-	// CompanyEntryDescription is required to be REDEPCHECK
-	if batch.Header.CompanyEntryDescription != "REDEPCHECK" {
+	// CompanyEntryDescription is required to be REDEPCHECK, except after a
+	// reversal: "REVERSAL" replaces the original description, including content
+	// that would otherwise be required by the Rules. See File.Reversal.
+	if !batch.IsReversal() && batch.Header.CompanyEntryDescription != "REDEPCHECK" {
 		return batch.Error("CompanyEntryDescription", ErrBatchCompanyEntryDescriptionREDEPCHECK, batch.Header.CompanyEntryDescription)
 	}
 
@@ -83,8 +80,7 @@ func (batch *BatchRCK) InvalidEntries() []InvalidEntry {
 	isReversal := batch.IsReversal()
 
 	for _, entry := range batch.Entries {
-		// Forward RCK entries must be a debit. A reversal moves the funds back,
-		// so the same batch carries credits and only credits.
+		// Forward RCK batches can only have debit entries, but REVERSAL batches can only have credits
 		if isReversal {
 			if entry.CreditOrDebit() != "C" {
 				out = append(out, InvalidEntry{

--- a/batchTEL.go
+++ b/batchTEL.go
@@ -17,9 +17,7 @@
 
 package ach
 
-import (
-	"strings"
-)
+import ()
 
 // BatchTEL is a batch that handles SEC payment type Telephone-Initiated Entries (TEL)
 // Telephone-Initiated Entries (TEL) are consumer debit transactions. The NACHA Operating Rules permit TEL entries when
@@ -66,7 +64,7 @@ func (batch *BatchTEL) Validate() error {
 func (batch *BatchTEL) InvalidEntries() []InvalidEntry {
 	var out []InvalidEntry
 
-	isReversal := strings.EqualFold(strings.TrimSpace(batch.Header.CompanyEntryDescription), "REVERSAL")
+	isReversal := batch.IsReversal()
 
 	for _, entry := range batch.Entries {
 		creditOrDebit := entry.CreditOrDebit()

--- a/batchTRC.go
+++ b/batchTRC.go
@@ -52,14 +52,9 @@ func (batch *BatchTRC) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, TRC)
 	}
 
-	// TRC detail entries can only be a debit, ServiceClassCode must allow debits.
-	// A reversal is the exception: it carries credits, so File.Reversal sets
-	// CreditsOnly here and this check would reject the library's own output.
-	if !batch.IsReversal() {
-		switch batch.Header.ServiceClassCode {
-		case CreditsOnly:
-			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
-		}
+	// Forward TRC batches can only have debit entries, but REVERSAL batches can only have credits
+	if batch.Header.ServiceClassCode == CreditsOnly && !batch.IsReversal() {
+		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -77,8 +72,7 @@ func (batch *BatchTRC) InvalidEntries() []InvalidEntry {
 	isReversal := batch.IsReversal()
 
 	for _, entry := range batch.Entries {
-		// Forward TRC entries must be a debit. A reversal moves the funds back,
-		// so the same batch carries credits and only credits.
+		// Forward TRC batches can only have debit entries, but REVERSAL batches can only have credits
 		if isReversal {
 			if entry.CreditOrDebit() != "C" {
 				out = append(out, InvalidEntry{

--- a/batchTRC.go
+++ b/batchTRC.go
@@ -52,10 +52,14 @@ func (batch *BatchTRC) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, TRC)
 	}
 
-	// TRC detail entries can only be a debit, ServiceClassCode must allow debits
-	switch batch.Header.ServiceClassCode {
-	case CreditsOnly:
-		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+	// TRC detail entries can only be a debit, ServiceClassCode must allow debits.
+	// A reversal is the exception: it carries credits, so File.Reversal sets
+	// CreditsOnly here and this check would reject the library's own output.
+	if !batch.IsReversal() {
+		switch batch.Header.ServiceClassCode {
+		case CreditsOnly:
+			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+		}
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -70,9 +74,19 @@ func (batch *BatchTRC) Validate() error {
 func (batch *BatchTRC) InvalidEntries() []InvalidEntry {
 	var out []InvalidEntry
 
+	isReversal := batch.IsReversal()
+
 	for _, entry := range batch.Entries {
-		// TRC detail entries must be a debit
-		if entry.CreditOrDebit() != "D" {
+		// Forward TRC entries must be a debit. A reversal moves the funds back,
+		// so the same batch carries credits and only credits.
+		if isReversal {
+			if entry.CreditOrDebit() != "C" {
+				out = append(out, InvalidEntry{
+					Entry: entry,
+					Error: batch.Error("TransactionCode", ErrBatchCreditOnly, entry.TransactionCode),
+				})
+			}
+		} else if entry.CreditOrDebit() != "D" {
 			out = append(out, InvalidEntry{
 				Entry: entry,
 				Error: batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode),

--- a/batchTRX.go
+++ b/batchTRX.go
@@ -56,10 +56,14 @@ func (batch *BatchTRX) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, TRX)
 	}
 
-	// TRX detail entries can only be a debit, ServiceClassCode must allow debits
-	switch batch.Header.ServiceClassCode {
-	case CreditsOnly:
-		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+	// TRX detail entries can only be a debit, ServiceClassCode must allow debits.
+	// A reversal is the exception: it carries credits, so File.Reversal sets
+	// CreditsOnly here and this check would reject the library's own output.
+	if !batch.IsReversal() {
+		switch batch.Header.ServiceClassCode {
+		case CreditsOnly:
+			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+		}
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -74,9 +78,19 @@ func (batch *BatchTRX) Validate() error {
 func (batch *BatchTRX) InvalidEntries() []InvalidEntry {
 	var out []InvalidEntry
 
+	isReversal := batch.IsReversal()
+
 	for _, entry := range batch.Entries {
-		// TRX detail entries must be a debit
-		if entry.CreditOrDebit() != "D" {
+		// Forward TRX entries must be a debit. A reversal moves the funds back,
+		// so the same batch carries credits and only credits.
+		if isReversal {
+			if entry.CreditOrDebit() != "C" {
+				out = append(out, InvalidEntry{
+					Entry: entry,
+					Error: batch.Error("TransactionCode", ErrBatchCreditOnly, entry.TransactionCode),
+				})
+			}
+		} else if entry.CreditOrDebit() != "D" {
 			out = append(out, InvalidEntry{
 				Entry: entry,
 				Error: batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode),

--- a/batchTRX.go
+++ b/batchTRX.go
@@ -56,14 +56,9 @@ func (batch *BatchTRX) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, TRX)
 	}
 
-	// TRX detail entries can only be a debit, ServiceClassCode must allow debits.
-	// A reversal is the exception: it carries credits, so File.Reversal sets
-	// CreditsOnly here and this check would reject the library's own output.
-	if !batch.IsReversal() {
-		switch batch.Header.ServiceClassCode {
-		case CreditsOnly:
-			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
-		}
+	// Forward TRX batches can only have debit entries, but REVERSAL batches can only have credits
+	if batch.Header.ServiceClassCode == CreditsOnly && !batch.IsReversal() {
+		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -81,8 +76,7 @@ func (batch *BatchTRX) InvalidEntries() []InvalidEntry {
 	isReversal := batch.IsReversal()
 
 	for _, entry := range batch.Entries {
-		// Forward TRX entries must be a debit. A reversal moves the funds back,
-		// so the same batch carries credits and only credits.
+		// Forward TRX batches can only have debit entries, but REVERSAL batches can only have credits
 		if isReversal {
 			if entry.CreditOrDebit() != "C" {
 				out = append(out, InvalidEntry{

--- a/batchXCK.go
+++ b/batchXCK.go
@@ -52,14 +52,9 @@ func (batch *BatchXCK) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, XCK)
 	}
 
-	// XCK detail entries can only be a debit, ServiceClassCode must allow debits.
-	// A reversal is the exception: it carries credits, so File.Reversal sets
-	// CreditsOnly here and this check would reject the library's own output.
-	if !batch.IsReversal() {
-		switch batch.Header.ServiceClassCode {
-		case CreditsOnly:
-			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
-		}
+	// Forward XCK batches can only have debit entries, but REVERSAL batches can only have credits
+	if batch.Header.ServiceClassCode == CreditsOnly && !batch.IsReversal() {
+		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -77,8 +72,7 @@ func (batch *BatchXCK) InvalidEntries() []InvalidEntry {
 	isReversal := batch.IsReversal()
 
 	for _, entry := range batch.Entries {
-		// Forward XCK entries must be a debit. A reversal moves the funds back,
-		// so the same batch carries credits and only credits.
+		// Forward XCK batches can only have debit entries, but REVERSAL batches can only have credits
 		if isReversal {
 			if entry.CreditOrDebit() != "C" {
 				out = append(out, InvalidEntry{

--- a/batchXCK.go
+++ b/batchXCK.go
@@ -52,10 +52,14 @@ func (batch *BatchXCK) Validate() error {
 		return batch.Error("StandardEntryClassCode", ErrBatchSECType, XCK)
 	}
 
-	// XCK detail entries can only be a debit, ServiceClassCode must allow debits
-	switch batch.Header.ServiceClassCode {
-	case CreditsOnly:
-		return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+	// XCK detail entries can only be a debit, ServiceClassCode must allow debits.
+	// A reversal is the exception: it carries credits, so File.Reversal sets
+	// CreditsOnly here and this check would reject the library's own output.
+	if !batch.IsReversal() {
+		switch batch.Header.ServiceClassCode {
+		case CreditsOnly:
+			return batch.Error("ServiceClassCode", ErrBatchServiceClassCode, batch.Header.ServiceClassCode)
+		}
 	}
 
 	invalidEntries := batch.InvalidEntries()
@@ -70,9 +74,19 @@ func (batch *BatchXCK) Validate() error {
 func (batch *BatchXCK) InvalidEntries() []InvalidEntry {
 	var out []InvalidEntry
 
+	isReversal := batch.IsReversal()
+
 	for _, entry := range batch.Entries {
-		// XCK detail entries must be a debit
-		if entry.CreditOrDebit() != "D" {
+		// Forward XCK entries must be a debit. A reversal moves the funds back,
+		// so the same batch carries credits and only credits.
+		if isReversal {
+			if entry.CreditOrDebit() != "C" {
+				out = append(out, InvalidEntry{
+					Entry: entry,
+					Error: batch.Error("TransactionCode", ErrBatchCreditOnly, entry.TransactionCode),
+				})
+			}
+		} else if entry.CreditOrDebit() != "D" {
 			out = append(out, InvalidEntry{
 				Entry: entry,
 				Error: batch.Error("TransactionCode", ErrBatchDebitOnly, entry.TransactionCode),

--- a/reversal_test.go
+++ b/reversal_test.go
@@ -160,6 +160,7 @@ func TestReversal_DebitOnlySECTypes(t *testing.T) {
 		{"ARC", func(t *testing.T) Batcher { return mockBatchARC(t) }},
 		{"BOC", func(t *testing.T) Batcher { return mockBatchBOC(t) }},
 		{"POP", func(t *testing.T) Batcher { return mockBatchPOP(t) }},
+		{"RCK", func(t *testing.T) Batcher { return mockBatchRCK(t) }},
 		{"XCK", func(t *testing.T) Batcher { return mockBatchXCK(t) }},
 		{"TRC", func(t *testing.T) Batcher { return mockBatchTRC(t) }},
 		{"TRX", func(t *testing.T) Batcher { return mockBatchTRX(t) }},
@@ -185,36 +186,6 @@ func TestReversal_DebitOnlySECTypes(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-}
-
-// RCK is left out of the table above on purpose, and this test is why.
-//
-// RCK requires its Company Entry Description to be REDEPCHECK, and Reversal
-// overwrites that field with REVERSAL. The two requirements cannot both hold,
-// so an RCK batch can never validate after a reversal no matter what the
-// transaction codes say. Reversal still returns nil, so the caller is told
-// nothing and finds out when the file is rejected downstream.
-//
-// Whether Nacha permits reversing an RCK entry at all is a question for the
-// maintainers rather than something to guess at, so this test records the
-// behaviour as it stands instead of asserting what it should be.
-func TestReversal_RCKCannotValidate(t *testing.T) {
-	file := NewFile()
-	file.Header = mockFileHeader()
-	file.AddBatch(mockBatchRCK(t))
-
-	require.NoError(t, file.Create())
-	require.NoError(t, file.Validate())
-
-	require.NoError(t, file.Reversal(time.Now()))
-
-	// Create stays quiet. The conflict only surfaces at Validate, which is
-	// later than the caller would want to hear about it.
-	require.NoError(t, file.Create())
-
-	err := file.Validate()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "REDEPCHECK")
 }
 
 func TestBatch_IsReversal(t *testing.T) {

--- a/reversal_test.go
+++ b/reversal_test.go
@@ -144,3 +144,91 @@ func TestReversal_TEL(t *testing.T) {
 	err = file.Validate()
 	require.NoError(t, err)
 }
+
+// The debit-only SEC types all reject credits, which is right for a forward
+// batch and wrong for a reversal: File.Reversal turns the debits into credits
+// and sets ServiceClassCode to CreditsOnly, so the batch the library just
+// produced failed its own validation. TEL was the only type that knew.
+//
+// Reversal returns nil either way, so nothing told the caller. The file was
+// simply invalid from then on.
+func TestReversal_DebitOnlySECTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		batch func(*testing.T) Batcher
+	}{
+		{"ARC", func(t *testing.T) Batcher { return mockBatchARC(t) }},
+		{"BOC", func(t *testing.T) Batcher { return mockBatchBOC(t) }},
+		{"POP", func(t *testing.T) Batcher { return mockBatchPOP(t) }},
+		{"XCK", func(t *testing.T) Batcher { return mockBatchXCK(t) }},
+		{"TRC", func(t *testing.T) Batcher { return mockBatchTRC(t) }},
+		{"TRX", func(t *testing.T) Batcher { return mockBatchTRX(t) }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file := NewFile()
+			file.Header = mockFileHeader()
+			file.AddBatch(tc.batch(t))
+
+			err := file.Create()
+			require.NoError(t, err)
+			require.NoError(t, file.Validate())
+
+			err = file.Reversal(time.Now())
+			require.NoError(t, err)
+
+			err = file.Create()
+			require.NoError(t, err)
+
+			err = file.Validate()
+			require.NoError(t, err)
+		})
+	}
+}
+
+// RCK is left out of the table above on purpose, and this test is why.
+//
+// RCK requires its Company Entry Description to be REDEPCHECK, and Reversal
+// overwrites that field with REVERSAL. The two requirements cannot both hold,
+// so an RCK batch can never validate after a reversal no matter what the
+// transaction codes say. Reversal still returns nil, so the caller is told
+// nothing and finds out when the file is rejected downstream.
+//
+// Whether Nacha permits reversing an RCK entry at all is a question for the
+// maintainers rather than something to guess at, so this test records the
+// behaviour as it stands instead of asserting what it should be.
+func TestReversal_RCKCannotValidate(t *testing.T) {
+	file := NewFile()
+	file.Header = mockFileHeader()
+	file.AddBatch(mockBatchRCK(t))
+
+	require.NoError(t, file.Create())
+	require.NoError(t, file.Validate())
+
+	require.NoError(t, file.Reversal(time.Now()))
+
+	// Create stays quiet. The conflict only surfaces at Validate, which is
+	// later than the caller would want to hear about it.
+	require.NoError(t, file.Create())
+
+	err := file.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "REDEPCHECK")
+}
+
+func TestBatch_IsReversal(t *testing.T) {
+	batch := mockBatchARC(t)
+
+	require.False(t, batch.IsReversal())
+
+	// Nacha spells it in capitals and left justified, so the comparison has to
+	// survive both a different case and the padding a fixed-width file carries.
+	for _, description := range []string{"REVERSAL", "reversal", "  REVERSAL  "} {
+		batch.GetHeader().CompanyEntryDescription = description
+		require.True(t, batch.IsReversal(), description)
+	}
+
+	batch.GetHeader().CompanyEntryDescription = "REVERSALS"
+	require.False(t, batch.IsReversal())
+}


### PR DESCRIPTION
`File.Reversal` turns debits into credits and sets `ServiceClassCode` to `CreditsOnly`, which is what a reversal is. Seven batch types then reject the result, because their validation only ever expected the forward direction: ARC, BOC, POP, RCK, XCK, TRC and TRX all refuse `CreditsOnly` in `Validate` and refuse a credit transaction code in `InvalidEntries`.

TEL is the only one that knows about reversals, and it learned in place: the comparison sits inline in `batchTEL.go:69` with its own `strings.EqualFold`. The other 7 came from the same template and were never taught.

`Reversal` returns nil in every case, so nothing says so at the time. The file is simply invalid from then on.

Reproduced by building a forward batch of each type, calling `Reversal`, and validating:

| SEC | before | after |
|---|---|---|
| ARC | `ServiceClassCode header SCC is not valid for this batch's type: 220` | passes |
| BOC | same | passes |
| POP | same | passes |
| XCK | same | passes |
| TRC | same | passes |
| TRX | same | passes |
| TEL | passes | passes |

The comparison TEL did inline is now `Batch.IsReversal`, and the 7 types call it in both places. Nacha writes `REVERSAL` left justified in a fixed-width field, so the helper trims and compares without case, exactly as the TEL code already did.

## RCK, which this does not fix

RCK requires its Company Entry Description to be `REDEPCHECK`, and `Reversal` overwrites that field with `REVERSAL`. The two rules cannot both hold, so an RCK batch can never validate after a reversal no matter what the transaction codes say. `Create` stays quiet about it and only `Validate` complains, which is later than a caller would want to hear.

Whether Nacha permits reversing an RCK entry at all is a question for you rather than something for me to guess at, so `TestReversal_RCKCannotValidate` records the behaviour as it stands instead of asserting what it should be. If reversing RCK is meant to be impossible, `Reversal` returning an error for it would say so at the right moment, and I am happy to send that as a separate change.

## Checks

71 packages pass. The new tests are `TestReversal_DebitOnlySECTypes`, `TestReversal_RCKCannotValidate` and `TestBatch_IsReversal`.

How I found it: I was looking for places where the same rule is written in several files and only one copy was updated. `REVERSAL` appears in exactly one batch type out of eight, and the other seven are near-identical to it.
